### PR TITLE
Make sure the Tree View is the only element that processes the `dragover` event

### DIFF
--- a/src/components/tree-view/tree-view/tree-view.tsx
+++ b/src/components/tree-view/tree-view/tree-view.tsx
@@ -521,6 +521,11 @@ export class ChTreeView {
   }
 
   private trackItemDrag = (event: DragEvent) => {
+    // The Tree View must be the only element that processes the "dragover"
+    // event. Any other element that processes this event can modify the
+    // `dropEffect` an thus break the drag and drop implementation
+    event.stopImmediatePropagation();
+
     event.preventDefault();
     this.lastDragEvent = event;
 


### PR DESCRIPTION
The Tree View must be the only element that processes the `dragover` event. Any other element that processes this event can modify the `dropEffect` an thus break the drag and drop implementation.