### PR TITLE
Add ch-style component to style chameleon components

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -799,6 +799,12 @@ export namespace Components {
          */
         "iconSrc": string;
     }
+    interface ChStyle {
+        /**
+          * Specifies the location of the stylesheet document
+         */
+        "href": string;
+    }
     interface ChSuggest {
         /**
           * If true, it will position the cursor at the end when the input is focused.
@@ -1392,6 +1398,12 @@ declare global {
         prototype: HTMLChStepListItemElement;
         new (): HTMLChStepListItemElement;
     };
+    interface HTMLChStyleElement extends Components.ChStyle, HTMLStencilElement {
+    }
+    var HTMLChStyleElement: {
+        prototype: HTMLChStyleElement;
+        new (): HTMLChStyleElement;
+    };
     interface HTMLChSuggestElement extends Components.ChSuggest, HTMLStencilElement {
     }
     var HTMLChSuggestElement: {
@@ -1492,6 +1504,7 @@ declare global {
         "ch-sidebar-menu-list-item": HTMLChSidebarMenuListItemElement;
         "ch-step-list": HTMLChStepListElement;
         "ch-step-list-item": HTMLChStepListItemElement;
+        "ch-style": HTMLChStyleElement;
         "ch-suggest": HTMLChSuggestElement;
         "ch-suggest-list": HTMLChSuggestListElement;
         "ch-suggest-list-item": HTMLChSuggestListItemElement;
@@ -2335,6 +2348,12 @@ declare namespace LocalJSX {
          */
         "onItemClicked"?: (event: ChStepListItemCustomEvent<any>) => void;
     }
