### PR TITLE
add a method to retrieve checked tree-items

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -17,6 +17,8 @@ import { ChPaginatorNavigateClickedEvent, ChPaginatorNavigateType } from "./comp
 import { ChPaginatorPagesPageChangedEvent } from "./components/paginator/paginator-pages/ch-paginator-pages";
 import { ecLevel } from "./components/qr/ch-qr";
 import { focusChangeAttempt, itemSelected } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
+import { checkedChTreeItem } from "./components/tree/ch-tree";
+import { chTreeItemData } from "./components/tree-item/ch-tree-item";
 import { ChWindowAlign } from "./components/window/ch-window";
 import { GxGrid, GxGridColumn } from "./components/gx-grid/genexus";
 import { GridChameleonState } from "./components/gx-grid/gx-grid-chameleon-state";
@@ -620,7 +622,7 @@ export namespace Components {
         /**
           * The total number of pages.
          */
-        "totalPages": number;
+        "totalPages": 1;
     }
     interface ChQr {
         /**
@@ -790,6 +792,10 @@ export namespace Components {
           * Set this attribute if you want all this tree tree-items to have the checkbox checked
          */
         "checked": boolean;
+        /**
+          * @returns an array of the ch-tree-items that are checked. Each array item is an object with "id" and "innerText".
+         */
+        "getChecked": () => Promise<checkedChTreeItem[]>;
         /**
           * Set this attribute if you want all the childen item's checkboxes to be checked when the parent item checkbox is checked, or to be unchecked when the parent item checkbox is unckecked.
          */
@@ -1911,7 +1917,7 @@ declare namespace LocalJSX {
         /**
           * The total number of pages.
          */
-        "totalPages"?: number;
+        "totalPages"?: 1;
     }
     interface ChQr {
         /**
@@ -2153,7 +2159,10 @@ declare namespace LocalJSX {
           * Set the left side icon from the available Gemini icon set : https://gx-gemini.netlify.app/?path=/story/icons-icons--controls
          */
         "leftIcon"?: string;
-        "onCheckboxClickedEvent"?: (event: CustomEvent<any>) => void;
+        /**
+          * Emits the checkbox information (chTreeItemData) that includes: the id, name(innerText) and checkbox value.
+         */
+        "onCheckboxClickedEvent"?: (event: CustomEvent<chTreeItemData>) => void;
         "onLiItemClicked"?: (event: CustomEvent<any>) => void;
         "onToggleIconClicked"?: (event: CustomEvent<any>) => void;
         /**

--- a/src/components/paginator/paginator-pages/readme.md
+++ b/src/components/paginator/paginator-pages/readme.md
@@ -11,7 +11,7 @@
 | `page`                 | `page`                    | The active page number.                                   | `number`  | `1`     |
 | `renderFirstLastPages` | `render-first-last-pages` | Flag to render the first and last pages.                  | `boolean` | `true`  |
 | `textDots`             | `text-dots`               | The text to display for the dots.                         | `string`  | `"..."` |
-| `totalPages`           | `total-pages`             | The total number of pages.                                | `number`  | `1`     |
+| `totalPages`           | `total-pages`             | The total number of pages.                                | `1`       | `1`     |
 
 
 ## Events

--- a/src/components/tree-item/ch-tree-item.tsx
+++ b/src/components/tree-item/ch-tree-item.tsx
@@ -94,7 +94,11 @@ export class ChTreeItem {
   //EVENTS
   @Event() liItemClicked: EventEmitter;
   @Event() toggleIconClicked: EventEmitter;
-  @Event() checkboxClickedEvent: EventEmitter;
+
+  /**
+   * Emits the checkbox information (chTreeItemData) that includes: the id, name(innerText) and checkbox value.
+   */
+  @Event() checkboxClickedEvent: EventEmitter<chTreeItemData>;
 
   @Element() el: HTMLChTreeItemElement;
 
@@ -538,15 +542,12 @@ export class ChTreeItem {
 
   checkboxClicked() {
     if (this.checkbox) {
-      if (this.checked) {
-        this.checked = false;
-        this.toggleTreeItemsCheckboxes(false);
-        this.checkboxClickedEvent.emit(false);
-      } else {
-        this.checked = true;
-        this.toggleTreeItemsCheckboxes(true);
-        this.checkboxClickedEvent.emit(true);
-      }
+      this.checked = !this.checked;
+      this.toggleTreeItemsCheckboxes(this.checked);
+      this.checkboxClickedEvent.emit({
+        checked: this.checked,
+        id: this.el.id
+      });
     }
     if (treeRef.toggleCheckboxes) {
       const items = this.el.querySelectorAll("ch-tree-item");
@@ -692,3 +693,8 @@ export class ChTreeItem {
     );
   }
 }
+
+export type chTreeItemData = {
+  checked: boolean;
+  id: string;
+};

--- a/src/components/tree-item/readme.md
+++ b/src/components/tree-item/readme.md
@@ -27,11 +27,11 @@
 
 ## Events
 
-| Event                  | Description | Type               |
-| ---------------------- | ----------- | ------------------ |
-| `checkboxClickedEvent` |             | `CustomEvent<any>` |
-| `liItemClicked`        |             | `CustomEvent<any>` |
-| `toggleIconClicked`    |             | `CustomEvent<any>` |
+| Event                  | Description                                                                                                | Type                                             |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `checkboxClickedEvent` | Emits the checkbox information (chTreeItemData) that includes: the id, name(innerText) and checkbox value. | `CustomEvent<{ checked: boolean; id: string; }>` |
+| `liItemClicked`        |                                                                                                            | `CustomEvent<any>`                               |
+| `toggleIconClicked`    |                                                                                                            | `CustomEvent<any>`                               |
 
 
 ## Methods

--- a/src/components/tree/ch-tree.tsx
+++ b/src/components/tree/ch-tree.tsx
@@ -1,4 +1,12 @@
-import { Component, Element, State, h, Prop, Listen } from "@stencil/core";
+import {
+  Component,
+  Element,
+  State,
+  h,
+  Prop,
+  Listen,
+  Method
+} from "@stencil/core";
 import { ChTreeItem } from "../tree-item/ch-tree-item";
 
 @Component({
@@ -61,6 +69,23 @@ export class ChTree {
     });
   }
 
+  /**
+   * @returns an array of the ch-tree-items that are checked. Each array item is an object with "id" and "innerText".
+   */
+  @Method()
+  async getChecked(): Promise<checkedChTreeItem[]> {
+    const allTreeItems = this.el.querySelectorAll("ch-tree-item");
+    const checkedTreeItems: checkedChTreeItem[] = [];
+    if (allTreeItems.length) {
+      allTreeItems.forEach(treeItem => {
+        if (treeItem.checked) {
+          checkedTreeItems.push({ id: treeItem.id, name: treeItem.innerText });
+        }
+      });
+    }
+    return checkedTreeItems;
+  }
+
   render() {
     return this.mainTree ? (
       <div
@@ -89,3 +114,8 @@ export class ChTree {
     );
   }
 }
+
+export type checkedChTreeItem = {
+  id: string;
+  name: string;
+};

--- a/src/components/tree/ch-tree.tsx
+++ b/src/components/tree/ch-tree.tsx
@@ -79,7 +79,7 @@ export class ChTree {
     if (allTreeItems.length) {
       allTreeItems.forEach(treeItem => {
         if (treeItem.checked) {
-          checkedTreeItems.push({ id: treeItem.id, name: treeItem.innerText });
+          checkedTreeItems.push({ id: treeItem.id });
         }
       });
     }
@@ -117,5 +117,4 @@ export class ChTree {
 
 export type checkedChTreeItem = {
   id: string;
-  name: string;
 };

--- a/src/components/tree/readme.md
+++ b/src/components/tree/readme.md
@@ -14,6 +14,19 @@
 | `toggleCheckboxes` | `toggle-checkboxes` | Set this attribute if you want all the childen item's checkboxes to be checked when the parent item checkbox is checked, or to be unchecked when the parent item checkbox is unckecked. | `boolean` | `false` |
 
 
+## Methods
+
+### `getChecked() => Promise<checkedChTreeItem[]>`
+
+
+
+#### Returns
+
+Type: `Promise<checkedChTreeItem[]>`
+
+
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/pages/tree.html
+++ b/src/pages/tree.html
@@ -40,13 +40,7 @@
   <body>
     <div class="container">
       <section class="section-dev" data-title="ch-tree">
-        <ch-tree
-          id="ch-treeview"
-          togglees="false"
-          checkbox
-          checked
-          toggle-checkboxes
-        >
+        <ch-tree id="ch-treeview" togglees="false" checkbox toggle-checkboxes>
           <ch-tree-item opened left-icon="/build/ch-icon-assets/generator.svg">
             Meats
             <ch-tree slot="tree">
@@ -59,7 +53,9 @@
                   <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
                     Turkey
                   </ch-tree-item>
-                  <ch-tree-item left-icon="general/knowledge-base">
+                  <ch-tree-item
+                    left-icon="/build/ch-icon-assets/knowledge-base.svg"
+                  >
                     Duck
                   </ch-tree-item>
                 </ch-tree>
@@ -69,13 +65,19 @@
               >
                 Red meats
                 <ch-tree slot="tree">
-                  <ch-tree-item left-icon="general/knowledge-base">
+                  <ch-tree-item
+                    left-icon="/build/ch-icon-assets/knowledge-base.svg"
+                  >
                     Beef
                   </ch-tree-item>
-                  <ch-tree-item left-icon="general/knowledge-base">
+                  <ch-tree-item
+                    left-icon="/build/ch-icon-assets/knowledge-base.svg"
+                  >
                     Lamb and mutton
                   </ch-tree-item>
-                  <ch-tree-item left-icon="general/knowledge-base">
+                  <ch-tree-item
+                    left-icon="/build/ch-icon-assets/knowledge-base.svg"
+                  >
                     Pork
                   </ch-tree-item>
                 </ch-tree>
@@ -84,7 +86,7 @@
           </ch-tree-item>
           <ch-tree-item
             id="fish"
-            left-icon="general/patterns"
+            left-icon="/build/ch-icon-assets/patterns.svg"
             opened
             download
             disabled
@@ -92,82 +94,121 @@
           >
             Fish
           </ch-tree-item>
-          <ch-tree-item opened left-icon="objects/module">
+          <ch-tree-item opened left-icon="/build/ch-icon-assets/java.svg">
             Fruits
             <ch-tree slot="tree">
-              <ch-tree-item left-icon="objects/module"> Orange </ch-tree-item>
-              <ch-tree-item left-icon="objects/module" opened>
+              <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
+                Orange
+              </ch-tree-item>
+              <ch-tree-item left-icon="/build/ch-icon-assets/java.svg" opened>
                 Banana
                 <ch-tree slot="tree">
-                  <ch-tree-item left-icon="objects/module">
+                  <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
                     Pisang
                   </ch-tree-item>
-                  <ch-tree-item left-icon="objects/module">
+                  <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
                     Red Banana
                   </ch-tree-item>
-                  <ch-tree-item left-icon="objects/module">
+                  <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
                     Cavendish
                     <ch-tree slot="tree">
-                      <ch-tree-item left-icon="objects/module">
+                      <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
                         Big
                       </ch-tree-item>
-                      <ch-tree-item left-icon="objects/module">
+                      <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
                         Small
                       </ch-tree-item>
-                      <ch-tree-item left-icon="objects/module">
+                      <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
                         Mini
                       </ch-tree-item>
                     </ch-tree>
                   </ch-tree-item>
                 </ch-tree>
               </ch-tree-item>
-              <ch-tree-item opened left-icon="objects/module">
+              <ch-tree-item opened left-icon="/build/ch-icon-assets/java.svg">
                 Strawberry
                 <ch-tree slot="tree">
-                  <ch-tree-item left-icon="objects/module">
+                  <ch-tree-item
+                    id="albion"
+                    left-icon="/build/ch-icon-assets/java.svg"
+                  >
                     Albion
                   </ch-tree-item>
-                  <ch-tree-item left-icon="objects/module" opened>
+                  <ch-tree-item
+                    left-icon="/build/ch-icon-assets/java.svg"
+                    opened
+                  >
                     Tillamook
                   </ch-tree-item>
-                  <ch-tree-item left-icon="objects/module">
+                  <ch-tree-item left-icon="/build/ch-icon-assets/java.svg">
                     Northeaster
                   </ch-tree-item>
                 </ch-tree>
               </ch-tree-item>
             </ch-tree>
           </ch-tree-item>
-          <ch-tree-item opened left-icon="objects/document" empty-tree>
+          <ch-tree-item
+            opened
+            left-icon="/build/ch-icon-assets/generator.svg"
+            empty-tree
+          >
             Nuts
             <ch-tree slot="tree">
-              <ch-tree-item opened left-icon="objects/document">
+              <ch-tree-item
+                opened
+                left-icon="/build/ch-icon-assets/generator.svg"
+              >
                 Almonds
                 <ch-tree slot="tree">
-                  <ch-tree-item left-icon="objects/document" opened>
+                  <ch-tree-item
+                    left-icon="/build/ch-icon-assets/generator.svg"
+                    opened
+                  >
                     Mollar de Tarragona
                   </ch-tree-item>
-                  <ch-tree-item left-icon="objects/document">
+                  <ch-tree-item left-icon="/build/ch-icon-assets/generator.svg">
                     Ferragnès
                   </ch-tree-item>
-                  <ch-tree-item left-icon="objects/document">
+                  <ch-tree-item left-icon="/build/ch-icon-assets/generator.svg">
                     Verdal
                   </ch-tree-item>
                 </ch-tree>
               </ch-tree-item>
-              <ch-tree-item left-icon="objects/document" opened>
+              <ch-tree-item
+                left-icon="/build/ch-icon-assets/generator.svg"
+                opened
+              >
                 Brazil nuts
               </ch-tree-item>
-              <ch-tree-item left-icon="objects/document">
+              <ch-tree-item left-icon="/build/ch-icon-assets/generator.svg">
                 Cashews
               </ch-tree-item>
-              <ch-tree-item left-icon="objects/document">
+              <ch-tree-item left-icon="/build/ch-icon-assets/generator.svg">
                 Chestnuts
               </ch-tree-item>
             </ch-tree>
           </ch-tree-item>
         </ch-tree>
       </section>
+      <button id="getTreeCheckedItems">Get Tree Checked Items</button>
     </div>
+
+    <script>
+      const tree = document.getElementById("ch-treeview");
+      tree.addEventListener("checkboxClickedEvent", function (e) {
+        console.log(e.detail);
+      });
+
+      const getTreeCheckedItems = document.getElementById(
+        "getTreeCheckedItems"
+      );
+      getTreeCheckedItems.addEventListener("click", function () {
+        (async () => {
+          const checkedItems = await tree.getChecked("todo-list");
+          console.log("checkedItems", checkedItems);
+        })();
+      });
+    </script>
 
     <script src="./assets/common.js"></script>
   </body>


### PR DESCRIPTION
@ncamera you will see that the array item has a "name" property, that equals to the ch-tree-item innerText. Ideally I think this should be a property maybe, like itemName, or caption, but the [ch-tree-item is currently using slotted content for this purpose](https://github.com/genexuslabs/chameleon-controls-library/blob/0553a1def3c4a0e49b57e6817d8615328d3c3faa/src/components/tree-item/ch-tree-item.tsx#L673-L675), and I don't think it is worthwhile making changes for this, considering that you are developing a new tree. 