### PR TITLE
[grid ] Add columnId to ChGridRowClickedEvent

### DIFF
--- a/src/components/grid/ch-grid-types.ts
+++ b/src/components/grid/ch-grid-types.ts
@@ -15,6 +15,7 @@ export interface ChGridCellSelectionChangedEvent {
 export interface ChGridRowClickedEvent {
   rowId: string;
   cellId?: string;
+  columnId?: string;
 }
 
 export type CSSProperties = {

--- a/src/components/grid/ch-grid.tsx
+++ b/src/components/grid/ch-grid.tsx
@@ -374,7 +374,8 @@ export class ChGrid {
     if (row) {
       this.rowClicked.emit({
         rowId: row.rowId,
-        cellId: cell?.cellId
+        cellId: cell?.cellId,
+        columnId: cell?.column.columnId
       });
 
       this.manager.selection.selecting = true;


### PR DESCRIPTION
The 'columnId' property is added to the detail of the rowClicked event