+    interface ChStyle {
+        /**
+          * Specifies the location of the stylesheet document
+         */
+        "href"?: string;
+    }
     interface ChSuggest {
         /**
           * If true, it will position the cursor at the end when the input is focused.
@@ -2641,6 +2660,7 @@ declare namespace LocalJSX {
         "ch-sidebar-menu-list-item": ChSidebarMenuListItem;
         "ch-step-list": ChStepList;
         "ch-step-list-item": ChStepListItem;
+        "ch-style": ChStyle;
         "ch-suggest": ChSuggest;
         "ch-suggest-list": ChSuggestList;
         "ch-suggest-list-item": ChSuggestListItem;
@@ -2696,6 +2716,7 @@ declare module "@stencil/core" {
             "ch-sidebar-menu-list-item": LocalJSX.ChSidebarMenuListItem & JSXBase.HTMLAttributes<HTMLChSidebarMenuListItemElement>;
             "ch-step-list": LocalJSX.ChStepList & JSXBase.HTMLAttributes<HTMLChStepListElement>;
             "ch-step-list-item": LocalJSX.ChStepListItem & JSXBase.HTMLAttributes<HTMLChStepListItemElement>;
+            "ch-style": LocalJSX.ChStyle & JSXBase.HTMLAttributes<HTMLChStyleElement>;
             "ch-suggest": LocalJSX.ChSuggest & JSXBase.HTMLAttributes<HTMLChSuggestElement>;
             "ch-suggest-list": LocalJSX.ChSuggestList & JSXBase.HTMLAttributes<HTMLChSuggestListElement>;
             "ch-suggest-list-item": LocalJSX.ChSuggestListItem & JSXBase.HTMLAttributes<HTMLChSuggestListItemElement>;

--- a/src/components/grid/ch-grid-manager.ts
+++ b/src/components/grid/ch-grid-manager.ts
@@ -7,6 +7,7 @@ import HTMLChGridCellElement from "./grid-cell/ch-grid-cell";
 import { ChGridManagerSelection } from "./ch-grid-manager-selection";
 import { ChGridManagerRowDrag } from "./ch-grid-manager-row-drag";
 import { ChGridManagerRowActions } from "./ch-grid-manager-row-actions";
+import { CH_GLOBAL_STYLESHEET } from "../style/ch-global-stylesheet";
 
 enum StyleRule {
   BASE_LAYER,
@@ -30,6 +31,7 @@ export class ChGridManager {
     this.styleSheet.insertRule(`:host {}`, StyleRule.BASE_LAYER);
     this.styleSheet.insertRule(".main {}", StyleRule.COLUMNS_WIDTH);
     this.grid.shadowRoot.adoptedStyleSheets.push(this.styleSheet);
+    this.grid.shadowRoot.adoptedStyleSheets.push(CH_GLOBAL_STYLESHEET);
 
     this.columns = new ChGridManagerColumns(this);
     this.selection = new ChGridManagerSelection(this);

--- a/src/components/style/ch-global-stylesheet.ts
+++ b/src/components/style/ch-global-stylesheet.ts
@@ -1,0 +1,1 @@
+export const CH_GLOBAL_STYLESHEET = new CSSStyleSheet({ disabled: true });

--- a/src/components/style/ch-style.scss
+++ b/src/components/style/ch-style.scss
@@ -1,0 +1,3 @@
+:host {
+  display: none;
+}

--- a/src/components/style/ch-style.tsx
+++ b/src/components/style/ch-style.tsx
@@ -1,0 +1,38 @@
+import { Component, Element, Prop } from "@stencil/core";
+import { CH_GLOBAL_STYLESHEET } from "./ch-global-stylesheet";
+
+/**
+ * It allows to include styles in the shadow-root of chameleon components,
+ * for example, to style the scrollbars.
+ * Use it in a similar way to the html STYLE tag or
+ * referencing an external stylesheet in a similar way to the html LINK tag.
+ */
+@Component({
+  tag: "ch-style",
+  styleUrl: "ch-style.scss",
+  shadow: true
+})
+export class ChStyle {
+  @Element() el: HTMLChStyleElement;
+
+  /**
+   * Specifies the location of the stylesheet document
+   */
+  @Prop() readonly href: string;
+
+  componentDidLoad() {
+    if (this.href) {
+      fetch(this.href).then(response => {
+        if (response.ok) {
+          response.text().then(style => {
+            CH_GLOBAL_STYLESHEET.replace(style);
+            CH_GLOBAL_STYLESHEET.disabled = false;
+          });
+        }
+      });
+    } else {
+      CH_GLOBAL_STYLESHEET.replace(this.el.innerText);
+      CH_GLOBAL_STYLESHEET.disabled = false;
+    }
+  }
+}

--- a/src/components/style/readme.md
+++ b/src/components/style/readme.md
@@ -1,0 +1,17 @@
+# ch-style
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description                                       | Type     | Default     |
+| -------- | --------- | ------------------------------------------------- | -------- | ----------- |
+| `href`   | `href`    | Specifies the location of the stylesheet document | `string` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/window/ch-window.tsx
+++ b/src/components/window/ch-window.tsx
@@ -9,6 +9,7 @@ import {
   Listen,
   Element
 } from "@stencil/core";
+import { CH_GLOBAL_STYLESHEET } from "../style/ch-global-stylesheet";
 
 export type ChWindowAlign =
   | "outside-start"
@@ -121,6 +122,7 @@ export class ChWindow {
 
     this.containerResizeObserverHandler(this.container);
     this.watchCSSAlign();
+    this.loadGlobalStyleSheet();
   }
 
   @Listen("mousedown", { passive: true })
@@ -295,6 +297,10 @@ export class ChWindow {
       this.hidden = true;
     }
   };
