### PR TITLE
[grid] selectCell method throws an exception

### DIFF
--- a/src/components/grid/ch-grid-manager.ts
+++ b/src/components/grid/ch-grid-manager.ts
@@ -244,7 +244,9 @@ export class ChGridManager {
       const row = this.getRow(rowId);
       const column = this.columns.getColumn(columnId);
 
-      return row.getCell(column);
+      if (row && column) {
+        return row.getCell(column);
+      }
     }
   }
 


### PR DESCRIPTION
If the rowId or columnId does not exist, an exception is thrown.