### PR TITLE
Fixes for ch-window

### DIFF
--- a/src/components/window/ch-window.scss
+++ b/src/components/window/ch-window.scss
@@ -1,6 +1,9 @@
 :host {
   --ch-window-offset-x: 0px;
   --ch-window-offset-y: 0px;
+
+  --ch-window-x-outside: 0px;
+  --ch-window-y-outside: 0px;
 }
 
 :host(:not([hidden])) {
@@ -49,10 +52,7 @@
 .window {
   display: flex;
   flex-direction: column;
-  transform: translate(
-      var(--ch-window-x-outside, 0px),
-      var(--ch-window-y-outside, 0px)
-    )
+  transform: translate(var(--ch-window-x-outside), var(--ch-window-y-outside))
     translate(var(--ch-window-x-drag, 0px), var(--ch-window-y-drag, 0px));
 
   :host([x-align="outside-start"]) & {


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Avoid custom var inheritance when nesting windows.

 - Check if the ch-window is relative to another containing block.