### PR TITLE
Fixes and improvements for ch-window control

### DIFF
--- a/src/components/window/ch-window.scss
+++ b/src/components/window/ch-window.scss
@@ -1,3 +1,8 @@
+:host {
+  --ch-window-offset-x: 0;
+  --ch-window-offset-y: 0;
+}
+
 :host(:not([hidden])) {
   display: contents;
 }
@@ -13,6 +18,12 @@
   display: flex;
   position: fixed;
   inset: 0;
+  inset-inline-start: calc(
+    var(--ch-window-inset-inline-start) + var(--ch-window-offset-x)
+  );
+  inset-block-start: calc(
+    var(--ch-window-inset-block-start) + var(--ch-window-offset-y)
+  );
   z-index: var(--ch-window-mask-z-index, 1000);
 
   :host(:is([x-align="outside-start"], [x-align="inside-start"])) & {

--- a/src/components/window/ch-window.tsx
+++ b/src/components/window/ch-window.tsx
@@ -196,13 +196,19 @@ export class ChWindow {
       const rect = this.container.getBoundingClientRect();
 
       // TODO: RTL positioning bug
-      this.mask.style.setProperty("inset-inline-start", `${rect.left}px`);
-      this.mask.style.setProperty("inset-block-start", `${rect.top}px`);
+      this.mask.style.setProperty(
+        "--ch-window-inset-inline-start",
+        `${rect.left}px`
+      );
+      this.mask.style.setProperty(
+        "--ch-window-inset-block-start",
+        `${rect.top}px`
+      );
       this.mask.style.width = `${rect.width}px`;
       this.mask.style.height = `${rect.height}px`;
     } else if (this.isContainerCssOverride || !this.container) {
-      this.mask.style.removeProperty("inset-inline-start");
-      this.mask.style.removeProperty("inset-block-start");
+      this.mask.style.removeProperty("--ch-window-inset-inline-start");
+      this.mask.style.removeProperty("--ch-window-inset-block-start");
       this.mask.style.removeProperty("width");
       this.mask.style.removeProperty("height");
     }

--- a/src/components/window/ch-window.tsx
+++ b/src/components/window/ch-window.tsx
@@ -122,6 +122,7 @@ export class ChWindow {
 
   @Listen("resize", { target: "window", passive: true })
   windowResizeHandler() {
+    this.updatePosition();
     this.watchCSSAlign();
   }
 

--- a/src/components/window/ch-window.tsx
+++ b/src/components/window/ch-window.tsx
@@ -235,10 +235,10 @@ export class ChWindow {
     const style = getComputedStyle(this.el);
     const container = style.getPropertyValue("--ch-window-container").trim();
     const xAlign = style
-      .getPropertyValue("--ch-window-x-align")
+      .getPropertyValue("--ch-window-align-x")
       .trim() as ChWindowAlign;
     const yAlign = style
-      .getPropertyValue("--ch-window-y-align")
+      .getPropertyValue("--ch-window-align-y")
       .trim() as ChWindowAlign;
 
     this.isContainerCssOverride = container.includes("window");

--- a/src/components/window/window-close/ch-window-close.tsx
+++ b/src/components/window/window-close/ch-window-close.tsx
@@ -26,7 +26,7 @@ export class ChWindowClose {
   @Listen("keydown", { passive: true })
   @Listen("click", { passive: true })
   pressedHandler(eventInfo: any) {
-    if (!eventInfo.key || eventInfo.key == "Enter" || eventInfo.key == " ") {
+    if (!eventInfo.key || eventInfo.key === "Enter" || eventInfo.key === " ") {
       this.windowCloseClicked.emit();
       eventInfo.stopPropagation();
     }


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Add support to specify an offset for the window's position.

 - Rename custom vars.

 - Add missing `updatePosition` when resizing the windows.

 - Use `===` instead of `==` in `ch-window-close` control