### PR TITLE
fix suggest slot issue

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -24,6 +24,7 @@ import { SuggestItemSelectedEvent } from "./components/suggest/suggest-list-item
 import { FocusChangeAttempt, SuggestItemSelectedEvent as SuggestItemSelectedEvent1 } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
 import { ActionGroupItemModel } from "./components/test/test-action-group/types";
 import { DropdownItemModel } from "./components/test/test-dropdown/types";
+import { SelectorCategoryData } from "./components/test/test-suggest/test-suggest";
 import { TreeXDataTransferInfo, TreeXDropCheckInfo, TreeXItemDragStartInfo, TreeXItemModel, TreeXLines, TreeXListItemExpandedInfo, TreeXListItemNewCaption, TreeXListItemSelectedInfo } from "./components/tree-x/types";
 import { TreeXOperationStatusModifyCaption } from "./components/test/types";
 import { checkedChTreeItem } from "./components/tree/ch-tree";
@@ -1066,6 +1067,14 @@ export namespace Components {
          */
         "separation": number;
     }
+    interface ChTestSuggest {
+        /**
+          * Callback invoked when user writes on object selector input, return possible options to show in autocomplete list
+         */
+        "selectorSourceCallback"?: (
+    prefix: string
+  ) => Promise<SelectorCategoryData[]>;
+    }
     interface ChTestTreeX {
         /**
           * Callback that is executed when an element tries to drop in another item of the tree. Returns whether the drop is valid.
@@ -1187,6 +1196,35 @@ export namespace Components {
           * Sets the progress propiety to determine the progress.
          */
         "progress": number;
+    }
+    interface ChTooltip {
+        /**
+          * Specifies the delay (in ms) for the tooltip to be displayed.
+         */
+        "delay": number;
+        /**
+          * Specifies the position of the tooltip relative to the container element.
+         */
+        "position": | "OutsideStart_OutsideStart"
+    | "InsideStart_OutsideStart"
+    | "Center_OutsideStart"
+    | "InsideEnd_OutsideStart"
+    | "OutsideEnd_OutsideStart"
+    | "OutsideStart_InsideStart"
+    | "OutsideEnd_InsideStart"
+    | "OutsideStart_Center"
+    | "OutsideEnd_Center"
+    | "OutsideStart_InsideEnd"
+    | "OutsideEnd_InsideEnd"
+    | "OutsideStart_OutsideEnd"
+    | "InsideStart_OutsideEnd"
+    | "Center_OutsideEnd"
+    | "InsideEnd_OutsideEnd"
+    | "OutsideEnd_OutsideEnd";
+        /**
+          * Specifies the tooltip description.
+         */
+        "tooltipId": string;
     }
     interface ChTree {
         /**
@@ -1961,6 +1999,12 @@ declare global {
         prototype: HTMLChTestDropdownElement;
         new (): HTMLChTestDropdownElement;
     };
+    interface HTMLChTestSuggestElement extends Components.ChTestSuggest, HTMLStencilElement {
+    }
+    var HTMLChTestSuggestElement: {
+        prototype: HTMLChTestSuggestElement;
+        new (): HTMLChTestSuggestElement;
+    };
     interface HTMLChTestTreeXElement extends Components.ChTestTreeX, HTMLStencilElement {
     }
     var HTMLChTestTreeXElement: {
@@ -1978,6 +2022,12 @@ declare global {
     var HTMLChTimerElement: {
         prototype: HTMLChTimerElement;
         new (): HTMLChTimerElement;
+    };
+    interface HTMLChTooltipElement extends Components.ChTooltip, HTMLStencilElement {
+    }
+    var HTMLChTooltipElement: {
+        prototype: HTMLChTooltipElement;
+        new (): HTMLChTooltipElement;
     };
     interface HTMLChTreeElement extends Components.ChTree, HTMLStencilElement {
     }
@@ -2084,9 +2134,11 @@ declare global {
         "ch-suggest-list-item": HTMLChSuggestListItemElement;
         "ch-test-action-group": HTMLChTestActionGroupElement;
         "ch-test-dropdown": HTMLChTestDropdownElement;
+        "ch-test-suggest": HTMLChTestSuggestElement;
         "ch-test-tree-x": HTMLChTestTreeXElement;
         "ch-textblock": HTMLChTextblockElement;
         "ch-timer": HTMLChTimerElement;
+        "ch-tooltip": HTMLChTooltipElement;
         "ch-tree": HTMLChTreeElement;
         "ch-tree-item": HTMLChTreeItemElement;
         "ch-tree-x": HTMLChTreeXElement;
@@ -3219,6 +3271,14 @@ declare namespace LocalJSX {
          */
         "separation"?: number;
     }
