### PR TITLE
Fixes and improvements for the ch-flexible-layout control

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -13,3 +13,8 @@ export type AccessibleRole =
   | "list"
   | "main"
   | "region";
+
+/**
+ * Specifies how the image will be rendered.
+ */
+export type ImageRender = "img" | "inject-svg" | "pseudo-element";

--- a/src/components/flexible-layout/flexible-layout/flexible-layout.scss
+++ b/src/components/flexible-layout/flexible-layout/flexible-layout.scss
@@ -1,3 +1,26 @@
 :host {
   display: contents;
 }
+
+.droppable-area {
+  // Reset popover's browser defaults
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  border: unset;
+  color: unset;
+
+  inset-block: var(--ch-flexible-layout-drop-area-block-start)
+    var(--ch-flexible-layout-drop-area-block-end);
+
+  inset-inline: var(--ch-flexible-layout-drop-area-inline-start)
+    var(--ch-flexible-layout-drop-area-inline-end);
+
+  background-color: color-mix(in srgb, currentColor 15%, transparent);
+
+  transition-property: inset;
+  transition-duration: 150ms;
+  transition-timing-function: ease-in-out;
+  pointer-events: none; // Avoid the capture of pointer events
+}

--- a/src/components/flexible-layout/flexible-layout/flexible-layout.tsx
+++ b/src/components/flexible-layout/flexible-layout/flexible-layout.tsx
@@ -89,10 +89,14 @@ export class ChFlexibleLayout {
   @Event() viewItemReorder: EventEmitter<WidgetReorderInfo>;
 
   /**
-   * Given the view ID and the item index, remove the item from the view
+   * Given the view ID and the item id, remove the page of the item from the view.
    */
   @Method()
-  async removeItemInView(viewId: string, index: number, forceRerender = true) {
+  async removeItemPageInView(
+    viewId: string,
+    itemId: string,
+    forceRerender = true
+  ) {
     const viewInfo = this.viewsInfo.get(viewId);
     if (!viewInfo) {
       return;
@@ -101,7 +105,7 @@ export class ChFlexibleLayout {
     const viewRef = this.el.shadowRoot.querySelector(
       `ch-tab[id='${viewInfo.id}']`
     ) as HTMLChTabElement;
-    await viewRef.removeItem(index, forceRerender);
+    await viewRef.removePage(itemId, forceRerender);
   }
 
   // @Listen("keydown", { target: "document" })

--- a/src/components/flexible-layout/flexible-layout/flexible-layout.tsx
+++ b/src/components/flexible-layout/flexible-layout/flexible-layout.tsx
@@ -210,6 +210,10 @@ export class ChFlexibleLayout {
             handleWidgetDrag(extendedDraggableView, this.#droppableAreaRef),
             { capture: true, passive: true, signal: abortController.signal }
           );
+
+          // Remove pointer events to not interfere on the mousemove event
+          extendedDraggableView.tabListView.style.pointerEvents = "none";
+          extendedDraggableView.pageView.style.pointerEvents = "none";
         }
       });
 
@@ -259,6 +263,10 @@ export class ChFlexibleLayout {
     // Remove mousemove handlers
     this.#draggableViews.forEach(draggableView => {
       draggableView.abortController.abort();
+
+      // Reset pointer events
+      draggableView.tabListView.style.pointerEvents = null;
+      draggableView.pageView.style.pointerEvents = null;
     });
 
     // Remove mouseup and keydown handlers

--- a/src/components/flexible-layout/flexible-layout/flexible-layout.tsx
+++ b/src/components/flexible-layout/flexible-layout/flexible-layout.tsx
@@ -173,7 +173,6 @@ export class ChFlexibleLayout {
       this.#draggedViewRef = event.target;
 
       const views = [...this.el.shadowRoot.querySelectorAll("ch-tab")];
-      // const itemInfo = this.viewsInfo.get(viewId).widgets[event.detail];
 
       this.#dragInfo = {
         index: event.detail,

--- a/src/components/flexible-layout/types.ts
+++ b/src/components/flexible-layout/types.ts
@@ -1,4 +1,4 @@
-import { AccessibleRole } from "../../common/types";
+import { AccessibleRole, ImageRender } from "../../common/types";
 import {
   LayoutSplitterDirection,
   LayoutSplitterSize
@@ -55,6 +55,11 @@ export type FlexibleLayoutWidget = {
   id: string;
   name: string;
   startImageSrc?: string;
+
+  /**
+   * Specifies how the image will be rendered. Defaults to `"pseudo-element"`.
+   */
+  startImageType?: ImageRender;
   wasRendered?: boolean;
 };
 

--- a/src/components/flexible-layout/types.ts
+++ b/src/components/flexible-layout/types.ts
@@ -110,3 +110,10 @@ export type DraggableViewInfo = {
   pageView: HTMLElement;
   tabListView: HTMLElement;
 };
+
+export type DraggableViewExtendedInfo = {
+  abortController: AbortController;
+  mainView: HTMLElement;
+  pageView: HTMLElement;
+  tabListView: HTMLElement;
+};

--- a/src/components/flexible-layout/types.ts
+++ b/src/components/flexible-layout/types.ts
@@ -52,6 +52,11 @@ export type FlexibleLayoutLeaf = {
 };
 
 export type FlexibleLayoutWidget = {
+  /**
+   * If `true` when a widget is closed its render state and DOM nodes won't be
+   * destroyed. Defaults to `false`.
+   */
+  conserveRenderState?: boolean;
   id: string;
   name: string;
   startImageSrc?: string;

--- a/src/components/flexible-layout/types.ts
+++ b/src/components/flexible-layout/types.ts
@@ -122,3 +122,22 @@ export type DraggableViewExtendedInfo = {
   tabListView: HTMLElement;
   viewId: string;
 };
+
+export type WidgetDragInfo = {
+  index: number;
+  viewId: string;
+};
+
+export type WidgetDropInfo = {
+  viewIdTarget: string;
+  dropAreaTarget: DroppableArea;
+};
+
+export type WidgetReorderInfo = WidgetDragInfo & WidgetDropInfo;
+
+export type DroppableArea =
+  | "block-start"
+  | "block-end"
+  | "inline-start"
+  | "inline-end"
+  | "center";

--- a/src/components/flexible-layout/types.ts
+++ b/src/components/flexible-layout/types.ts
@@ -1,6 +1,7 @@
 import { AccessibleRole, ImageRender } from "../../common/types";
 import {
   LayoutSplitterDirection,
+  LayoutSplitterDistributionGroup,
   LayoutSplitterSize
 } from "../layout-splitter/types";
 import { TabType } from "../tab/types";
@@ -11,7 +12,7 @@ import { TabType } from "../tab/types";
 export type ViewType = TabType | "blockStart";
 export type ViewAccessibleRole = Exclude<AccessibleRole, "article" | "list">;
 
-/**
+/*
  * TODO: For some reason, this type does not work when is applied to an object,
  * and the "main" or "blockStart" keys are defined
  */
@@ -80,6 +81,10 @@ export type FlexibleLayoutRenders = { [key: string]: () => any };
 // - - - - - - - - - - - - - - - - - - - -
 export type FlexibleLayoutView = {
   id: string;
+  itemRef: FlexibleLayoutLeaf;
+  itemRefIndex: number;
+  parentDistributionRef: LayoutSplitterDistributionGroup;
+  parentItemRef: FlexibleLayoutGroup;
   type: ViewType;
   expanded?: boolean;
   exportParts: string;

--- a/src/components/flexible-layout/types.ts
+++ b/src/components/flexible-layout/types.ts
@@ -99,10 +99,14 @@ export type ViewSelectedItemInfo = {
 //               Interfaces
 // - - - - - - - - - - - - - - - - - - - -
 export interface DraggableView {
+  endDragPreview: () => Promise<void>;
+
   /**
    * Returns the info associated to the draggable views.
    */
   getDraggableViews: () => Promise<DraggableViewInfo>;
+
+  promoteDragPreviewToTopLayer: () => Promise<void>;
 }
 
 export type DraggableViewInfo = {

--- a/src/components/flexible-layout/types.ts
+++ b/src/components/flexible-layout/types.ts
@@ -120,4 +120,5 @@ export type DraggableViewExtendedInfo = {
   mainView: HTMLElement;
   pageView: HTMLElement;
   tabListView: HTMLElement;
+  viewId: string;
 };

--- a/src/components/flexible-layout/utils.ts
+++ b/src/components/flexible-layout/utils.ts
@@ -1,5 +1,5 @@
 import { inBetween } from "../../common/utils";
-import { DraggableViewInfo } from "./types";
+import { DraggableViewExtendedInfo } from "./types";
 
 type DroppableArea =
   | "block-start"
@@ -21,14 +21,14 @@ const INLINE_END = "--ch-flexible-layout-drop-area-inline-end";
  * be displayed at the START position with half the size.
  */
 const START_HALF_THRESHOLD = 30; // In percentage
-const START_HALF_THRESHOLD_FRACTION = START_HALF_THRESHOLD / 100;
 
 /**
  * If the mouse position is in the interval [70%, 100%] the droppable area
  * should be displayed at the END position with half the size.
  */
 const END_HALF_THRESHOLD = 100 - START_HALF_THRESHOLD; // In percentage
-const END_HALF_THRESHOLD_FRACTION = 1 - START_HALF_THRESHOLD_FRACTION;
+
+const EDGE_SIZE = 0.5;
 
 const setProperty = (element: HTMLElement, property: string, value: number) =>
   element.style.setProperty(property, `${value}px`);
@@ -41,14 +41,13 @@ const droppableAreaMap: {
 } = {
   "block-start": (documentRect, mainViewRect) => [
     mainViewRect.top,
-    documentRect.height -
-      (mainViewRect.top + mainViewRect.height * START_HALF_THRESHOLD_FRACTION),
+    documentRect.height - (mainViewRect.top + mainViewRect.height * EDGE_SIZE),
     mainViewRect.left,
     documentRect.width - (mainViewRect.left + mainViewRect.width)
   ],
 
   "block-end": (documentRect, mainViewRect) => [
-    mainViewRect.top + mainViewRect.height * END_HALF_THRESHOLD_FRACTION,
+    mainViewRect.top + mainViewRect.height * EDGE_SIZE,
     documentRect.height - (mainViewRect.top + mainViewRect.height),
     mainViewRect.left,
     documentRect.width - (mainViewRect.left + mainViewRect.width)
@@ -58,14 +57,13 @@ const droppableAreaMap: {
     mainViewRect.top,
     documentRect.height - (mainViewRect.top + mainViewRect.height),
     mainViewRect.left,
-    documentRect.width -
-      (mainViewRect.left + mainViewRect.width * START_HALF_THRESHOLD_FRACTION)
+    documentRect.width - (mainViewRect.left + mainViewRect.width * EDGE_SIZE)
   ],
 
   "inline-end": (documentRect, mainViewRect) => [
     mainViewRect.top,
     documentRect.height - (mainViewRect.top + mainViewRect.height),
-    mainViewRect.left + mainViewRect.width * END_HALF_THRESHOLD_FRACTION,
+    mainViewRect.left + mainViewRect.width * EDGE_SIZE,
     documentRect.width - (mainViewRect.left + mainViewRect.width)
   ],
 
@@ -80,8 +78,10 @@ const droppableAreaMap: {
 let lastDroppableArea: DroppableArea;
 
 export const handleDraggableViewMouseMove =
-  (draggableView: DraggableViewInfo, droppableAreaRef: HTMLElement) =>
+  (draggableView: DraggableViewExtendedInfo, droppableAreaRef: HTMLElement) =>
   (event: MouseEvent) => {
+    event.stopPropagation(); // Prevents the remove of the droppable area
+
     // - - - - - - - - - - - DOM read operations - - - - - - - - - - -
     const documentRect = document.documentElement.getBoundingClientRect();
     const mainViewRect = draggableView.mainView.getBoundingClientRect();

--- a/src/components/flexible-layout/utils.ts
+++ b/src/components/flexible-layout/utils.ts
@@ -77,7 +77,7 @@ const droppableAreaMap: {
 
 let lastDroppableArea: DroppableArea;
 
-export const handleDraggableViewMouseMove =
+export const handleWidgetDrag =
   (draggableView: DraggableViewExtendedInfo, droppableAreaRef: HTMLElement) =>
   (event: MouseEvent) => {
     event.stopPropagation(); // Prevents the remove of the droppable area

--- a/src/components/flexible-layout/utils.ts
+++ b/src/components/flexible-layout/utils.ts
@@ -1,12 +1,9 @@
 import { inBetween } from "../../common/utils";
-import { DraggableViewExtendedInfo } from "./types";
-
-type DroppableArea =
-  | "block-start"
-  | "block-end"
-  | "inline-start"
-  | "inline-end"
-  | "center";
+import {
+  DraggableViewExtendedInfo,
+  DroppableArea,
+  WidgetDropInfo
+} from "./types";
 
 type DroppableAreaSizes = [number, number, number, number];
 
@@ -76,6 +73,7 @@ const droppableAreaMap: {
 };
 
 let lastDroppableArea: DroppableArea;
+let lastViewId: string;
 
 export const handleWidgetDrag =
   (draggableView: DraggableViewExtendedInfo, droppableAreaRef: HTMLElement) =>
@@ -136,10 +134,14 @@ export const handleWidgetDrag =
     }
 
     // If the droppable area did not change, there is no need to update the DOM
-    if (lastDroppableArea === droppableArea) {
+    if (
+      lastViewId === draggableView.viewId &&
+      lastDroppableArea === droppableArea
+    ) {
       return;
     }
     lastDroppableArea = droppableArea;
+    lastViewId = draggableView.viewId;
 
     const droppableAreaSizes = droppableAreaMap[droppableArea](
       documentRect,
@@ -156,5 +158,11 @@ export const handleWidgetDrag =
 
 export const removeDroppableAreaStyles = (droppableAreaRef: HTMLElement) => {
   lastDroppableArea = undefined;
+  lastViewId = undefined;
   droppableAreaRef.removeAttribute("style");
 };
+
+export const getWidgetDropInfo = (): WidgetDropInfo | undefined =>
+  lastDroppableArea === undefined
+    ? undefined
+    : { dropAreaTarget: lastDroppableArea, viewIdTarget: lastViewId };

--- a/src/components/flexible-layout/utils.ts
+++ b/src/components/flexible-layout/utils.ts
@@ -1,0 +1,160 @@
+import { inBetween } from "../../common/utils";
+import { DraggableViewInfo } from "./types";
+
+type DroppableArea =
+  | "block-start"
+  | "block-end"
+  | "inline-start"
+  | "inline-end"
+  | "center";
+
+type DroppableAreaSizes = [number, number, number, number];
+
+// Custom vars
+const BLOCK_START = "--ch-flexible-layout-drop-area-block-start";
+const BLOCK_END = "--ch-flexible-layout-drop-area-block-end";
+const INLINE_START = "--ch-flexible-layout-drop-area-inline-start";
+const INLINE_END = "--ch-flexible-layout-drop-area-inline-end";
+
+/**
+ * If the mouse position is in the interval [0%, 30%] the droppable area should
+ * be displayed at the START position with half the size.
+ */
+const START_HALF_THRESHOLD = 30; // In percentage
+const START_HALF_THRESHOLD_FRACTION = START_HALF_THRESHOLD / 100;
+
+/**
+ * If the mouse position is in the interval [70%, 100%] the droppable area
+ * should be displayed at the END position with half the size.
+ */
+const END_HALF_THRESHOLD = 100 - START_HALF_THRESHOLD; // In percentage
+const END_HALF_THRESHOLD_FRACTION = 1 - START_HALF_THRESHOLD_FRACTION;
+
+const setProperty = (element: HTMLElement, property: string, value: number) =>
+  element.style.setProperty(property, `${value}px`);
+
+const droppableAreaMap: {
+  [key in DroppableArea]: (
+    documentRect: DOMRect,
+    mainViewRect: DOMRect
+  ) => DroppableAreaSizes;
+} = {
+  "block-start": (documentRect, mainViewRect) => [
+    mainViewRect.top,
+    documentRect.height -
+      (mainViewRect.top + mainViewRect.height * START_HALF_THRESHOLD_FRACTION),
+    mainViewRect.left,
+    documentRect.width - (mainViewRect.left + mainViewRect.width)
+  ],
+
+  "block-end": (documentRect, mainViewRect) => [
+    mainViewRect.top + mainViewRect.height * END_HALF_THRESHOLD_FRACTION,
+    documentRect.height - (mainViewRect.top + mainViewRect.height),
+    mainViewRect.left,
+    documentRect.width - (mainViewRect.left + mainViewRect.width)
+  ],
+
+  "inline-start": (documentRect, mainViewRect) => [
+    mainViewRect.top,
+    documentRect.height - (mainViewRect.top + mainViewRect.height),
+    mainViewRect.left,
+    documentRect.width -
+      (mainViewRect.left + mainViewRect.width * START_HALF_THRESHOLD_FRACTION)
+  ],
+
+  "inline-end": (documentRect, mainViewRect) => [
+    mainViewRect.top,
+    documentRect.height - (mainViewRect.top + mainViewRect.height),
+    mainViewRect.left + mainViewRect.width * END_HALF_THRESHOLD_FRACTION,
+    documentRect.width - (mainViewRect.left + mainViewRect.width)
+  ],
+
+  center: (documentRect, mainViewRect) => [
+    mainViewRect.top,
+    documentRect.height - (mainViewRect.top + mainViewRect.height),
+    mainViewRect.left,
+    documentRect.width - (mainViewRect.left + mainViewRect.width)
+  ]
+};
+
+let lastDroppableArea: DroppableArea;
+
+export const handleDraggableViewMouseMove =
+  (draggableView: DraggableViewInfo, droppableAreaRef: HTMLElement) =>
+  (event: MouseEvent) => {
+    // - - - - - - - - - - - DOM read operations - - - - - - - - - - -
+    const documentRect = document.documentElement.getBoundingClientRect();
+    const mainViewRect = draggableView.mainView.getBoundingClientRect();
+    const positionX = event.clientX; // Mouse position X
+    const positionY = event.clientY; // Mouse position Y
+
+    const distanceToTheLeftEdge = positionX - mainViewRect.left;
+    const distanceToTheTopEdge = positionY - mainViewRect.top;
+
+    const relativePositionX =
+      (distanceToTheLeftEdge / mainViewRect.width) * 100;
+    const relativePositionY =
+      (distanceToTheTopEdge / mainViewRect.height) * 100;
+
+    let droppableArea: DroppableArea;
+
+    // Block start (Most likely droppable area)
+    if (
+      relativePositionY <= START_HALF_THRESHOLD &&
+      inBetween(relativePositionY, relativePositionX, 100 - relativePositionY)
+    ) {
+      droppableArea = "block-start";
+    }
+
+    // Inline End (second most likely droppable area)
+    else if (
+      relativePositionX >= END_HALF_THRESHOLD &&
+      inBetween(100 - relativePositionX, relativePositionY, relativePositionX)
+    ) {
+      droppableArea = "inline-end";
+    }
+
+    // Inline Start
+    else if (
+      relativePositionX <= START_HALF_THRESHOLD &&
+      inBetween(relativePositionX, relativePositionY, 100 - relativePositionX)
+    ) {
+      droppableArea = "inline-start";
+    }
+
+    // Block end
+    else if (
+      relativePositionY >= END_HALF_THRESHOLD &&
+      inBetween(100 - relativePositionY, relativePositionX, relativePositionY)
+    ) {
+      droppableArea = "block-end";
+    }
+
+    // Center
+    else {
+      droppableArea = "center";
+    }
+
+    // If the droppable area did not change, there is no need to update the DOM
+    if (lastDroppableArea === droppableArea) {
+      return;
+    }
+    lastDroppableArea = droppableArea;
+
+    const droppableAreaSizes = droppableAreaMap[droppableArea](
+      documentRect,
+      mainViewRect
+    );
+
+    // - - - - - - - - - - - DOM write operations - - - - - - - - - - -
+    setProperty(droppableAreaRef, BLOCK_START, droppableAreaSizes[0]);
+    setProperty(droppableAreaRef, BLOCK_END, droppableAreaSizes[1]);
+
+    setProperty(droppableAreaRef, INLINE_START, droppableAreaSizes[2]);
+    setProperty(droppableAreaRef, INLINE_END, droppableAreaSizes[3]);
+  };
+
+export const removeDroppableAreaStyles = (droppableAreaRef: HTMLElement) => {
+  lastDroppableArea = undefined;
+  droppableAreaRef.removeAttribute("style");
+};

--- a/src/components/layout-splitter/layout-splitter.scss
+++ b/src/components/layout-splitter/layout-splitter.scss
@@ -23,6 +23,10 @@
   position: absolute;
   z-index: 1;
 
+  &[aria-disabled] {
+    pointer-events: none;
+  }
+
   // Remove default focus style
   &:focus-visible {
     outline: unset;

--- a/src/components/layout-splitter/layout-splitter.tsx
+++ b/src/components/layout-splitter/layout-splitter.tsx
@@ -68,6 +68,12 @@ export class ChLayoutSplitter implements ChComponent {
   @Prop() readonly barAccessibleName: string = "Resize";
 
   /**
+   * This attribute lets you specify if the resize operation is disabled in all
+   * drag bars. If `true`, the drag bars are disabled.
+   */
+  @Prop() readonly dragBarDisabled: boolean = false;
+
+  /**
    * Specifies the resizing increment (in pixel) that is applied when using the
    * keyboard to resize a drag bar.
    */
@@ -275,6 +281,7 @@ export class ChLayoutSplitter implements ChComponent {
           // - - - Accessibility - - -
           role="separator"
           aria-controls={getAriaControls(indexPrefix, index)}
+          aria-disabled={this.dragBarDisabled ? "true" : null}
           aria-label={this.barAccessibleName}
           aria-orientation={direction === "columns" ? "vertical" : "horizontal"}
           title={this.barAccessibleName}
@@ -285,18 +292,21 @@ export class ChLayoutSplitter implements ChComponent {
           style={{
             [DRAG_BAR_POSITION_CUSTOM_VAR]: `calc(${item.dragBarPosition})`
           }}
-          onKeyDown={this.#handleResize(
-            direction,
-            index,
-            fixedSizesSum,
-            layoutItems
-          )}
-          onMouseDown={this.#mouseDownHandler(
-            direction,
-            index,
-            fixedSizesSum,
-            layoutItems
-          )}
+          onKeyDown={
+            !this.dragBarDisabled
+              ? this.#handleResize(direction, index, fixedSizesSum, layoutItems)
+              : null
+          }
+          onMouseDown={
+            !this.dragBarDisabled
+              ? this.#mouseDownHandler(
+                  direction,
+                  index,
+                  fixedSizesSum,
+                  layoutItems
+                )
+              : null
+          }
         ></div>
       )
     ]);

--- a/src/components/renders/flexible-layout/flexible-layout-render.tsx
+++ b/src/components/renders/flexible-layout/flexible-layout-render.tsx
@@ -6,7 +6,7 @@ import {
   ViewItemCloseInfo,
   ViewSelectedItemInfo
 } from "../../flexible-layout/types";
-import { getLayoutModel } from "../../flexible-layout/flexible-layout/utils";
+import { getLayoutModel } from "./utils";
 import { ChFlexibleLayoutCustomEvent } from "../../../components";
 import { LayoutSplitterDistribution } from "../../layout-splitter/types";
 

--- a/src/components/renders/flexible-layout/remove-view.ts
+++ b/src/components/renders/flexible-layout/remove-view.ts
@@ -1,0 +1,52 @@
+import { removeElement } from "../../../common/array";
+import {
+  FlexibleLayoutLeaf,
+  FlexibleLayoutView
+} from "../../flexible-layout/types";
+
+export const removeView = (
+  viewId: string,
+  viewsInfo: Map<string, FlexibleLayoutView>,
+  renderedWidgets: Set<string>,
+  removeRenderedWidgets: boolean
+) => {
+  const viewInfo = viewsInfo.get(viewId);
+
+  if (!viewInfo) {
+    return false;
+  }
+
+  // Remove rendered widgets
+  if (removeRenderedWidgets) {
+    viewInfo.widgets.forEach(widget => {
+      renderedWidgets.delete(widget.id);
+    });
+  }
+
+  const parentItemRefItems = viewInfo.parentItemRef.items;
+
+  // The space reserved for the view can be given to a sibling view
+  if (parentItemRefItems.length > 1) {
+    const viewToAddSpace =
+      parentItemRefItems[
+        viewInfo.itemRefIndex === 0 ? 1 : viewInfo.itemRefIndex - 1
+      ];
+
+    addSpaceToView(viewInfo.itemRef, viewToAddSpace as FlexibleLayoutLeaf);
+  }
+
+  // Delete the view
+  removeElement(parentItemRefItems, viewInfo.itemRefIndex);
+  removeElement(viewInfo.parentDistributionRef.items, viewInfo.itemRefIndex);
+  viewsInfo.delete(viewId);
+
+  return true;
+};
+
+function addSpaceToView(
+  viewToSubtract: FlexibleLayoutLeaf,
+  viewToAdd: FlexibleLayoutLeaf
+) {
+  console.log(viewToSubtract, viewToAdd);
+  // TODO: Add implementation. Ensure the given space is relative to 100% (1fr)
+}

--- a/src/components/renders/flexible-layout/utils.ts
+++ b/src/components/renders/flexible-layout/utils.ts
@@ -11,7 +11,7 @@ import {
   FlexibleLayoutItem,
   FlexibleLayoutLeaf,
   FlexibleLayoutView
-} from "../types";
+} from "../../flexible-layout/types";
 
 let lastViewId = 0;
 

--- a/src/components/renders/flexible-layout/utils.ts
+++ b/src/components/renders/flexible-layout/utils.ts
@@ -15,10 +15,15 @@ import {
 
 let lastViewId = 0;
 
+export const ROOT_VIEW: null = null;
+
 export const getViewId = () => `view-${lastViewId++}`;
 
 export const mapWidgetsToView = (
   flexibleLayoutLeaf: FlexibleLayoutLeaf,
+  itemRefIndex: number,
+  parentDistributionRef: LayoutSplitterDistributionGroup,
+  parentItemRef: FlexibleLayoutGroup,
   viewsInfo: Map<string, FlexibleLayoutView>,
   blockStartWidgets: Set<string>,
   renderedWidgets: Set<string>
@@ -34,6 +39,10 @@ export const mapWidgetsToView = (
     // Store widgets in the Map
     viewsInfo.set(viewId, {
       id: viewId,
+      itemRef: flexibleLayoutLeaf,
+      itemRefIndex: itemRefIndex,
+      parentDistributionRef: parentDistributionRef,
+      parentItemRef: parentItemRef,
       type: viewType,
       exportParts: "",
       widgets: widgets
@@ -73,6 +82,10 @@ export const mapWidgetsToView = (
   // Store widgets in the Map
   viewsInfo.set(viewId, {
     id: viewId,
+    itemRef: flexibleLayoutLeaf,
+    itemRefIndex: itemRefIndex,
+    parentDistributionRef: parentDistributionRef,
+    parentItemRef: parentItemRef,
     exportParts,
     selectedWidgetId: selectedWidgetId,
     type: viewType,
@@ -84,27 +97,33 @@ export const mapWidgetsToView = (
 
 const getItemsModel = (
   flexibleItems: FlexibleLayoutItem[],
+  parentItemRef: FlexibleLayoutGroup,
+  parentDistributionRef: LayoutSplitterDistributionGroup,
   viewsInfo: Map<string, FlexibleLayoutView>,
   blockStartWidgets: Set<string>,
   layoutSplitterParts: Set<string>,
   renderedWidgets: Set<string>
 ): LayoutSplitterDistributionItem[] =>
-  flexibleItems.map(item => {
+  flexibleItems.map((item, itemIndex) => {
     // Group
     if ((item as FlexibleLayoutGroup).items != null) {
       const group = item as FlexibleLayoutGroup;
 
+      // Necessary to have the reference before the getItemsModel call
       const splitterGroup: LayoutSplitterDistributionGroup = {
         direction: group.direction,
-        items: getItemsModel(
-          group.items,
-          viewsInfo,
-          blockStartWidgets,
-          layoutSplitterParts,
-          renderedWidgets
-        ),
         size: group.size
-      };
+      } as any;
+
+      splitterGroup.items = getItemsModel(
+        group.items,
+        group,
+        splitterGroup,
+        viewsInfo,
+        blockStartWidgets,
+        layoutSplitterParts,
+        renderedWidgets
+      );
 
       // Custom behaviors
       addCustomBehavior(item, splitterGroup, layoutSplitterParts);
@@ -117,6 +136,9 @@ const getItemsModel = (
 
     const viewId = mapWidgetsToView(
       leaf,
+      itemIndex,
+      parentDistributionRef,
+      parentItemRef,
       viewsInfo,
       blockStartWidgets,
       renderedWidgets
@@ -158,6 +180,8 @@ export const getLayoutModel = (
   direction: flexibleLayout.direction,
   items: getItemsModel(
     flexibleLayout.items,
+    ROOT_VIEW,
+    ROOT_VIEW,
     viewsInfo,
     blockStartWidgets,
     layoutSplitterParts,

--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -102,7 +102,7 @@ $z-index-gx-navbar-item: 107; // Same as $z-index-gx-navbar-item from w-c-l
   top: 0; // Necessary since the custom vars are physical values
   z-index: $z-index-gx-navbar-item + 1;
 
-  &[popover] {
+  &:popover-open {
     // Reset popover's browser defaults
     padding: 0;
     margin: 0;

--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -102,6 +102,18 @@ $z-index-gx-navbar-item: 107; // Same as $z-index-gx-navbar-item from w-c-l
   top: 0; // Necessary since the custom vars are physical values
   z-index: $z-index-gx-navbar-item + 1;
 
+  &[popover] {
+    // Reset popover's browser defaults
+    padding: 0;
+    margin: 0;
+    border: unset;
+    color: unset;
+
+    // The preview MUST NOT capture pointer-events in order to properly show
+    // the droppable areas
+    pointer-events: none;
+  }
+
   &-element {
     cursor: grabbing;
   }

--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -211,7 +211,7 @@ $z-index-gx-navbar-item: 107; // Same as $z-index-gx-navbar-item from w-c-l
 }
 
 // content-visibility: hidden is faster for rendering the content back, as
-// it preserves the rendering state of content (display: none does not)
+// it preserves the rendering state of the content (display: none does not)
 @supports (content-visibility: hidden) {
   .page-container--collapsed,
   .page--hidden {

--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -49,10 +49,17 @@ $z-index-gx-navbar-item: 107; // Same as $z-index-gx-navbar-item from w-c-l
   cursor: pointer;
 }
 
-.caption-image {
+.caption-image,
+.decorative-image::before {
   display: block;
   block-size: 18px;
   inline-size: 18px;
+}
+
+.decorative-image::before {
+  content: "";
+  -webkit-mask: var(--ch-tab-decorative-image) 50% 50% / 100% 100% no-repeat;
+  background-color: currentColor;
 }
 
 .close-button::after {

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -61,6 +61,8 @@ const MOUSE_POSITION_Y = "--ch-tab-mouse-position-y";
 const TAB_LIST_EDGE_START_POSITION = "--ch-tab-tab-list-start";
 const TAB_LIST_EDGE_END_POSITION = "--ch-tab-tab-list-end";
 
+const DECORATIVE_IMAGE = "--ch-tab-decorative-image";
+
 // Key codes
 const ARROW_UP = "ArrowUp";
 const ARROW_RIGHT = "ArrowRight";
@@ -85,6 +87,10 @@ const LAST_CAPTION_BUTTON = (tabListRef: HTMLElement) =>
   tabListRef.querySelector(":scope>button:last-child");
 
 // Utility functions
+const isDecorativeImg = (item: FlexibleLayoutWidget) =>
+  item.startImageSrc &&
+  (!item.startImageType || item.startImageType === "pseudo-element");
+
 const getDirection = (type: TabType): TabDirection =>
   type === "main" || type === "blockEnd" ? "block" : "inline";
 const isBlockDirection = (direction: TabDirection) => direction === "block";
@@ -747,6 +753,7 @@ export class ChTab implements DraggableView {
   };
 
   #imgRender = (item: FlexibleLayoutWidget) =>
+    item.startImageType === "img" &&
     item.startImageSrc && (
       <img
         aria-hidden="true"
@@ -777,6 +784,8 @@ export class ChTab implements DraggableView {
           aria-selected={(item.id === this.selectedId).toString()}
           class={{
             [this.#classes.BUTTON]: true,
+            "decorative-image": isDecorativeImg(item),
+
             "dragged-element": this.draggedElementIndex === index,
             "dragged-element--outside":
               this.draggedElementIndex === index &&
@@ -799,6 +808,11 @@ export class ChTab implements DraggableView {
             [CAPTION_ID(item.id)]: true,
             [SELECTED_PART]: item.id === this.selectedId
           })}
+          style={
+            isDecorativeImg(item)
+              ? { [DECORATIVE_IMAGE]: `url("${item.startImageSrc}")` }
+              : null
+          }
           onAuxClick={this.#handleClose(index, item.id)}
           onClick={
             !(item.id === this.selectedId)

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -385,7 +385,7 @@ export class ChTab implements DraggableView {
   /**
    * Fired the first time a caption button is dragged outside of its tab list.
    */
-  @Event() itemDragStart: EventEmitter<any>;
+  @Event() itemDragStart: EventEmitter<number>;
 
   /**
    * Returns the info associated to the draggable view.
@@ -539,6 +539,7 @@ export class ChTab implements DraggableView {
     // remove the events on animations frame. Otherwise we would remove the
     // events and in the next frame the mousemove handler will be executes
     requestAnimationFrame(() => {
+      // TODO: UPDATE THIS TO USE SyncWithRAF.cancel()
       document.body.removeEventListener("mousemove", this.#handleItemDrag, {
         capture: true
       });
@@ -638,7 +639,7 @@ export class ChTab implements DraggableView {
         // Remove transition before the render to avoid flickering in the animation
         this.el.style.setProperty(TRANSITION_DURATION, "0s");
 
-        this.itemDragStart.emit();
+        this.itemDragStart.emit(this.draggedElementIndex);
         return;
       }
 

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -237,7 +237,6 @@ export class ChTab implements DraggableView {
    * placed when dragging a caption, to consider that the caption is within the
    * tab list.
    */
-  // eslint-disable-next-line @stencil-community/own-props-must-be-private
   #mouseBoundingLimits: TabElementSize;
 
   #renderedPages: Set<string> = new Set();
@@ -777,7 +776,9 @@ export class ChTab implements DraggableView {
             [this.#classes.BUTTON]: true,
             "dragged-element": this.draggedElementIndex === index,
             "dragged-element--outside":
-              this.draggedElementIndex === index && this.hasCrossedBoundaries,
+              this.draggedElementIndex === index &&
+              this.hasCrossedBoundaries &&
+              this.items.length > 1,
             "shifted-element": this.draggedElementIndex !== -1,
 
             "shifted-element--start":

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -890,13 +890,22 @@ export class ChTab implements DraggableView {
         ref={el => (this.#dragPreviewRef = el)}
       >
         <button
-          class={{ [this.#classes.BUTTON]: true, [DRAG_PREVIEW_ELEMENT]: true }}
+          class={{
+            [this.#classes.BUTTON]: true,
+            [DRAG_PREVIEW_ELEMENT]: true,
+            "decorative-image": isDecorativeImg(draggedElement)
+          }}
           part={tokenMap({
             [this.#parts.BUTTON]: true,
             [CAPTION_ID(draggedElement.id)]: true,
             [DRAG_PREVIEW_ELEMENT]: true,
             [SELECTED_PART]: draggedElement.id === this.selectedId
           })}
+          style={
+            isDecorativeImg(draggedElement)
+              ? { [DECORATIVE_IMAGE]: `url("${draggedElement.startImageSrc}")` }
+              : null
+          }
         >
           {this.#imgRender(draggedElement)}
 

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -389,6 +389,15 @@ export class ChTab implements DraggableView {
   @Event() itemDragStart: EventEmitter<number>;
 
   /**
+   * Ends the preview of the dragged item. Useful for ending the preview via
+   * keyboard interaction.
+   */
+  @Method()
+  async endDragPreview(): Promise<void> {
+    this.#handleDragEnd();
+  }
+
+  /**
    * Returns the info associated to the draggable view.
    */
   @Method()
@@ -405,6 +414,12 @@ export class ChTab implements DraggableView {
    */
   @Method()
   async promoteDragPreviewToTopLayer(): Promise<void> {
+    // If this property is added in a declarative way via the Stencil's render,
+    // we would have to use requestAnimationFrame to delay the shopPopover()
+    // method, since the popover defaults to "auto", which does not allow to
+    // keep multiple "auto" popover open at the same time
+    this.#dragPreviewRef.popover = "manual";
+
     this.#dragPreviewRef.showPopover();
   }
 
@@ -854,7 +869,6 @@ export class ChTab implements DraggableView {
         aria-hidden="true"
         class={classes}
         part={tokenMap(classes)}
-        popover="manual"
         ref={el => (this.#dragPreviewRef = el)}
       >
         <button

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -243,6 +243,7 @@ export class ChTab implements DraggableView {
   #renderedPages: Set<string> = new Set();
 
   // Refs
+  #dragPreviewRef: HTMLDivElement;
   #tabListRef: HTMLDivElement;
   #tabPageRef: HTMLDivElement;
 
@@ -397,6 +398,14 @@ export class ChTab implements DraggableView {
       pageView: this.#tabPageRef,
       tabListView: this.#tabListRef
     };
+  }
+
+  /**
+   * Promotes the drag preview to the top layer. Useful to avoid z-index issues.
+   */
+  @Method()
+  async promoteDragPreviewToTopLayer(): Promise<void> {
+    this.#dragPreviewRef.showPopover();
   }
 
   /**
@@ -841,9 +850,14 @@ export class ChTab implements DraggableView {
     };
 
     return (
-      <div class={classes} part={tokenMap(classes)}>
+      <div
+        aria-hidden="true"
+        class={classes}
+        part={tokenMap(classes)}
+        popover="manual"
+        ref={el => (this.#dragPreviewRef = el)}
+      >
         <button
-          aria-hidden="true"
           class={{ [this.#classes.BUTTON]: true, [DRAG_PREVIEW_ELEMENT]: true }}
           part={tokenMap({
             [this.#parts.BUTTON]: true,

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -415,6 +415,10 @@ export class ChTab implements DraggableView {
    */
   @Method()
   async promoteDragPreviewToTopLayer(): Promise<void> {
+    if (this.draggedElementIndex === -1) {
+      return;
+    }
+
     // If this property is added in a declarative way via the Stencil's render,
     // we would have to use requestAnimationFrame to delay the shopPopover()
     // method, since the popover defaults to "auto", which does not allow to

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -435,12 +435,11 @@ export class ChTab implements DraggableView {
   }
 
   /**
-   * Given an index, remove the item from the tab control
+   * Given an id, remove the page from the render
    */
   @Method()
-  async removeItem(index: number, forceRerender = true) {
-    const removedItem = removeElement(this.items, index);
-    this.#renderedPages.delete(removedItem.id);
+  async removePage(pageId: string, forceRerender = true) {
+    this.#renderedPages.delete(pageId);
 
     if (forceRerender) {
       forceUpdate(this);

--- a/src/components/test/test-flexible-layout/renders.tsx
+++ b/src/components/test/test-flexible-layout/renders.tsx
@@ -42,8 +42,16 @@ export const defaultLayout: FlexibleLayout = {
           viewType: "inlineStart",
           selectedWidgetId: KB_EXPLORER,
           widgets: [
-            { id: KB_EXPLORER, name: "KB Explorer" },
-            { id: PREFERENCES, name: "Preferences" }
+            {
+              id: KB_EXPLORER,
+              name: "KB Explorer",
+              startImageSrc: "assets/icons/toolbar/kb-explorer.svg"
+            },
+            {
+              id: PREFERENCES,
+              name: "Preferences",
+              startImageSrc: "assets/icons/toolbar/preferences.svg"
+            }
           ]
         },
         {
@@ -62,7 +70,13 @@ export const defaultLayout: FlexibleLayout = {
           expanded: true,
           size: "300px",
           viewType: "inlineEnd",
-          widgets: [{ id: PROPERTIES, name: "Properties" }]
+          widgets: [
+            {
+              id: PROPERTIES,
+              name: "Properties",
+              startImageSrc: "assets/icons/toolbar/properties.svg"
+            }
+          ]
         }
       ]
     },
@@ -102,8 +116,16 @@ export const layout2: FlexibleLayout = {
           viewType: "inlineStart",
           selectedWidgetId: KB_EXPLORER,
           widgets: [
-            { id: KB_EXPLORER, name: "KB Explorer" },
-            { id: PREFERENCES, name: "Preferences" }
+            {
+              id: KB_EXPLORER,
+              name: "KB Explorer",
+              startImageSrc: "assets/icons/toolbar/kb-explorer.svg"
+            },
+            {
+              id: PREFERENCES,
+              name: "Preferences",
+              startImageSrc: "assets/icons/toolbar/preferences.svg"
+            }
           ]
         },
         {
@@ -132,7 +154,13 @@ export const layout2: FlexibleLayout = {
           expanded: true,
           size: "300px",
           viewType: "inlineEnd",
-          widgets: [{ id: PROPERTIES, name: "Properties" }]
+          widgets: [
+            {
+              id: PROPERTIES,
+              name: "Properties",
+              startImageSrc: "assets/icons/toolbar/properties.svg"
+            }
+          ]
         }
       ]
     },
@@ -172,8 +200,16 @@ export const layout3: FlexibleLayout = {
           viewType: "inlineStart",
           selectedWidgetId: KB_EXPLORER,
           widgets: [
-            { id: KB_EXPLORER, name: "KB Explorer" },
-            { id: PREFERENCES, name: "Preferences" }
+            {
+              id: KB_EXPLORER,
+              name: "KB Explorer",
+              startImageSrc: "assets/icons/toolbar/kb-explorer.svg"
+            },
+            {
+              id: PREFERENCES,
+              name: "Preferences",
+              startImageSrc: "assets/icons/toolbar/preferences.svg"
+            }
           ]
         },
         {
@@ -226,7 +262,13 @@ export const layout3: FlexibleLayout = {
           expanded: true,
           size: "300px",
           viewType: "inlineEnd",
-          widgets: [{ id: PROPERTIES, name: "Properties" }]
+          widgets: [
+            {
+              id: PROPERTIES,
+              name: "Properties",
+              startImageSrc: "assets/icons/toolbar/properties.svg"
+            }
+          ]
         }
       ]
     }

--- a/src/components/test/test-flexible-layout/renders.tsx
+++ b/src/components/test/test-flexible-layout/renders.tsx
@@ -294,6 +294,7 @@ export const layoutRenders: FlexibleLayoutRenders = {
     <ch-tree-view-render
       treeModel={kbExplorerModel}
       lazyLoadTreeItemsCallback={lazyLoadTreeItems}
+      multiSelection
       showLines="last"
     ></ch-tree-view-render>
   ),
@@ -304,6 +305,7 @@ export const layoutRenders: FlexibleLayoutRenders = {
       dropDisabled={true}
       editableItems={false}
       lazyLoadTreeItemsCallback={lazyLoadTreeItems}
+      multiSelection
       showLines="all"
     ></ch-tree-view-render>
   ),

--- a/src/components/test/test-flexible-layout/renders.tsx
+++ b/src/components/test/test-flexible-layout/renders.tsx
@@ -5,6 +5,7 @@ import {
 } from "../../flexible-layout/types";
 
 import {
+  eagerLargeModel,
   lazyLoadItemsDictionary,
   kbExplorerModel,
   preferencesModel
@@ -15,6 +16,7 @@ import { TreeViewItemModel } from "../../tree-view/tree-view/types";
 const MENU_BAR = "menu-bar";
 const KB_EXPLORER = "kb-explorer";
 const PREFERENCES = "preferences";
+const HEAVY_TREE = "heavy-tree";
 const START_PAGE = "start-page";
 const GRID = "Grid";
 const STRUCT_EDITOR = "StructEditor";
@@ -51,6 +53,11 @@ export const defaultLayout: FlexibleLayout = {
               id: PREFERENCES,
               name: "Preferences",
               startImageSrc: "assets/icons/toolbar/preferences.svg"
+            },
+            {
+              id: HEAVY_TREE,
+              name: "Heavy Tree",
+              startImageSrc: "assets/icons/toolbar/kb-explorer.svg"
             }
           ]
         },
@@ -125,6 +132,11 @@ export const layout2: FlexibleLayout = {
               id: PREFERENCES,
               name: "Preferences",
               startImageSrc: "assets/icons/toolbar/preferences.svg"
+            },
+            {
+              id: HEAVY_TREE,
+              name: "Heavy Tree",
+              startImageSrc: "assets/icons/toolbar/kb-explorer.svg"
             }
           ]
         },
@@ -209,6 +221,11 @@ export const layout3: FlexibleLayout = {
               id: PREFERENCES,
               name: "Preferences",
               startImageSrc: "assets/icons/toolbar/preferences.svg"
+            },
+            {
+              id: HEAVY_TREE,
+              name: "Heavy Tree",
+              startImageSrc: "assets/icons/toolbar/kb-explorer.svg"
             }
           ]
         },
@@ -344,5 +361,15 @@ export const layoutRenders: FlexibleLayoutRenders = {
       Properties render... <input type="text" />
     </div>
   ),
-  [OUTPUT]: () => <div>Output render... </div>
+  [OUTPUT]: () => <div>Output render... </div>,
+  [HEAVY_TREE]: () => (
+    <ch-tree-view-render
+      treeModel={eagerLargeModel}
+      dragDisabled={true}
+      dropDisabled={true}
+      editableItems={false}
+      multiSelection
+      showLines="all"
+    ></ch-tree-view-render>
+  )
 };

--- a/src/components/test/test-flexible-layout/test-flexible-layout.scss
+++ b/src/components/test/test-flexible-layout/test-flexible-layout.scss
@@ -109,6 +109,11 @@ ch-test-flexible-layout {
     background-color: #f7f7f7;
   }
 
+  &::part(block__page-container),
+  &::part(inline__page-container) {
+    overflow: auto;
+  }
+
   // - - - - - - - - - - - - - - - -
   //          Drag preview
   // - - - - - - - - - - - - - - - -

--- a/src/components/test/test-flexible-layout/test-flexible-layout.scss
+++ b/src/components/test/test-flexible-layout/test-flexible-layout.scss
@@ -28,11 +28,10 @@ ch-test-flexible-layout {
     inline-size: 48px;
 
     &::before {
-      content: "";
       display: flex;
       block-size: 100%;
       inline-size: 100%;
-      background-color: currentColor;
+      -webkit-mask-size: 16px;
     }
   }
 
@@ -54,21 +53,6 @@ ch-test-flexible-layout {
     inset-inline-end: 1px;
   }
 
-  &::part(caption-kb-explorer)::before {
-    -webkit-mask: url("assets/icons/toolbar/kb-explorer.svg") 50% 50% / 16px
-      16px no-repeat;
-  }
-
-  &::part(caption-preferences)::before {
-    -webkit-mask: url("assets/icons/toolbar/preferences.svg") 50% 50% / 16px
-      16px no-repeat;
-  }
-
-  &::part(caption-properties)::before {
-    -webkit-mask: url("assets/icons/toolbar/properties.svg") 50% 50% / 16px 16px
-      no-repeat;
-  }
-
   &::part(inline__page-name) {
     display: block;
     padding-block: 8px;
@@ -88,6 +72,11 @@ ch-test-flexible-layout {
     }
   }
 
+  &::part(inline__button):focus-visible {
+    outline: 1px solid currentColor;
+    outline-offset: -1px;
+  }
+
   // Main, BlockEnd
   &::part(block__button) {
     padding-block: 6px;
@@ -103,6 +92,20 @@ ch-test-flexible-layout {
 
   &::part(block__button selected) {
     background-color: #fff;
+  }
+
+  &::part(block__button selected blockEnd) {
+    position: relative;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline: 0;
+      block-size: 1px;
+      background-color: currentColor;
+      z-index: 1;
+    }
   }
 
   &::part(block__tab-list) {

--- a/src/components/tree-view/tree-view/tree-view.tsx
+++ b/src/components/tree-view/tree-view/tree-view.tsx
@@ -334,6 +334,9 @@ export class ChTreeView {
   handleItemDragStart(
     event: ChTreeViewItemCustomEvent<TreeViewItemDragStartInfo>
   ) {
+    // Avoid bubbling as this event can listened in other components (e.g. ch-flexible-layout)
+    event.stopPropagation();
+
     document.body.addEventListener("dragover", this.trackItemDrag, {
       capture: true
     });

--- a/src/components/tree-view/tree-view/tree-view.tsx
+++ b/src/components/tree-view/tree-view/tree-view.tsx
@@ -240,9 +240,22 @@ export class ChTreeView {
     // Reset the validity of the droppable zones with each new drag start
     this.validDroppableZoneCache.clear();
 
-    this.draggingInTheDocument = true;
-    this.dragStartTimestamp = new Date().getTime();
-    this.draggedItems = JSON.parse(event.dataTransfer.getData(TEXT_FORMAT));
+    // If there is no data, the dragstart does not achieve the interface required
+    const data = event.dataTransfer.getData(TEXT_FORMAT);
+    if (data === "") {
+      return;
+    }
+
+    try {
+      // Try to parse the data
+      const paredData = JSON.parse(data);
+
+      this.draggedItems = paredData;
+      this.draggingInTheDocument = true;
+      this.dragStartTimestamp = new Date().getTime();
+    } catch {
+      // Empty
+    }
   }
 
   @Listen("dragend", { capture: true, passive: true, target: "window" })

--- a/src/pages/assets/models/tree.js
+++ b/src/pages/assets/models/tree.js
@@ -15,6 +15,10 @@ const KB_EXPLORER_ORDER = {
   images: 8
 };
 
+const FIRST_LEVEL_SIZE = 10;
+const SECOND_LEVEL_SIZE = 20;
+const THIRD_LEVEL_SIZE = 20;
+
 export const kbExplorerModel = [
   {
     id: "root",
@@ -743,3 +747,44 @@ export const lazyLoadItemsDictionary = {
   Panel: importOBjectsPanelModel,
   "Environment.GeneXusNext": Environment_GeneXusNext_preferencesModel
 };
+
+export const eagerLargeModel = [];
+
+for (let i = 0; i < FIRST_LEVEL_SIZE; i++) {
+  const subEagerLargeModel = [];
+  const modelId = "item-" + i;
+
+  for (let j = 0; j < SECOND_LEVEL_SIZE; j++) {
+    const subModelId = modelId + "-" + j;
+    const subSubEagerLargeModel = [];
+
+    for (let k = 0; k < THIRD_LEVEL_SIZE; k++) {
+      const subSubModelId = subModelId + "-" + k;
+
+      subSubEagerLargeModel.push({
+        id: subSubModelId,
+        caption: subSubModelId,
+        leaf: true,
+        leftImgSrc: "./assets/icons/file.svg"
+      });
+    }
+
+    subEagerLargeModel.push({
+      id: subModelId,
+      caption: subModelId,
+      expanded: true,
+      leaf: false,
+      leftImgSrc: "./assets/icons/knowledge-base.svg",
+      items: subSubEagerLargeModel
+    });
+  }
+
+  eagerLargeModel.push({
+    id: modelId,
+    caption: modelId,
+    expanded: true,
+    leaf: false,
+    leftImgSrc: "assets/icons/patterns.svg",
+    items: subEagerLargeModel
+  });
+}


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fixes:
   - Fixed tab bar collapsing with only one item when dragging it out.

   - Add `"passive: true"` in event handlers.

   - Fix race condition when removing event handlers in `ch-tab`.

   - Better check of for `dataTransfer` format in `ch-tree-view`'s dragstart event.

   - Avoid `itemDragStart` bubbling in `ch-tree-view`.
     Avoid bubbling as this event can listened in other components (e.g. `ch-flexible-layout`).

 - Features:
   - Add support to promote the drag preview to the top layer in `ch-tab`.

   - Add support to show droppable areas in `ch-flexible-layout`.

   - Add support to disable resize in `ch-layout-splitter`.

   - Improved UX when dragging a widget.

   - Add support for rendering other image types in `ch-layout-splitter` and `ch-tab`.

   - Add support for preserving or removing the item state on close event in `ch-layout-splitter`.

   - Initial version of reordering items with drag and drop in `ch-layout-splitter`.

   - Initial support for removing a view in `ch-layout-splitter`.