+
+  private loadGlobalStyleSheet() {
+    this.el.shadowRoot.adoptedStyleSheets.push(CH_GLOBAL_STYLESHEET);
+  }
 
   render() {
     return (

--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,8 @@
         "tree",
         "window",
         "suggest",
-        "step-list"
+        "step-list",
+        "style"
       ];
     </script>
   </head>

--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -1,0 +1,21 @@
+:host {
+  scrollbar-color: orange orangered;
+}
+
+::-webkit-scrollbar {
+  width: 12px;
+}
+
+::-webkit-scrollbar-track {
+  background: orange;
+  border-radius: 5px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: orangered;
+  border-radius: 5px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: darkred;
+}

--- a/src/pages/style.html
+++ b/src/pages/style.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>ch-window</title>
+    <script type="module" src="/build/chameleon.esm.js"></script>
+    <script nomodule src="/build/chameleon.js"></script>
+    <link href="/build/chameleon.css" rel="stylesheet" />
+    <link rel="stylesheet" href="./assets/styles.css" />
+
+    <link rel="stylesheet" href="./grid.css" />
+    <style>
+      ch-grid {
+        height: 200px;
+      }
+      ch-grid-column::part(settings-main) {
+        height: 70px;
+        overflow: auto;
+      }
+    </style>
+
+    <ch-style href="./style.css"> </ch-style>
+    <!--
+    <ch-style>
+      :host {
+        scrollbar-color: red green;
+      }
+      
+      ::-webkit-scrollbar {
+        width: 12px; /* width of the entire scrollbar */
+      }
+      
+      /* Track of the scrollbar */
+      ::-webkit-scrollbar-track {
+        background: red; /* color of the tracking area */
+      }
+      
+      /* Handle (or "thumb") of the scrollbar */
+      ::-webkit-scrollbar-thumb {
+        background: green; /* color of the scroll thumb */
+      }
+      
+      /* Handle on hover */
+      ::-webkit-scrollbar-thumb:hover {
+        background: #555; /* color of the scroll thumb on hover */
+      }      
+    </ch-style>
+    -->
+  </head>
+  <body>
+    <div class="container">
+      <section class="section-dev" data-title="grid scrollbar">
+        <ch-grid row-selection-mode="none">
+          <ch-grid-columnset>
+            <ch-grid-column
+              column-id="code"
+              column-name="Country Code"
+              sort-direction="asc"
+            >
+              <div class="column-settings" slot="settings">
+                Column Settings !!
+              </div>
+            </ch-grid-column>
+            <ch-grid-column column-id="name" column-name="Country Name">
+              <div class="column-settings" slot="settings">
+                Column Settings !!
+              </div>
+            </ch-grid-column>
+            <ch-grid-column
+              column-id="population"
+              column-name="Country Population"
+            >
+              <div class="column-settings" slot="settings">
+                Column Settings !!
+              </div>
+            </ch-grid-column>
+            <ch-grid-column column-id="language" column-name="Country Language">
+              <div class="column-settings" slot="settings">
+                Column Settings !!
+              </div>
+            </ch-grid-column>
+          </ch-grid-columnset>
+
+          <ch-grid-row rowid="ar">
+            <ch-grid-cell>AR</ch-grid-cell>
+            <ch-grid-cell>Argentina</ch-grid-cell>
+            <ch-grid-cell>45.400.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="bo">
+            <ch-grid-cell>BO</ch-grid-cell>
+            <ch-grid-cell>Bolivia</ch-grid-cell>
+            <ch-grid-cell>11.800.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="br">
+            <ch-grid-cell>BR</ch-grid-cell>
+            <ch-grid-cell>Brasil</ch-grid-cell>
+            <ch-grid-cell>212.600.000</ch-grid-cell>
+            <ch-grid-cell>Português</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="cl">
+            <ch-grid-cell>CL</ch-grid-cell>
+            <ch-grid-cell>Chile</ch-grid-cell>
+            <ch-grid-cell>19.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="ec">
+            <ch-grid-cell>EC</ch-grid-cell>
+            <ch-grid-cell>Ecuador</ch-grid-cell>
+            <ch-grid-cell>17.600.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="py">
+            <ch-grid-cell>PY</ch-grid-cell>
+            <ch-grid-cell>Paraguay</ch-grid-cell>
+            <ch-grid-cell>7.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="pe">
+            <ch-grid-cell>PE</ch-grid-cell>
+            <ch-grid-cell>Perú</ch-grid-cell>
+            <ch-grid-cell>32.800.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="uy">
+            <ch-grid-cell>UY</ch-grid-cell>
+            <ch-grid-cell>Uruguay</ch-grid-cell>
+            <ch-grid-cell>3.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="ve">
+            <ch-grid-cell>VE</ch-grid-cell>
+            <ch-grid-cell>Venezuela</ch-grid-cell>
+            <ch-grid-cell>28.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+
+          <ch-grid-actionbar slot="footer">
+            <ch-grid-action-refresh title="Refresh"></ch-grid-action-refresh>
+            <ch-grid-action-settings title="Settings"></ch-grid-action-settings>
+          </ch-grid-actionbar>
+        </ch-grid>
+      </section>
+    </div>
+
+    <script src="./assets/common.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This component allows you to embed styles in the shadow-root of chameleon components.
For example, it allows you to style the scrollbars.

<ch-style>
:host {
  scrollbar-color: orange orangered;
}
::-webkit-scrollbar {
  width: 12px;
}
::-webkit-scrollbar-track {
  background: orange;
  border-radius: 5px;
}
::-webkit-scrollbar-thumb {
  background: orangered;
  border-radius: 5px;
}
::-webkit-scrollbar-thumb:hover {
  background: darkred;
}
</ch-style>