### PR TITLE
[ch-window] Fix closeOnOutsideClick, closeOnEscape

### DIFF
--- a/src/components/window/ch-window.tsx
+++ b/src/components/window/ch-window.tsx
@@ -142,6 +142,12 @@ export class ChWindow {
     this.loadGlobalStyleSheet();
   }
 
+  componentDidLoad() {
+    if (!this.hidden) {
+      this.addListeners();
+    }
+  }
+
   @Listen("mousedown", { passive: true })
   mousedownHandler(eventInfo: MouseEvent) {
     if (this.isDraggable(eventInfo.composedPath())) {


### PR DESCRIPTION
If the component is started in an open state, the properties 'closeOnOutsideClick' and 'closeOnEscape' do not work.