### PR TITLE
Add new ESLint rules to improve code consistency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
       "always",
       { enforceForIfStatements: true }
     ], // This rule checks for expressions that can be shortened using logical assignment operator
+    "dot-notation": "warn", // This rule is aimed at maintaining code consistency and improving code readability by encouraging use of the dot notation style whenever possible. As such, it will warn when it encounters an unnecessary use of square-bracket notation.
     "max-depth": ["warn", 3], // Enforce a maximum depth that blocks can be nested. Many developers consider code difficult to read if blocks are nested beyond a certain depth
     "no-alert": "error", // Disallow the use of alert, confirm, and prompt
     "no-console": "warn", // Warning when using console.log, console.warn or console.error

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     "no-alert": "error", // Disallow the use of alert, confirm, and prompt
     "no-console": "warn", // Warning when using console.log, console.warn or console.error
     "no-else-return": ["warn", { allowElseIf: false }], // Disallow else blocks after return statements in if statements
+    "no-extra-boolean-cast": "error", // Disallow unnecessary boolean casts
     "no-debugger": "error", // Error when using debugger;
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements
     "no-empty": "error", // Disallow empty block statements

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     "max-depth": ["warn", 3], // Enforce a maximum depth that blocks can be nested. Many developers consider code difficult to read if blocks are nested beyond a certain depth
     "no-alert": "error", // Disallow the use of alert, confirm, and prompt
     "no-console": "warn", // Warning when using console.log, console.warn or console.error
+    "no-else-return": ["warn", { allowElseIf: false }], // Disallow else blocks after return statements in if statements
     "no-debugger": "error", // Error when using debugger;
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements
     "no-empty": "error", // Disallow empty block statements

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements
     "no-empty": "error", // Disallow empty block statements
     "no-lonely-if": "warn", // Disallow if statements as the only statement in else blocks
+    "no-multi-assign": "error", // Disallow use of chained assignment expressions
     "no-nested-ternary": "warn", // Warns the use of nested ternary expressions
     "no-sequences": "error", // Disallow comma operators
     "no-undef": "off", // Allows defining undefined variables

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,11 @@ module.exports = {
     camelcase: "warn", // Enforce camelcase naming convention
     curly: "error", // Enforce consistent brace style for all control statements
     eqeqeq: ["warn", "always", { null: "ignore" }], // Require the use of === and !==   "ignore" -------> Do not apply this rule to null
+    "logical-assignment-operators": [
+      "warn",
+      "always",
+      { enforceForIfStatements: true }
+    ], // This rule checks for expressions that can be shortened using logical assignment operator
     "max-depth": ["warn", 3], // Enforce a maximum depth that blocks can be nested. Many developers consider code difficult to read if blocks are nested beyond a certain depth
     "no-alert": "error", // Disallow the use of alert, confirm, and prompt
     "no-console": "warn", // Warning when using console.log, console.warn or console.error

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     "no-sequences": "error", // Disallow comma operators
     "no-undef": "off", // Allows defining undefined variables
     "no-unneeded-ternary": "warn", // Disallow ternary operators when simpler alternatives exist
+    "no-useless-return": "error", // Disallow redundant return statements
     "spaced-comment": ["error", "always", { exceptions: ["-", "+", "/"] }], // Enforce consistent spacing after the // or /* in a comment
 
     // - - - - - - - - - - - -

--- a/src/components/gx-grid/gx-grid-chameleon-state.ts
+++ b/src/components/gx-grid/gx-grid-chameleon-state.ts
@@ -11,7 +11,7 @@ export class GridChameleonManagerState {
   static load(grid: GxGrid, state: GridChameleonState) {
     this.grid = grid;
     this.state = state ?? {};
-    this.state.Columns = this.state.Columns ?? [];
+    this.state.Columns ??= [];
 
     this.loadLocal();
     this.apply();
@@ -150,9 +150,7 @@ export class GridChameleonManagerState {
   private static getColumnFilter(name: string): GridChameleonStateColumnFilter {
     const column = this.getColumn(name);
 
-    if (!column.Filter) {
-      column.Filter = {};
-    }
+    column.Filter ||= {};
 
     return column.Filter;
   }

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -12,7 +12,7 @@ export class ChIcon {
 
   @Element() element: HTMLChIconElement;
 
-  /*********************************
+  /** *******************************
   PROPERTIES & STATE
   *********************************/
   /**
@@ -44,7 +44,7 @@ export class ChIcon {
 
   @State() private svgContent?: string;
 
-  /*********************************
+  /** *******************************
   METHODS
   *********************************/
 
@@ -75,6 +75,8 @@ export class ChIcon {
       typeof window !== "undefined" &&
       (window as any).IntersectionObserver
     ) {
+      // TODO: FIX THIS
+      // eslint-disable-next-line no-multi-assign
       const io = (this.io = new (window as any).IntersectionObserver(
         (data: IntersectionObserverEntry[]) => {
           if (data[0].isIntersecting) {

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -107,7 +107,6 @@ export class ChIcon {
         }
       } else {
         this.svgContent = "";
-        return;
       }
     }
   }

--- a/src/components/next/data-modeling-render/next-data-modeling-render.tsx
+++ b/src/components/next/data-modeling-render/next-data-modeling-render.tsx
@@ -352,8 +352,6 @@ export class NextDataModeling implements ChComponent {
       );
 
       this.entityWasAdded = "none";
-
-      return;
     }
   }
 

--- a/src/components/renders/tree-view/genexus-implementation.ts
+++ b/src/components/renders/tree-view/genexus-implementation.ts
@@ -60,9 +60,7 @@ function getImage(
   name: string,
   gxImageConstructor: (name: string) => any
 ): any {
-  if (!computedStyle) {
-    computedStyle = getComputedStyle(document.documentElement);
-  }
+  computedStyle ||= getComputedStyle(document.documentElement);
 
   let value = computedStyle.getPropertyValue(`--gx-image_${name}`);
 


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Added the following ESLint rules:
   - `"logical-assignment-operators"` (warn): This rule checks for expressions that can be shortened using logical assignment operator
   https://eslint.org/docs/latest/rules/logical-assignment-operators

   - `"dot-notation"` (warn): This rule is aimed at maintaining code consistency and improving code readability by encouraging use of the dot notation style whenever possible. As such, it will warn when it encounters an unnecessary use of square-bracket notation.
   https://eslint.org/docs/latest/rules/dot-notation

   - `"no-else-return"` (warn): Disallow else blocks after return statements in if statements
    https://eslint.org/docs/latest/rules/no-else-return

   - `"no-extra-boolean-cast"` (error): Disallow unnecessary boolean casts
    https://eslint.org/docs/latest/rules/no-extra-boolean-cast

   - `"no-multi-assign"` (error): Disallow use of chained assignment expressions
    https://eslint.org/docs/latest/rules/no-multi-assign

   - `"no-useless-return"` (error): Disallow redundant return statements
    https://eslint.org/docs/latest/rules/no-useless-return