### PR TITLE
fix ch-window hide logic

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -20,7 +20,8 @@ import { ChPaginatorNavigateClickedEvent, ChPaginatorNavigateType } from "./comp
 import { ChPaginatorPagesPageChangedEvent } from "./components/paginator/paginator-pages/ch-paginator-pages";
 import { ecLevel } from "./components/qr/ch-qr";
 import { GxDataTransferInfo, LabelPosition } from "./common/types";
-import { FocusChangeAttempt, SuggestItemSelectedEvent } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
+import { SuggestItemSelectedEvent } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
+import { FocusChangeAttempt, SuggestItemSelectedEvent as SuggestItemSelectedEvent1 } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
 import { ActionGroupItemModel } from "./components/test/test-action-group/types";
 import { DropdownItemModel } from "./components/test/test-dropdown/types";
 import { TreeXDataTransferInfo, TreeXDropCheckInfo, TreeXItemDragStartInfo, TreeXItemModel, TreeXLines, TreeXListItemExpandedInfo, TreeXListItemNewCaption, TreeXListItemSelectedInfo, TreeXModel } from "./components/tree-x/types";
@@ -3101,6 +3102,10 @@ declare namespace LocalJSX {
           * The label position
          */
         "labelPosition"?: LabelPosition;
+        /**
+          * This event is emitted when an item was selected.
+         */
+        "onSelectionChanged"?: (event: ChSuggestCustomEvent<SuggestItemSelectedEvent>) => void;
         /**
           * This event is emitted every time there input events fires, and it emits the actual input value.
          */

--- a/src/components/suggest/ch-suggest.tsx
+++ b/src/components/suggest/ch-suggest.tsx
@@ -138,6 +138,11 @@ INDEX:
    */
   @Event() valueChanged: EventEmitter<string>;
 
+  /**
+   * This event is emitted when an item was selected.
+   */
+  @Event() selectionChanged: EventEmitter<SuggestItemSelectedEvent>;
+
   // 6.COMPONENT LIFECYCLE EVENTS //
 
   // 7.LISTENERS //
@@ -146,6 +151,12 @@ INDEX:
   itemSelectedHandler(event: CustomEvent<SuggestItemSelectedEvent>) {
     this.value = event.detail.value;
     this.closeWindow();
+    this.selectionChanged.emit({
+      value: this.value,
+      description: event.detail.description,
+      icon: event.detail.icon,
+      indexes: event.detail.indexes
+    });
   }
 
   @Listen("focusChangeAttempt")

--- a/src/components/suggest/ch-suggest.tsx
+++ b/src/components/suggest/ch-suggest.tsx
@@ -147,16 +147,12 @@ INDEX:
 
   // 7.LISTENERS //
 
-  @Listen("itemSelected")
+  @Listen("itemSelected", { capture: true })
   itemSelectedHandler(event: CustomEvent<SuggestItemSelectedEvent>) {
+    event.stopPropagation();
     this.value = event.detail.value;
     this.closeWindow();
-    this.selectionChanged.emit({
-      value: this.value,
-      description: event.detail.description,
-      icon: event.detail.icon,
-      indexes: event.detail.indexes
-    });
+    this.selectionChanged.emit(event.detail);
   }
 
   @Listen("focusChangeAttempt")

--- a/src/components/suggest/ch-suggest.tsx
+++ b/src/components/suggest/ch-suggest.tsx
@@ -178,6 +178,7 @@ INDEX:
   windowClosedHandler() {
     this.textInput.focus();
     this.windowHidden = true;
+    this.el.innerHTML = "";
   }
 
   // 9.PUBLIC METHODS API //

--- a/src/components/suggest/readme.md
+++ b/src/components/suggest/readme.md
@@ -21,9 +21,10 @@
 
 ## Events
 
-| Event          | Description                                                                                     | Type                  |
-| -------------- | ----------------------------------------------------------------------------------------------- | --------------------- |
-| `valueChanged` | This event is emitted every time there input events fires, and it emits the actual input value. | `CustomEvent<string>` |
+| Event              | Description                                                                                     | Type                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `selectionChanged` | This event is emitted when an item was selected.                                                | `CustomEvent<{ value: any; indexes: SuggestItemIndexes; description?: string; icon?: string; }>` |
+| `valueChanged`     | This event is emitted every time there input events fires, and it emits the actual input value. | `CustomEvent<string>`                                                                            |
 
 
 ## Methods

--- a/src/pages/suggest.html
+++ b/src/pages/suggest.html
@@ -281,6 +281,7 @@
                 chSuggestListItem.innerText = item.innerText;
                 chSuggestListItem.value = item.getAttribute("data-value");
                 chSuggestListItem.itemId = item.getAttribute("data-id");
+                chSuggestListItem.iconSrc = item.getAttribute("data-icon");
                 if (category) {
                   chSuggestList.appendChild(chSuggestListItem);
                 } else {
@@ -321,8 +322,8 @@
         console.log("valueChanged event:", e.detail);
       });
 
-      chSuggest.addEventListener("itemSelected", e => {
-        console.log("itemSelected event:", e.detail);
+      chSuggest.addEventListener("selectionChanged", e => {
+        console.log("selectionChanged event:", e.detail);
       });
     </script>
     <script src="assets/common.js"></script>

--- a/src/pages/suggest.html
+++ b/src/pages/suggest.html
@@ -184,7 +184,7 @@
       </ul>
 
       <!-- ch-suggest -->
-      <section class="section-dev" data-title="ch-suggest">
+      <section class="section-dev" data-title="ch-suggest" id="section-dev">
         <ch-suggest
           label="This is the label"
           suggest-title="Select your food"
@@ -321,9 +321,11 @@
       chSuggest.addEventListener("valueChanged", e => {
         console.log("valueChanged event:", e.detail);
       });
-
       chSuggest.addEventListener("selectionChanged", e => {
         console.log("selectionChanged event:", e.detail);
+      });
+      chSuggest.addEventListener("itemSelected", e => {
+        console.log("itemSelected event:", e.detail);
       });
     </script>
     <script src="assets/common.js"></script>


### PR DESCRIPTION
**1.fix**
Sometimes ch-window was not being displayed again, when it should. The issue was that the display of the ch-window is bound to whether or not there is slotted content, and there were a couple of situations where slotted content remained when it shouldn't:
- when the ch-window was closed by the user, by pressing escape, or by clicking outside the window
- when the ch-window was closed by the user because he/she selected an item.

The fix is to clear slotted content every time the ch-window is closed.

**2.improvement**
Even though the suggest-list-item emmits an event 'itemSelected' that can be used by the user, it is not possible to use this event directly on the ch-suggest element like this:

`<ch-suggest onItemSelected="..." >`

because the event does not exists on the ch-suggest. To improve how the user can listen to the event, an additional event was created on the ch-suggest, called 'selectionChanged', that emits the same information the 'itemSelected' emits.