### PR TITLE
Fixes and improvements for barcode scanner

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -218,40 +218,33 @@ export namespace Components {
      */
     interface ChBarcodeScanner {
         /**
+          * The height (in pixels) of the QR box displayed at the center of the video.
+         */
+        "barcodeBoxHeight": number;
+        /**
+          * The width (in pixels) of the QR box displayed at the center of the video.
+         */
+        "barcodeBoxWidth": number;
+        /**
           * Specifies the ID of the selected camera. Only works if `cameraPreference === "SelectedById"`.
          */
         "cameraId"?: string;
         /**
           * Specifies the camera preference for scanning.
          */
-        "cameraPreference": | "Default"
-    | "FrontCamera"
-    | "BackCamera"
-    | "SelectedById";
+        "cameraPreference": "Default" | "FrontCamera" | "BackCamera";
         /**
           * Specifies how much time (in ms) should pass before to emit the read event with the same last decoded text. If the last decoded text is different from the new decoded text, this property is ignored.
          */
-        "intervalBetweenReadsForTheSameDecode": number;
-        /**
-          * The height (in pixels) of the QR box displayed at the center of the video.
-         */
-        "qrBoxHeight": number;
-        /**
-          * The width (in pixels) of the QR box displayed at the center of the video.
-         */
-        "qrBoxWidth": number;
+        "readDebounce": number;
         /**
           * Scan a file a return a promise with the decoded text.
          */
         "scan": (imageFile: File) => Promise<string>;
         /**
-          * @todo Add support
+          * `true` if the control is scanning.
          */
-        "scanMode": "camera" | "file";
-        /**
-          * `true` if the control should stop the scanning.
-         */
-        "stopped": boolean;
+        "scanning": boolean;
     }
     interface ChCheckbox {
         /**
@@ -2436,8 +2429,8 @@ declare global {
         new (): HTMLChAlertElement;
     };
     interface HTMLChBarcodeScannerElementEventMap {
-        "read": string;
         "cameras": string[];
+        "read": string;
     }
     /**
      * This component allows you to scan a wide variety of types of barcode and QR
@@ -3643,44 +3636,37 @@ declare namespace LocalJSX {
      */
     interface ChBarcodeScanner {
         /**
+          * The height (in pixels) of the QR box displayed at the center of the video.
+         */
+        "barcodeBoxHeight"?: number;
+        /**
+          * The width (in pixels) of the QR box displayed at the center of the video.
+         */
+        "barcodeBoxWidth"?: number;
+        /**
           * Specifies the ID of the selected camera. Only works if `cameraPreference === "SelectedById"`.
          */
         "cameraId"?: string;
         /**
           * Specifies the camera preference for scanning.
          */
-        "cameraPreference"?: | "Default"
-    | "FrontCamera"
-    | "BackCamera"
-    | "SelectedById";
-        /**
-          * Specifies how much time (in ms) should pass before to emit the read event with the same last decoded text. If the last decoded text is different from the new decoded text, this property is ignored.
-         */
-        "intervalBetweenReadsForTheSameDecode"?: number;
+        "cameraPreference"?: "Default" | "FrontCamera" | "BackCamera";
         /**
           * Fired when the control is first rendered. Contains the ids about all available cameras.
          */
         "onCameras"?: (event: ChBarcodeScannerCustomEvent<string[]>) => void;
         /**
-          * Fired when the menu action is activated.
+          * Fired when a new barcode is decoded.
          */
         "onRead"?: (event: ChBarcodeScannerCustomEvent<string>) => void;
         /**
-          * The height (in pixels) of the QR box displayed at the center of the video.
+          * Specifies how much time (in ms) should pass before to emit the read event with the same last decoded text. If the last decoded text is different from the new decoded text, this property is ignored.
          */
-        "qrBoxHeight"?: number;
+        "readDebounce"?: number;
         /**
-          * The width (in pixels) of the QR box displayed at the center of the video.
+          * `true` if the control is scanning.
          */
-        "qrBoxWidth"?: number;
-        /**
-          * @todo Add support
-         */
-        "scanMode"?: "camera" | "file";
-        /**
-          * `true` if the control should stop the scanning.
-         */
-        "stopped"?: boolean;
+        "scanning"?: boolean;
     }
     interface ChCheckbox {
         /**

--- a/src/components/barcode-scanner/readme.md
+++ b/src/components/barcode-scanner/readme.md
@@ -2,6 +2,7 @@
 
 <!-- Auto Generated Below -->
 
+
 ## Overview
 
 This component allows you to scan a wide variety of types of barcode and QR
@@ -9,22 +10,23 @@ codes.
 
 ## Properties
 
-| Property                               | Attribute                                    | Description                                                                                                                                                                                           | Type                                                           | Default     |
-| -------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ----------- |
-| `cameraId`                             | `camera-id`                                  | Specifies the ID of the selected camera. Only works if `cameraPreference === "SelectedById"`.                                                                                                         | `string`                                                       | `undefined` |
-| `cameraPreference`                     | `camera-preference`                          | Specifies the camera preference for scanning.                                                                                                                                                         | `"BackCamera" \| "Default" \| "FrontCamera" \| "SelectedById"` | `"Default"` |
-| `intervalBetweenReadsForTheSameDecode` | `interval-between-reads-for-the-same-decode` | Specifies how much time (in ms) should pass before to emit the read event with the same last decoded text. If the last decoded text is different from the new decoded text, this property is ignored. | `number`                                                       | `200`       |
-| `qrBoxHeight`                          | `qr-box-height`                              | The height (in pixels) of the QR box displayed at the center of the video.                                                                                                                            | `number`                                                       | `200`       |
-| `qrBoxWidth`                           | `qr-box-width`                               | The width (in pixels) of the QR box displayed at the center of the video.                                                                                                                             | `number`                                                       | `200`       |
-| `scanMode`                             | `scan-mode`                                  |                                                                                                                                                                                                       | `"camera" \| "file"`                                           | `"camera"`  |
-| `stopped`                              | `stopped`                                    | `true` if the control should stop the scanning.                                                                                                                                                       | `boolean`                                                      | `undefined` |
+| Property           | Attribute            | Description                                                                                                                                                                                           | Type                                         | Default     |
+| ------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ----------- |
+| `barcodeBoxHeight` | `barcode-box-height` | The height (in pixels) of the QR box displayed at the center of the video.                                                                                                                            | `number`                                     | `200`       |
+| `barcodeBoxWidth`  | `barcode-box-width`  | The width (in pixels) of the QR box displayed at the center of the video.                                                                                                                             | `number`                                     | `200`       |
+| `cameraId`         | `camera-id`          | Specifies the ID of the selected camera. Only works if `cameraPreference === "SelectedById"`.                                                                                                         | `string`                                     | `undefined` |
+| `cameraPreference` | `camera-preference`  | Specifies the camera preference for scanning.                                                                                                                                                         | `"BackCamera" \| "Default" \| "FrontCamera"` | `"Default"` |
+| `readDebounce`     | `read-debounce`      | Specifies how much time (in ms) should pass before to emit the read event with the same last decoded text. If the last decoded text is different from the new decoded text, this property is ignored. | `number`                                     | `200`       |
+| `scanning`         | `scanning`           | `true` if the control is scanning.                                                                                                                                                                    | `boolean`                                    | `true`      |
+
 
 ## Events
 
 | Event     | Description                                                                             | Type                    |
 | --------- | --------------------------------------------------------------------------------------- | ----------------------- |
 | `cameras` | Fired when the control is first rendered. Contains the ids about all available cameras. | `CustomEvent<string[]>` |
-| `read`    | Fired when the menu action is activated.                                                | `CustomEvent<string>`   |
+| `read`    | Fired when a new barcode is decoded.                                                    | `CustomEvent<string>`   |
+
 
 ## Methods
 
@@ -42,7 +44,9 @@ Scan a file a return a promise with the decoded text.
 
 Type: `Promise<string>`
 
----
 
-_Built with [StencilJS](https://stenciljs.com/)_
 
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Rename `barcodeBoxWidth` -> `qrBoxWidth`.
 - Rename `barcodeBoxHeight` -> `qrBoxHeight`.
 - Rename `intervalBetweenReadsForTheSameDecode` -> `readDebounce`.
 - Replace `stopped` property with the `scanning` property.

 - Removed `SelectedById` value for the `cameraPreference` property.
 - Removed `cameras` event.