### PR TITLE
[ch-grid] Fix issues related with focus

### DIFF
--- a/src/components/common/helpers.ts
+++ b/src/components/common/helpers.ts
@@ -25,3 +25,15 @@ export enum MouseEventButtons {
   BACK = 8,
   FORWARD = 16
 }
+
+export function focusComposedPath(): HTMLElement[] {
+  const composedPath = [];
+  let root: Document | ShadowRoot = document;
+
+  while (root && root.activeElement) {
+    composedPath.push(root.activeElement);
+    root = root.activeElement.shadowRoot;
+  }
+
+  return composedPath.reverse();
+}

--- a/src/components/grid/ch-grid.tsx
+++ b/src/components/grid/ch-grid.tsx
@@ -392,31 +392,38 @@ export class ChGrid {
           : null);
     }
 
-    if (this.manager.selection.selecting) {
-      const row = this.manager.getRowEventTarget(eventInfo);
-      const cell = this.manager.getCellEventTarget(eventInfo);
+    selectingBlock: {
+      if (this.manager.selection.selecting) {
+        if (focusComposedPath()[0] !== this.el) {
+          this.stopSelecting();
+          break selectingBlock;
+        }
 
-      if (
-        row &&
-        (this.manager.selection.selectingRow !== row ||
-          this.manager.selection.selectingCell !== cell)
-      ) {
-        const isKeyModifierPressed = mouseEventModifierKey(eventInfo);
-        const isMouseButtonRightPressed = mouseEventHasButtonPressed(
-          eventInfo,
-          MouseEventButtons.RIGHT
-        );
+        const row = this.manager.getRowEventTarget(eventInfo);
+        const cell = this.manager.getCellEventTarget(eventInfo);
 
-        this.selectByPointerEvent(
-          row,
-          cell,
-          isKeyModifierPressed && !isMouseButtonRightPressed,
-          !isMouseButtonRightPressed,
-          isMouseButtonRightPressed
-        );
+        if (
+          row &&
+          (this.manager.selection.selectingRow !== row ||
+            this.manager.selection.selectingCell !== cell)
+        ) {
+          const isKeyModifierPressed = mouseEventModifierKey(eventInfo);
+          const isMouseButtonRightPressed = mouseEventHasButtonPressed(
+            eventInfo,
+            MouseEventButtons.RIGHT
+          );
 
-        this.manager.selection.selectingRow = row;
-        this.manager.selection.selectingCell = cell;
+          this.selectByPointerEvent(
+            row,
+            cell,
+            isKeyModifierPressed && !isMouseButtonRightPressed,
+            !isMouseButtonRightPressed,
+            isMouseButtonRightPressed
+          );
+
+          this.manager.selection.selectingRow = row;
+          this.manager.selection.selectingCell = cell;
+        }
       }
     }
   }
@@ -453,9 +460,7 @@ export class ChGrid {
 
   @Listen("mouseup", { passive: true })
   mouseUpHandler() {
-    this.manager.selection.selecting = false;
-    this.manager.selection.selectingRow = null;
-    this.manager.selection.selectingCell = null;
+    this.stopSelecting();
   }
 
   @Listen("dblclick", { passive: true })
@@ -999,6 +1004,12 @@ export class ChGrid {
     this.cellSelected = cellSelected;
 
     rowFocused?.ensureVisible();
+  }
+
+  private stopSelecting() {
+    this.manager.selection.selecting = false;
+    this.manager.selection.selectingRow = null;
+    this.manager.selection.selectingCell = null;
   }
 
   private renderSettings() {

--- a/src/components/grid/ch-grid.tsx
+++ b/src/components/grid/ch-grid.tsx
@@ -38,6 +38,7 @@ import {
 import {
   MouseEventButton,
   MouseEventButtons,
+  focusComposedPath,
   mouseEventHasButtonPressed,
   mouseEventModifierKey
 } from "../common/helpers";
@@ -282,7 +283,7 @@ export class ChGrid {
   @Listen("keydown", { target: "window" })
   windowKeyDownHandler(eventInfo: KeyboardEvent) {
     if (
-      document.activeElement === this.el &&
+      focusComposedPath()[0] === this.el &&
       [
         " ",
         "+",
@@ -303,7 +304,7 @@ export class ChGrid {
 
   @Listen("keydown", { passive: true })
   keyDownHandler(eventInfo: KeyboardEvent) {
-    if (document.activeElement === this.el) {
+    if (focusComposedPath()[0] === this.el) {
       switch (eventInfo.key) {
         case " ":
           this.toggleRowsMarked();


### PR DESCRIPTION
- Keyboard navigation doesn't work if ch-grid is inside a shadow-root
- If a text selection is made in an input that is inside a cell and the mouse moves outside of it over another cell, then the cell that has the input loses the selection.