+    interface ChTestSuggest {
+        /**
+          * Callback invoked when user writes on object selector input, return possible options to show in autocomplete list
+         */
+        "selectorSourceCallback"?: (
+    prefix: string
+  ) => Promise<SelectorCategoryData[]>;
+    }
     interface ChTestTreeX {
         /**
           * Callback that is executed when an element tries to drop in another item of the tree. Returns whether the drop is valid.
@@ -3309,6 +3369,35 @@ declare namespace LocalJSX {
           * Sets the progress propiety to determine the progress.
          */
         "progress"?: number;
+    }
+    interface ChTooltip {
+        /**
+          * Specifies the delay (in ms) for the tooltip to be displayed.
+         */
+        "delay"?: number;
+        /**
+          * Specifies the position of the tooltip relative to the container element.
+         */
+        "position"?: | "OutsideStart_OutsideStart"
+    | "InsideStart_OutsideStart"
+    | "Center_OutsideStart"
+    | "InsideEnd_OutsideStart"
+    | "OutsideEnd_OutsideStart"
+    | "OutsideStart_InsideStart"
+    | "OutsideEnd_InsideStart"
+    | "OutsideStart_Center"
+    | "OutsideEnd_Center"
+    | "OutsideStart_InsideEnd"
+    | "OutsideEnd_InsideEnd"
+    | "OutsideStart_OutsideEnd"
+    | "InsideStart_OutsideEnd"
+    | "Center_OutsideEnd"
+    | "InsideEnd_OutsideEnd"
+    | "OutsideEnd_OutsideEnd";
+        /**
+          * Specifies the tooltip description.
+         */
+        "tooltipId"?: string;
     }
     interface ChTree {
         /**
@@ -3713,9 +3802,11 @@ declare namespace LocalJSX {
         "ch-suggest-list-item": ChSuggestListItem;
         "ch-test-action-group": ChTestActionGroup;
         "ch-test-dropdown": ChTestDropdown;
+        "ch-test-suggest": ChTestSuggest;
         "ch-test-tree-x": ChTestTreeX;
         "ch-textblock": ChTextblock;
         "ch-timer": ChTimer;
+        "ch-tooltip": ChTooltip;
         "ch-tree": ChTree;
         "ch-tree-item": ChTreeItem;
         "ch-tree-x": ChTreeX;
@@ -3781,9 +3872,11 @@ declare module "@stencil/core" {
             "ch-suggest-list-item": LocalJSX.ChSuggestListItem & JSXBase.HTMLAttributes<HTMLChSuggestListItemElement>;
             "ch-test-action-group": LocalJSX.ChTestActionGroup & JSXBase.HTMLAttributes<HTMLChTestActionGroupElement>;
             "ch-test-dropdown": LocalJSX.ChTestDropdown & JSXBase.HTMLAttributes<HTMLChTestDropdownElement>;
+            "ch-test-suggest": LocalJSX.ChTestSuggest & JSXBase.HTMLAttributes<HTMLChTestSuggestElement>;
             "ch-test-tree-x": LocalJSX.ChTestTreeX & JSXBase.HTMLAttributes<HTMLChTestTreeXElement>;
             "ch-textblock": LocalJSX.ChTextblock & JSXBase.HTMLAttributes<HTMLChTextblockElement>;
             "ch-timer": LocalJSX.ChTimer & JSXBase.HTMLAttributes<HTMLChTimerElement>;
+            "ch-tooltip": LocalJSX.ChTooltip & JSXBase.HTMLAttributes<HTMLChTooltipElement>;
             "ch-tree": LocalJSX.ChTree & JSXBase.HTMLAttributes<HTMLChTreeElement>;
             "ch-tree-item": LocalJSX.ChTreeItem & JSXBase.HTMLAttributes<HTMLChTreeItemElement>;
             "ch-tree-x": LocalJSX.ChTreeX & JSXBase.HTMLAttributes<HTMLChTreeXElement>;

--- a/src/components/suggest/ch-suggest.tsx
+++ b/src/components/suggest/ch-suggest.tsx
@@ -84,6 +84,7 @@ INDEX:
 
   private textInput!: HTMLInputElement;
   private chWindow!: HTMLChWindowElement;
+  private slot!: HTMLSlotElement;
   @Element() el: HTMLChSuggestElement;
 
   // 3.STATE() VARIABLES //
@@ -185,7 +186,7 @@ INDEX:
   windowClosedHandler() {
     this.textInput.focus();
     this.windowHidden = true;
-    this.el.innerHTML = "";
+    this.slot.innerHTML = "";
   }
 
   // 9.PUBLIC METHODS API //
@@ -390,7 +391,10 @@ INDEX:
             close:close-button,
             window:dropdown"
           >
-            <slot onSlotchange={this.evaluateSlotIsEmpty}></slot>
+            <slot
+              onSlotchange={this.evaluateSlotIsEmpty}
+              ref={el => (this.slot = el as HTMLSlotElement)}
+            ></slot>
           </ch-window>
         </div>
       </Host>

--- a/src/components/suggest/readme.md
+++ b/src/components/suggest/readme.md
@@ -52,6 +52,10 @@ Type: `Promise<void>`
 
 ## Dependencies
 
+### Used by
+
+ - [ch-test-suggest](../test/test-suggest)
+
 ### Depends on
 
 - [ch-window](../window)
@@ -61,6 +65,7 @@ Type: `Promise<void>`
 graph TD;
   ch-suggest --> ch-window
   ch-window --> ch-window-close
+  ch-test-suggest --> ch-suggest
   style ch-suggest fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/suggest/suggest-list-item/readme.md
+++ b/src/components/suggest/suggest-list-item/readme.md
@@ -29,6 +29,19 @@
 | `"content-wrapper"` |             |
 
 
+## Dependencies
+
+### Used by
+
+ - [ch-test-suggest](../../test/test-suggest)
+
+### Graph
+```mermaid
+graph TD;
+  ch-test-suggest --> ch-suggest-list-item
+  style ch-suggest-list-item fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/suggest/suggest-list/readme.md
+++ b/src/components/suggest/suggest-list/readme.md
@@ -20,6 +20,19 @@
 | `"title"` |             |
 
 
+## Dependencies
+
+### Used by
+
+ - [ch-test-suggest](../../test/test-suggest)
+
+### Graph
+```mermaid
+graph TD;
+  ch-test-suggest --> ch-suggest-list
+  style ch-suggest-list fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/test/test-suggest/helpers.ts
+++ b/src/components/test/test-suggest/helpers.ts
@@ -1,0 +1,36 @@
+import { SelectorCategoryData, ObjectData } from "./test-suggest";
+
+import { SuggestItemData } from "../../suggest/suggest-list-item/ch-suggest-list-item";
+import { SuggestListData } from "../../suggest/suggest-list/ch-suggest-list";
+import { SuggestData } from "../../suggest/ch-suggest";
+
+/**
+ * @description This function converts SelectorCategoryData[] SuggestData
+ */
+export const convertObjectDataToSuggestData = (
+  selectorCategoriesData: SelectorCategoryData[]
+): SuggestData => {
+  const suggestData: SuggestData = {
+    suggestItems: null,
+    suggestLists: []
+  };
+  if (selectorCategoriesData.length) {
+    selectorCategoriesData.forEach(selectorCategory => {
+      const suggestList: SuggestListData = {
+        label: selectorCategory.name,
+        items: []
+      };
+      selectorCategory.items.forEach((objectData: ObjectData) => {
+        const suggestItem: SuggestItemData = {
+          value: objectData.id,
+
+          description: objectData.description,
+          icon: objectData.icon
+        };
+        suggestList.items.push(suggestItem);
+      });
+      suggestData.suggestLists.push(suggestList);
+    });
+  }
+  return suggestData;
+};

--- a/src/components/test/test-suggest/readme.md
+++ b/src/components/test/test-suggest/readme.md
@@ -1,0 +1,43 @@
+# ch-test-suggest
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property                 | Attribute | Description                                                                                                      | Type                                                  | Default     |
+| ------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ----------- |
+| `selectorSourceCallback` | --        | Callback invoked when user writes on object selector input, return possible options to show in autocomplete list | `(prefix: string) => Promise<SelectorCategoryData[]>` | `undefined` |
+
+
+## Shadow Parts
+
+| Part                        | Description |
+| --------------------------- | ----------- |
+| `"object-selector-suggest"` |             |
+
+
+## Dependencies
+
+### Depends on
+
+- [ch-suggest](../../suggest)
+- [ch-suggest-list](../../suggest/suggest-list)
+- [ch-suggest-list-item](../../suggest/suggest-list-item)
+
+### Graph
+```mermaid
+graph TD;
+  ch-test-suggest --> ch-suggest
+  ch-test-suggest --> ch-suggest-list
+  ch-test-suggest --> ch-suggest-list-item
+  ch-suggest --> ch-window
+  ch-window --> ch-window-close
+  style ch-test-suggest fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/test/test-suggest/renderSuggest.tsx
+++ b/src/components/test/test-suggest/renderSuggest.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { h } from "@stencil/core";
+import { SuggestItemData } from "../../suggest/suggest-list-item/ch-suggest-list-item";
+import { SuggestListData } from "../../suggest/suggest-list/ch-suggest-list";
+import { SuggestData } from "../../suggest/ch-suggest";
+
+export const renderSuggestLists = (
+  suggestData: SuggestData
+): HTMLChSuggestListElement[] => {
+  if (suggestData?.suggestLists.length) {
+    const randomNumber = Math.random();
+    const result = suggestData.suggestLists.map(
+      (list: SuggestListData): HTMLChSuggestListElement => {
+        return (
+          <ch-suggest-list label={list.label} key={randomNumber}>
+            {list.items.map((item: SuggestItemData) => {
+              return renderSuggestListsItem(item);
+            })}
+          </ch-suggest-list>
+        );
+      }
+    );
+    return result;
+  }
+  return null;
+};
+
+const renderSuggestListsItem = (
+  suggestItem: SuggestItemData
+): HTMLChSuggestListItemElement => {
+  return (
+    <ch-suggest-list-item value={suggestItem.value}>
+      {[suggestItem.description || suggestItem.value]}
+    </ch-suggest-list-item>
+  );
+};

--- a/src/components/test/test-suggest/test-suggest.css
+++ b/src/components/test/test-suggest/test-suggest.css
@@ -1,0 +1,114 @@
+:host {
+  display: block;
+}
+/*general*/
+:root {
+  --highlight-color: rgb(163, 25, 161);
+}
+/*ch-suggest*/
+ch-suggest {
+  display: block;
+}
+ch-suggest::part(title) {
+  display: block;
+  font-weight: bold;
+}
+ch-suggest::part(label) {
+  font-weight: 500;
+}
+ch-suggest[label-position="start"]::part(label) {
+  margin-inline-end: 8px;
+  display: flex;
+  align-items: center;
+}
+ch-suggest[label-position="above"]::part(label) {
+  margin-block-end: 4px;
+}
+ch-suggest::part(close-button) {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+ch-suggest::part(close-button)::after {
+  content: "✖";
+  line-height: 8px;
+  height: 100%;
+  display: block;
+  border: 1px solid black;
+  cursor: pointer;
+  text-align: center;
+  line-height: 16px;
+}
+ch-suggest::part(header) {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-block-end: 8px;
+}
+ch-suggest::part(ch-window-close) {
+  width: 10px;
+  height: 10px;
+}
+ch-suggest::part(input) {
+  padding: 4px 8px;
+  border: 1px solid black;
+}
+ch-suggest::part(input):focus {
+  outline: 2px solid var(--highlight-color);
+  border-color: var(--highlight-color);
+}
+/*ch-suggest-list*/
+ch-suggest-list {
+  background-color: rgba(234, 234, 234, 0.224);
+  border: 1px solid rgba(128, 128, 128, 0.275);
+  border-radius: 4px;
+  padding: 8px;
+  margin-block-end: 4px;
+}
+ch-suggest-list::part(title) {
+  font-size: 14px;
+  font-weight: bold;
+  text-transform: uppercase;
+  margin: 4px 0 8px 0;
+}
+/*ch-suggest-list-item*/
+ch-suggest-list-item::part(button) {
+  padding: 4px 8px;
+  cursor: pointer;
+  gap: 4px;
+}
+ch-suggest-list-item ch-icon {
+  --icon-size: 16px;
+  margin-inline-end: 2px;
+}
+ch-suggest-list-item:hover {
+  background-color: var(--ch-color--violet-100);
+}
+ch-suggest-list-item:focus,
+ch-suggest-list-item[selected]:focus {
+  outline: 2px solid var(--highlight-color);
+}
+ch-suggest-list-item[selected] {
+  background-color: rgba(241, 184, 243, 0.42);
+  outline: none;
+}
+ch-suggest-list-item::part(button):focus {
+  outline: 2px solid var(--highlight-color);
+  border-color: var(--highlight-color);
+}
+/*content-wrapper*/
+ch-suggest-list-item::part(content-wrapper) {
+  display: flex;
+  gap: 8px;
+}
+/*ch-window*/
+ch-suggest::part(dropdown) {
+  margin-block-start: 4px;
+  border: 1px solid black;
+  background-color: white;
+  padding: 8px;
+}
+/*focus*/
+:focus {
+  outline-style: none !important;
+}

--- a/src/components/test/test-suggest/test-suggest.tsx
+++ b/src/components/test/test-suggest/test-suggest.tsx
@@ -25,14 +25,7 @@ INDEX:
 
   // 1.OWN PROPERTIES //
 
-  /**
-   * The last SelectorCategoryData[] returned by selectorSourceCallback
-   */
-  private selectorCategoryData: SelectorCategoryData[] = [];
-
   // 2. REFERENCE TO ELEMENTS //
-
-  private selectObjectSuggestEl!: HTMLChSuggestElement;
 
   // 3.STATE() VARIABLES //
 
@@ -67,7 +60,6 @@ INDEX:
     const value = e.detail;
     this.selectorSourceCallback(value)
       .then(result => {
-        this.selectorCategoryData = result;
         /* show suggestions*/
         this.objectsSuggestions = convertObjectDataToSuggestData(result);
       })
@@ -83,7 +75,6 @@ INDEX:
       <Host>
         <ch-suggest
           onValueChanged={this.selectObjectValueChangedHandler}
-          ref={el => (this.selectObjectSuggestEl = el as HTMLChSuggestElement)}
           part="object-selector-suggest"
           exportparts="dropdown:select-object-dropdown"
         >

--- a/src/components/test/test-suggest/test-suggest.tsx
+++ b/src/components/test/test-suggest/test-suggest.tsx
@@ -1,0 +1,107 @@
+import { Component, Host, h, Prop, State } from "@stencil/core";
+import { SuggestData } from "../../suggest/ch-suggest";
+import { convertObjectDataToSuggestData } from "./helpers";
+import { renderSuggestLists } from "./renderSuggest";
+
+@Component({
+  tag: "ch-test-suggest",
+  styleUrl: "test-suggest.css",
+  shadow: true
+})
+export class ChTestSuggest {
+  /*
+INDEX:
+1.OWN PROPERTIES
+2.REFERENCE TO ELEMENTS
+3.STATE() VARIABLES
+4.PUBLIC PROPERTY API | WATCH'S
+5.EVENTS (EMIT)
+6.COMPONENT LIFECYCLE EVENTS
+7.LISTENERS
+8.PUBLIC METHODS API
+9.LOCAL METHODS
+10.RENDER() FUNCTION
+*/
+
+  // 1.OWN PROPERTIES //
+
+  /**
+   * The last SelectorCategoryData[] returned by selectorSourceCallback
+   */
+  private selectorCategoryData: SelectorCategoryData[] = [];
+
+  // 2. REFERENCE TO ELEMENTS //
+
+  private selectObjectSuggestEl!: HTMLChSuggestElement;
+
+  // 3.STATE() VARIABLES //
+
+  /**
+   * The objects suggestions that will appear on the suggest
+   */
+  @State() objectsSuggestions: SuggestData;
+
+  // 4.PUBLIC PROPERTY API | WATCH'S //
+
+  /**
+   * Callback invoked when user writes on object selector input, return possible options to show in autocomplete list
+   */
+  @Prop() readonly selectorSourceCallback?: (
+    prefix: string
+  ) => Promise<SelectorCategoryData[]>;
+
+  // 5.EVENTS (EMIT) //
+
+  // 6.COMPONENT LIFECYCLE EVENTS //
+
+  // 7.LISTENERS //
+
+  // 8.PUBLIC METHODS API //
+
+  // 9.LOCAL METHODS //
+
+  /**
+   * This handler gets fired every time the value of the 'Select Object' ch-suggest changes.
+   */
+  private selectObjectValueChangedHandler = async (e: CustomEvent<string>) => {
+    const value = e.detail;
+    this.selectorSourceCallback(value)
+      .then(result => {
+        this.selectorCategoryData = result;
+        /* show suggestions*/
+        this.objectsSuggestions = convertObjectDataToSuggestData(result);
+      })
+      .catch(() => {
+        // to do
+      });
+  };
+
+  // 10.RENDER() FUNCTION //
+
+  render() {
+    return (
+      <Host>
+        <ch-suggest
+          onValueChanged={this.selectObjectValueChangedHandler}
+          ref={el => (this.selectObjectSuggestEl = el as HTMLChSuggestElement)}
+          part="object-selector-suggest"
+          exportparts="dropdown:select-object-dropdown"
+        >
+          {renderSuggestLists(this.objectsSuggestions)}
+        </ch-suggest>
+      </Host>
+    );
+  }
+}
+
+export type SelectorCategoryData = {
+  name: string;
+  items: ObjectData[];
+};
+
+export type ObjectData = {
+  id: string;
+  icon: string;
+  name: string;
+  description?: string;
+};

--- a/src/components/tooltip/readme.md
+++ b/src/components/tooltip/readme.md
@@ -1,0 +1,33 @@
+# ch-tooltip
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property    | Attribute    | Description                                                              | Type                                                                                                                                                                                                                                                                                                                                                                                                                                               | Default                 |
+| ----------- | ------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `delay`     | `delay`      | Specifies the delay (in ms) for the tooltip to be displayed.             | `number`                                                                                                                                                                                                                                                                                                                                                                                                                                           | `100`                   |
+| `position`  | `position`   | Specifies the position of the tooltip relative to the container element. | `"Center_OutsideEnd" \| "Center_OutsideStart" \| "InsideEnd_OutsideEnd" \| "InsideEnd_OutsideStart" \| "InsideStart_OutsideEnd" \| "InsideStart_OutsideStart" \| "OutsideEnd_Center" \| "OutsideEnd_InsideEnd" \| "OutsideEnd_InsideStart" \| "OutsideEnd_OutsideEnd" \| "OutsideEnd_OutsideStart" \| "OutsideStart_Center" \| "OutsideStart_InsideEnd" \| "OutsideStart_InsideStart" \| "OutsideStart_OutsideEnd" \| "OutsideStart_OutsideStart"` | `"OutsideStart_Center"` |
+| `tooltipId` | `tooltip-id` | Specifies the tooltip description.                                       | `string`                                                                                                                                                                                                                                                                                                                                                                                                                                           | `"Tooltip"`             |
+
+
+## Dependencies
+
+### Depends on
+
+- [ch-window](../window)
+
+### Graph
+```mermaid
+graph TD;
+  ch-tooltip --> ch-window
+  ch-window --> ch-window-close
+  style ch-tooltip fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/window/readme.md
+++ b/src/components/window/readme.md
@@ -55,6 +55,7 @@
  - [ch-grid-row-actions](../grid/grid-row-actions)
  - [ch-grid-settings](../grid/grid-settings)
  - [ch-suggest](../suggest)
+ - [ch-tooltip](../tooltip)
 
 ### Depends on
 
@@ -69,6 +70,7 @@ graph TD;
   ch-grid-row-actions --> ch-window
   ch-grid-settings --> ch-window
   ch-suggest --> ch-window
+  ch-tooltip --> ch-window
   style ch-window fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/pages/test-suggest.html
+++ b/src/pages/test-suggest.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>ch-suggest</title>
+    <link rel="icon" type="image/ico" href="./assets/ch.ico" />
+    <script type="module" src="/build/chameleon.esm.js"></script>
+    <script nomodule src="/build/chameleon.js"></script>
+    <link href="/build/chameleon.css" rel="stylesheet" />
+    <link rel="stylesheet" href="./assets/styles/styles.css" />
+  </head>
+  <body class="styles">
+    <!-- Here goes the .header-dev (common.js)-->
+
+    <div class="container">
+      <ch-test-suggest id="ch-test-suggest"></ch-test-suggest>
+    </div>
+
+    <script>
+      const chTestSuggest = document.getElementById("ch-test-suggest");
+
+      /*Array of all the options the suggest could list*/
+      const selectorCategoryObjects = [
+        {
+          name: "attributes",
+          items: [
+            {
+              id: "has-both-id",
+              icon: "general/db2",
+              name: "Has Both",
+              description: "Is Referenced By + Has References To"
+            },
+            {
+              id: "has-none-id",
+              icon: "general/db2",
+              name: "Has none",
+              description: "Is not Referenced By + Has no References To"
+            },
+            {
+              id: "referenced-by-id",
+              icon: "general/db2",
+              name: "Referenced By",
+              description: "Is Referenced By only"
+            },
+            {
+              id: "references-to-id",
+              icon: "general/db2",
+              name: "Has References To",
+              description: "Has References To only"
+            },
+            {
+              id: "referenced-by-error-id",
+              icon: "general/db2",
+              name: "Referenced By ERROR",
+              description: "Is Referenced By couldn't be retrieved"
+            },
+            {
+              id: "references-to-error-id",
+              icon: "general/db2",
+              name: "References To ERROR",
+              description: "References To couldn't be retrieved"
+            }
+          ]
+        },
+        {
+          name: "object",
+          items: [
+            {
+              id: "golosina-123-id",
+              icon: "general/knowledge-base",
+              name: "Golosina",
+              description: "Golosina description"
+            },
+            {
+              id: "countries-with-attractions-id",
+              icon: "general/references",
+              name: "CountriesWithAttractions",
+              description: "CountriesWithAttractions description"
+            }
+          ]
+        },
+        {
+          name: "tables",
+          items: [
+            {
+              id: "country-id",
+              icon: "general/customization",
+              name: "Country",
+              description: "Country description"
+            }
+          ]
+        },
+        {
+          name: "search",
+          items: [
+            {
+              id: "countries-with-attractions-countries-with-attractions-id",
+              icon: "general/launchpad",
+              name: "CountriesWithAttractions - Countries With Attractions",
+              description: "CountriesWithAttractions description"
+            },
+            {
+              id: "countryid-coundtryid-id",
+              icon: "general/generator",
+              name: "CountryId - CountryId",
+              description: "CountryId description"
+            }
+          ]
+        }
+      ];
+
+      /*Function that filters selectorCategoryObjects with the actual suggest value*/
+      function searchAndFilterArray(objectsArray, searchValue) {
+        const results = [];
+
+        objectsArray.filter(category => {
+          const filteredItems = category.items.filter(item => {
+            const lowerSearchValue = searchValue.toLowerCase();
+            const lowerName = item.name.toLowerCase();
+            const lowerDescription = item.description
+              ? item.description.toLowerCase()
+              : "";
+
+            return (
+              lowerName.includes(lowerSearchValue) ||
+              lowerDescription.includes(lowerSearchValue)
+            );
+          });
+
+          if (filteredItems.length > 0) {
+            results.push({
+              name: category.name,
+              items: filteredItems.map(item => ({
+                id: item.id,
+                icon: item.icon,
+                name: item.name,
+                description: item.description || ""
+              }))
+            });
+          }
+        });
+        return results;
+      }
+
+      /*selectorSourceCallback*/
+      chTestSuggest.selectorSourceCallback = function (prefix) {
+        let selectorSourceCallbackPromise = new Promise(function (
+          resolve,
+          reject
+        ) {
+          const selectorCategoryFilteredData = searchAndFilterArray(
+            selectorCategoryObjects,
+            prefix
+          );
+          if (selectorCategoryFilteredData) {
+            resolve(selectorCategoryFilteredData);
+          } else {
+            //reject(false);
+          }
+        });
+        return selectorSourceCallbackPromise;
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
- Fix ch-suggest slot issue
- Create a test under /test/test-suggest

@ncamera the previous fix worked fine on a test that I made on a simple html page yesterday (suggest.html) :

the previous fix:
`this.el.innerHTML = "";`

But today on gxi-ide-web project, where we use the ch-suggest on a tsx file, it presented a bug after the second time the user searches: 

`TypeError: Cannot read properties of null (reading 'insertBefore')`

After some researching, it seems that `innerHTML = "";` has to be applied on the slot itself :

`this.slot.innerHTML = "";`

where _slot_ is a reference to the slot:

```
<slot  onSlotchange={this.evaluateSlotIsEmpty}
ref={el => (this.slot = el as HTMLSlotElement)}>
</slot>
```

I have created a test component _ch-test-suggest_ to replicate the case of use of gx-ide-web, and tested it. Now is working fine.

Sorry for the inconvenience. 
