### PR TITLE
[grid] Sometimes it doesn't work to collapse a row

### DIFF
--- a/src/components/grid/ch-grid.tsx
+++ b/src/components/grid/ch-grid.tsx
@@ -163,7 +163,6 @@ export class ChGrid {
   rowFocusedHandler(row: HTMLChGridRowElement, previous: HTMLChGridRowElement) {
     if (row) {
       row.focused = true;
-      row.ensureVisible();
     }
     if (previous) {
       previous.focused = false;


### PR DESCRIPTION
If the grid does not have focus, collapsing a row if the row or one of its children is selected does not work