### PR TITLE
Fixes and improvements for the `ch-layout-splitter` control

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ To run the unit tests for the custom elements, run:
 npm test
 ```
 
+To run the spec tests for a specific custom elements, run:
+
+```bash
+npm run test.spec <component-name-without-prefix>
+```
+
+For example:
+
+```bash
+npm run test.spec layout-splitter
+```
+
 ## Building for production
 
 To build the design for production, run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "jest-cli": "~29.7.0",
         "lint-staged": "~13.0.0",
         "prettier": "~2.7.0",
-        "puppeteer": "~15.2.0",
+        "puppeteer": "~22.1.0",
         "typescript": "~5.2.0"
       }
     },
@@ -1325,6 +1325,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.0.1.tgz",
+      "integrity": "sha512-IQj/rJY1MNfZ6Z2ERu+6S0LkIPBSXRGddgmvODqjm1afHy04aJIiWmoohuFtL78SPSlbjpIMuFVfhyqsR5Ng4A==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.4.0",
+        "tar-fs": "3.0.5",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1393,6 +1414,12 @@
       "peerDependencies": {
         "@stencil/core": ">=2.0.0 || >=3.0.0-beta.0 || >= 4.0.0-beta.0 || >= 4.0.0"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1796,15 +1823,15 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dev": true,
       "dependencies": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/aggregate-error": {
@@ -2021,6 +2048,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2050,6 +2089,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2173,6 +2218,43 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bare-events": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.0.tgz",
+      "integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.1.5.tgz",
+      "integrity": "sha512-5t0nlecX+N2uJqdxe9d18A98cp2u9BETelbjKpiVgQqzzmVNFYWEAjQHqS+2Khgto1vcwhik9cXucaj5ve2WWA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-os": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "streamx": "^2.13.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.0.tgz",
+      "integrity": "sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.0.tgz",
+      "integrity": "sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2193,15 +2275,13 @@
         }
       ]
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+    "node_modules/basic-ftp": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
       "dev": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2405,11 +2485,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+    "node_modules/chromium-bidi": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.9.tgz",
+      "integrity": "sha512-wOTX3m2zuHX0zRX4h7Ol1DAGz0cqHzo2IrAPvOqBxdd4ZR32vxg4FKNjmBihi1oP9b1QGSBBG5VNUUXUCsxDfg==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -2582,6 +2669,32 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2604,12 +2717,12 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dev": true,
       "dependencies": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -2624,6 +2737,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/debug": {
@@ -2717,6 +2839,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2747,9 +2883,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1011705",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz",
-      "integrity": "sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q==",
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
       "dev": true
     },
     "node_modules/diff-sequences": {
@@ -2833,6 +2969,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -3005,6 +3150,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -3418,6 +3584,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -3554,11 +3726,19 @@
         "is-callable": "^1.1.3"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3689,6 +3869,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "dev": true,
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.2.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -3992,17 +4187,30 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -4140,6 +4348,25 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
@@ -5177,6 +5404,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5223,6 +5456,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -6472,10 +6717,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true
     },
     "node_modules/ms": {
@@ -6489,10 +6734,19 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -6741,6 +6995,38 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "pac-resolver": "^7.0.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/parent-module": {
@@ -7045,6 +7331,34 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.3",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -7071,28 +7385,38 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.2.0.tgz",
-      "integrity": "sha512-6Mzj5pbq4J4DxJE5o6V+arrOB9Gma0CxOLP1zKYMrMR7AYuNaPzsK7pBrpDwI64W6Mxk5G7NqiLSFTrgSzR1zg==",
-      "deprecated": "< 21.5.0 is no longer supported",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.1.0.tgz",
+      "integrity": "sha512-suatHy6A48YkoykjrJNkJaixWVrvnPtzIgngK17V/P0MvgSyJzuu21PyR+0lWIK0cfZqKqmR8CHZvHzOCd4MIg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1011705",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "pkg-dir": "4.2.0",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.8.0"
+        "@puppeteer/browsers": "2.0.1",
+        "cosmiconfig": "9.0.0",
+        "puppeteer-core": "22.1.0"
+      },
+      "bin": {
+        "puppeteer": "lib/esm/puppeteer/node/cli.js"
       },
       "engines": {
-        "node": ">=14.1.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.1.0.tgz",
+      "integrity": "sha512-LdsQxslPf0Rpk6gLvkyyrraad2S4PUjGCT2CAKS2EnrRPpzIb6fsrFnoPNZxLlMkU7apU1g4Nf5wYePdSjxLkQ==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "2.0.1",
+        "chromium-bidi": "0.5.9",
+        "cross-fetch": "4.0.0",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pure-rand": {
@@ -7136,25 +7460,17 @@
         }
       ]
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.5",
@@ -7359,26 +7675,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -7548,6 +7844,44 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+      "integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
+      "dev": true,
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7611,13 +7945,17 @@
         "@stencil/core": ">=1.9.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+    "node_modules/streamx": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.0.tgz",
+      "integrity": "sha512-a7Fi0PoUeusrUcMS4+HxivnZqYsw2MFEP841TIyLxTcEIucHcJsk+0ARcq3tGq1xDn+xK7sKHetvfMzI1/CzMA==",
       "dev": true,
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -7818,31 +8156,28 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
+      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
       "dev": true,
       "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
       }
     },
     "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
       "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/test-exclude": {
@@ -8170,6 +8505,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -8209,10 +8553,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
@@ -8460,16 +8804,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jest-cli": "~29.7.0",
     "lint-staged": "~13.0.0",
     "prettier": "~2.7.0",
-    "puppeteer": "~15.2.0",
+    "puppeteer": "~22.1.0",
     "typescript": "~5.2.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint src/**/*{.ts,.tsx} --fix",
     "start": "stencil build --dev --watch --serve --docs",
     "test": "stencil test --spec --e2e",
+    "test.coverage": "stencil test --spec --e2e --coverage --no-cache",
     "test.watch": "stencil test --spec --e2e --watchAll",
     "validate": "npm run lint && npm run test && npm run build",
     "validate.ci": "npm run lint && npm run build -- --max-workers 1 --debug"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start": "stencil build --dev --watch --serve --docs",
     "test": "stencil test --spec --e2e",
     "test.coverage": "stencil test --spec --e2e --coverage --no-cache",
+    "test.spec": "stencil test --spec --coverage --no-cache",
     "test.watch": "stencil test --spec --e2e --watchAll",
     "validate": "npm run lint && npm run test && npm run build",
     "validate.ci": "npm run lint && npm run build -- --max-workers 1 --debug"

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -69,7 +69,13 @@ export const tokenMap = (tokens: { [key: string]: boolean }) =>
  */
 export const inBetween = (x: number, y: number, z: number) => x <= y && y <= z;
 
-const resetDragImage = new Image();
+let resetDragImage;
+
+/* @__PURE__ */ if (!window.Image) {
+  resetDragImage = "test";
+}
+
+resetDragImage ??= new Image();
 export const removeDragImage = (event: DragEvent) =>
   event.dataTransfer.setDragImage(resetDragImage, 0, 0);
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -29,6 +29,8 @@ export function debounce(
 
 export const isRTL = () => document.documentElement.dir === "rtl";
 
+export const ROOT_VIEW: null = null;
+
 /*  This functions overrides a method adding calls before (`before()`) and
     after (`after()`) 
 */

--- a/src/components/layout-splitter/layout-splitter.tsx
+++ b/src/components/layout-splitter/layout-splitter.tsx
@@ -11,11 +11,11 @@ import { Component as ChComponent } from "../../common/interfaces";
 import {
   DragBarMouseDownEventInfo,
   GroupExtended,
+  ItemExtended,
   LayoutSplitterDirection,
   LayoutSplitterDistribution,
   LayoutSplitterDistributionGroup,
   LayoutSplitterDistributionItem,
-  LayoutSplitterDistributionItemExtended,
   LayoutSplitterDistributionLeaf,
   LayoutSplitterItemAddResult,
   LayoutSplitterItemRemoveResult
@@ -41,10 +41,7 @@ const DIRECTION_CLASS = (direction: LayoutSplitterDirection) =>
 
 const TEMPLATE_STYLE = (
   items: LayoutSplitterDistributionItem[],
-  itemsInfo: Map<
-    string,
-    LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>
-  >,
+  itemsInfo: Map<string, ItemExtended>,
   fixedSizesSum: number
 ) => ({
   [GRID_TEMPLATE_DIRECTION_CUSTOM_VAR]: sizesToGridTemplate(
@@ -85,10 +82,7 @@ export class ChLayoutSplitter implements ChComponent {
   #fixedSizesSumRoot: number;
 
   // Distribution of elements
-  #itemsInfo: Map<
-    string,
-    LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>
-  > = new Map();
+  #itemsInfo: Map<string, ItemExtended> = new Map();
 
   @Element() el: HTMLChLayoutSplitterElement;
 
@@ -369,11 +363,7 @@ export class ChLayoutSplitter implements ChComponent {
           style={TEMPLATE_STYLE(
             (item as LayoutSplitterDistributionGroup).items,
             this.#itemsInfo,
-            (
-              this.#itemsInfo.get(
-                item.id
-              ) as LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionGroup>
-            ).fixedSizesSum
+            (this.#itemsInfo.get(item.id) as GroupExtended).fixedSizesSum
           )}
         >
           {this.#renderItems(

--- a/src/components/layout-splitter/layout-splitter.tsx
+++ b/src/components/layout-splitter/layout-splitter.tsx
@@ -338,10 +338,16 @@ export class ChLayoutSplitter implements ChComponent {
       );
     };
 
-  #renderItems = (direction: LayoutSplitterDirection, layoutItems: Item[]) => {
-    const lastComponentIndex = layoutItems.length - 1;
+  #renderItem = (
+    direction: LayoutSplitterDirection,
+    lastComponentIndex: number,
+    layoutItems: Item[],
+    item: Item,
+    index: number
+  ) => {
+    const itemInfo = this.#itemsInfo.get(item.id);
 
-    return layoutItems.map((item, index) => [
+    return [
       (item as Group).items ? (
         <div
           id={item.id}
@@ -350,10 +356,14 @@ export class ChLayoutSplitter implements ChComponent {
           style={TEMPLATE_STYLE(
             (item as Group).items,
             this.#itemsInfo,
-            (this.#itemsInfo.get(item.id) as GroupExtended).fixedSizesSum
+            (itemInfo as GroupExtended).fixedSizesSum
           )}
         >
-          {this.#renderItems((item as Group).direction, (item as Group).items)}
+          {this.#renderItems(
+            (item as Group).direction,
+            (item as Group).items,
+            (item as Group).items.length - 1
+          )}
         </div>
       ) : (
         <div id={item.id} class="leaf">
@@ -390,8 +400,17 @@ export class ChLayoutSplitter implements ChComponent {
           }
         ></div>
       )
-    ]);
+    ];
   };
+
+  #renderItems = (
+    direction: LayoutSplitterDirection,
+    layoutItems: Item[],
+    lastComponentIndex: number
+  ) =>
+    layoutItems.map((item, index) =>
+      this.#renderItem(direction, lastComponentIndex, layoutItems, item, index)
+    );
 
   private updateLayoutInfo(layout: LayoutSplitterDistribution) {
     // Clear old information
@@ -432,7 +451,11 @@ export class ChLayoutSplitter implements ChComponent {
           this.#fixedSizesSumRoot
         )}
       >
-        {this.#renderItems(layoutModel.direction, layoutModel.items)}
+        {this.#renderItems(
+          layoutModel.direction,
+          layoutModel.items,
+          layoutModel.items.length - 1
+        )}
       </div>
     );
   }

--- a/src/components/layout-splitter/layout-splitter.tsx
+++ b/src/components/layout-splitter/layout-splitter.tsx
@@ -24,6 +24,7 @@ import {
   FIXED_SIZES_SUM_CUSTOM_VAR,
   fixAndUpdateLayoutModel,
   getMousePosition,
+  hasMinSize,
   sizesToGridTemplate,
   updateComponentsAndDragBar
 } from "./utils";
@@ -263,7 +264,7 @@ export class ChLayoutSplitter implements ChComponent {
           ? dragBarContainer.clientWidth
           : dragBarContainer.clientHeight,
       direction: direction,
-      dragBarContainer: dragBar,
+      dragBar: dragBar,
       fixedSizesSumRoot: this.#fixedSizesSumRoot,
       itemStartId: layoutItems[index].id,
       itemEndId: layoutItems[index + 1].id,
@@ -368,7 +369,7 @@ export class ChLayoutSplitter implements ChComponent {
           )}
         </div>
       ) : (
-        <div id={item.id} class="leaf">
+        <div id={item.id} class={!hasMinSize(item) ? "leaf" : undefined}>
           <slot key={item.id} name={item.id} />
         </div>
       ),

--- a/src/components/layout-splitter/layout-splitter.tsx
+++ b/src/components/layout-splitter/layout-splitter.tsx
@@ -27,9 +27,8 @@ import {
   sizesToGridTemplate,
   updateComponentsAndDragBar
 } from "./utils";
-import { isRTL } from "../../common/utils";
+import { ROOT_VIEW, isRTL } from "../../common/utils";
 import { NO_FIXED_SIZES_TO_UPDATE, removeItem } from "./remove-item";
-import { ROOT_VIEW } from "../renders/flexible-layout/utils";
 import { addSiblingLeaf } from "./add-sibling-item";
 import { SyncWithRAF } from "../../common/sync-with-frames";
 

--- a/src/components/layout-splitter/layout-splitter.tsx
+++ b/src/components/layout-splitter/layout-splitter.tsx
@@ -32,7 +32,6 @@ import { NO_FIXED_SIZES_TO_UPDATE, removeItem } from "./remove-item";
 import { addSiblingLeaf } from "./add-sibling-item";
 import { SyncWithRAF } from "../../common/sync-with-frames";
 
-type Leaf = LayoutSplitterDistributionLeaf;
 type Group = LayoutSplitterDistributionGroup;
 type Item = LayoutSplitterDistributionItem;
 
@@ -135,7 +134,7 @@ export class ChLayoutSplitter implements ChComponent {
     parentGroup: string,
     siblingItem: string,
     placedInTheSibling: "before" | "after",
-    leafInfo: Leaf,
+    leafInfo: LayoutSplitterDistributionLeaf,
     takeHalfTheSpaceOfTheSiblingItem: boolean
   ): Promise<LayoutSplitterItemAddResult> {
     const result = addSiblingLeaf(

--- a/src/components/layout-splitter/layout-splitter.tsx
+++ b/src/components/layout-splitter/layout-splitter.tsx
@@ -253,7 +253,8 @@ export class ChLayoutSplitter implements ChComponent {
     event: Event
   ) => {
     // Initialize the values needed for drag processing
-    const dragBarContainer = (event.target as HTMLElement).parentElement;
+    const dragBar = event.target as HTMLElement;
+    const dragBarContainer = dragBar.parentElement;
 
     this.#mouseDownInfo = {
       container: dragBarContainer,
@@ -262,6 +263,7 @@ export class ChLayoutSplitter implements ChComponent {
           ? dragBarContainer.clientWidth
           : dragBarContainer.clientHeight,
       direction: direction,
+      dragBarContainer: dragBar,
       fixedSizesSumRoot: this.#fixedSizesSumRoot,
       itemStartId: layoutItems[index].id,
       itemEndId: layoutItems[index + 1].id,
@@ -345,7 +347,7 @@ export class ChLayoutSplitter implements ChComponent {
     item: Item,
     index: number
   ) => {
-    const itemInfo = this.#itemsInfo.get(item.id);
+    const itemUIModel = this.#itemsInfo.get(item.id);
 
     return [
       (item as Group).items ? (
@@ -356,7 +358,7 @@ export class ChLayoutSplitter implements ChComponent {
           style={TEMPLATE_STYLE(
             (item as Group).items,
             this.#itemsInfo,
-            (itemInfo as GroupExtended).fixedSizesSum
+            (itemUIModel as GroupExtended).fixedSizesSum
           )}
         >
           {this.#renderItems(
@@ -379,6 +381,7 @@ export class ChLayoutSplitter implements ChComponent {
           aria-disabled={this.dragBarDisabled ? "true" : null}
           aria-label={this.barAccessibleName}
           aria-orientation={direction === "columns" ? "vertical" : "horizontal"}
+          aria-valuetext={itemUIModel.actualSize}
           title={this.barAccessibleName}
           tabindex="0"
           // - - - - - - - - - - - - -

--- a/src/components/layout-splitter/layout-splitter.tsx
+++ b/src/components/layout-splitter/layout-splitter.tsx
@@ -32,6 +32,10 @@ import { NO_FIXED_SIZES_TO_UPDATE, removeItem } from "./remove-item";
 import { addSiblingLeaf } from "./add-sibling-item";
 import { SyncWithRAF } from "../../common/sync-with-frames";
 
+type Leaf = LayoutSplitterDistributionLeaf;
+type Group = LayoutSplitterDistributionGroup;
+type Item = LayoutSplitterDistributionItem;
+
 const RESIZING_CLASS = "gx-layout-splitter--resizing";
 const GRID_TEMPLATE_DIRECTION_CUSTOM_VAR = "--ch-layout-splitter__distribution";
 
@@ -39,7 +43,7 @@ const DIRECTION_CLASS = (direction: LayoutSplitterDirection) =>
   `group direction--${direction}`;
 
 const TEMPLATE_STYLE = (
-  items: LayoutSplitterDistributionItem[],
+  items: Item[],
   itemsInfo: Map<string, ItemExtended>,
   fixedSizesSum: number
 ) => ({
@@ -51,10 +55,8 @@ const TEMPLATE_STYLE = (
   [FIXED_SIZES_SUM_CUSTOM_VAR]: `${fixedSizesSum}px`
 });
 
-const getAriaControls = (
-  layoutItems: LayoutSplitterDistributionItem[],
-  index: number
-) => `${layoutItems[index].id} ${layoutItems[index + 1].id}`;
+const getAriaControls = (layoutItems: Item[], index: number) =>
+  `${layoutItems[index].id} ${layoutItems[index + 1].id}`;
 
 // Key codes
 const ARROW_UP = "ArrowUp";
@@ -133,7 +135,7 @@ export class ChLayoutSplitter implements ChComponent {
     parentGroup: string,
     siblingItem: string,
     placedInTheSibling: "before" | "after",
-    leafInfo: LayoutSplitterDistributionLeaf,
+    leafInfo: Leaf,
     takeHalfTheSpaceOfTheSiblingItem: boolean
   ): Promise<LayoutSplitterItemAddResult> {
     const result = addSiblingLeaf(
@@ -248,7 +250,7 @@ export class ChLayoutSplitter implements ChComponent {
   #initializeDragBarValuesForResizeProcessing = (
     direction: LayoutSplitterDirection,
     index: number,
-    layoutItems: LayoutSplitterDistributionItem[],
+    layoutItems: Item[],
     event: Event
   ) => {
     // Initialize the values needed for drag processing
@@ -273,11 +275,7 @@ export class ChLayoutSplitter implements ChComponent {
   };
 
   #mouseDownHandler =
-    (
-      direction: LayoutSplitterDirection,
-      index: number,
-      layoutItems: LayoutSplitterDistributionItem[]
-    ) =>
+    (direction: LayoutSplitterDirection, index: number, layoutItems: Item[]) =>
     (event: MouseEvent) => {
       // Necessary to prevent selecting the inner image (or other elements) of
       // the bar item when the mouse is down
@@ -308,11 +306,7 @@ export class ChLayoutSplitter implements ChComponent {
     };
 
   #handleResize =
-    (
-      direction: LayoutSplitterDirection,
-      index: number,
-      layoutItems: LayoutSplitterDistributionItem[]
-    ) =>
+    (direction: LayoutSplitterDirection, index: number, layoutItems: Item[]) =>
     (event: KeyboardEvent) => {
       if (
         (direction === "rows" &&
@@ -345,30 +339,22 @@ export class ChLayoutSplitter implements ChComponent {
       );
     };
 
-  #renderItems = (
-    direction: LayoutSplitterDirection,
-    layoutItems: LayoutSplitterDistributionItem[]
-  ) => {
+  #renderItems = (direction: LayoutSplitterDirection, layoutItems: Item[]) => {
     const lastComponentIndex = layoutItems.length - 1;
 
     return layoutItems.map((item, index) => [
-      (item as LayoutSplitterDistributionGroup).items ? (
+      (item as Group).items ? (
         <div
           id={item.id}
-          class={DIRECTION_CLASS(
-            (item as LayoutSplitterDistributionGroup).direction
-          )}
+          class={DIRECTION_CLASS((item as Group).direction)}
           part={item.id}
           style={TEMPLATE_STYLE(
-            (item as LayoutSplitterDistributionGroup).items,
+            (item as Group).items,
             this.#itemsInfo,
             (this.#itemsInfo.get(item.id) as GroupExtended).fixedSizesSum
           )}
         >
-          {this.#renderItems(
-            (item as LayoutSplitterDistributionGroup).direction,
-            (item as LayoutSplitterDistributionGroup).items
-          )}
+          {this.#renderItems((item as Group).direction, (item as Group).items)}
         </div>
       ) : (
         <div id={item.id} class="leaf">

--- a/src/components/layout-splitter/remove-item.ts
+++ b/src/components/layout-splitter/remove-item.ts
@@ -1,9 +1,9 @@
 import { removeElement } from "../../common/array";
 import {
   GroupExtended,
+  ItemExtended,
   LayoutSplitterDistributionGroup,
   LayoutSplitterDistributionItem,
-  LayoutSplitterDistributionItemExtended,
   LayoutSplitterItemRemoveResult,
   LayoutSplitterReconnectedSubtree
 } from "./types";
@@ -26,10 +26,7 @@ export const NO_FIXED_SIZES_TO_UPDATE = 0;
 
 export const removeItem = (
   itemId: string,
-  itemsInfo: Map<
-    string,
-    LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>
-  >
+  itemsInfo: Map<string, ItemExtended>
 ): LayoutSplitterItemRemoveResult => {
   const itemToRemoveUIModel = itemsInfo.get(itemId);
   let reconnectedSubtree: LayoutSplitterReconnectedSubtree = undefined;
@@ -163,8 +160,8 @@ export const removeItem = (
 };
 
 function addSpaceToItemAndGetNewFixesSizes(
-  itemToSubtractUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>,
-  itemToAddUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>,
+  itemToSubtractUIModel: ItemExtended,
+  itemToAddUIModel: ItemExtended,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _itemToAddSpaceIsBefore: boolean
 ): number {

--- a/src/components/layout-splitter/test/fixAndUpdateLayoutModel.spec.ts
+++ b/src/components/layout-splitter/test/fixAndUpdateLayoutModel.spec.ts
@@ -1,0 +1,58 @@
+import { fixAndUpdateLayoutModel } from "../utils";
+import { ItemExtended, LayoutSplitterDistribution } from "../types";
+
+describe("[ch-layout-splitter] [fixAndUpdateLayoutModel]", () => {
+  const itemsInfo: Map<string, ItemExtended> = new Map();
+
+  const model: LayoutSplitterDistribution = {
+    id: "root",
+    direction: "rows",
+    items: [
+      {
+        id: "sub-group-1",
+        size: "1fr",
+        direction: "columns",
+        items: [
+          { id: "start-component", size: "100px", minSize: "200px" },
+          { id: "center-component", size: "1fr", minSize: "250px" },
+          { id: "end-component", size: "270px", minSize: "400px" }
+        ]
+      },
+      { id: "end-end-component", size: "250px", minSize: "249px" },
+      { id: "end-end-component-2", size: "250px", minSize: "251px" }
+    ]
+  };
+
+  const resultModel: LayoutSplitterDistribution = {
+    id: "root",
+    direction: "rows",
+    items: [
+      {
+        id: "sub-group-1",
+        size: "1fr",
+        direction: "columns",
+        items: [
+          { id: "start-component", size: "200px", minSize: "200px" },
+          { id: "center-component", size: "1fr", minSize: "250px" },
+          { id: "end-component", size: "400px", minSize: "400px" }
+        ]
+      },
+      { id: "end-end-component", size: "250px", minSize: "249px" },
+      { id: "end-end-component-2", size: "251px", minSize: "251px" }
+    ]
+  };
+
+  it("updates px values that are lower to the minSize", async () => {
+    const testModel = structuredClone(model);
+    fixAndUpdateLayoutModel(testModel, itemsInfo);
+
+    expect(JSON.stringify(testModel)).toEqual(JSON.stringify(resultModel));
+  });
+
+  it("the fixedSizesSum of the root is affected by the px values that are lower than minSize", async () => {
+    const testModel = structuredClone(model);
+    const fixedSizesSum = fixAndUpdateLayoutModel(testModel, itemsInfo);
+
+    expect(fixedSizesSum).toEqual(501);
+  });
+});

--- a/src/components/layout-splitter/test/getFrValue.spec.ts
+++ b/src/components/layout-splitter/test/getFrValue.spec.ts
@@ -1,0 +1,16 @@
+import { getFrValue } from "../utils";
+
+describe("[ch-layout-splitter] [getFrValue]", () => {
+  const values = [1, -1, 0.5, -0.5, 0.33, -0.33, 80, -80];
+
+  values.forEach(value => {
+    it("should get the correct fr value", async () => {
+      const frValue = getFrValue({
+        id: "any",
+        size: `${value}fr`
+      });
+
+      expect(frValue).toEqual(value);
+    });
+  });
+});

--- a/src/components/layout-splitter/test/getPxValue.spec.ts
+++ b/src/components/layout-splitter/test/getPxValue.spec.ts
@@ -1,0 +1,34 @@
+import { getPxValue } from "../utils";
+
+describe("[ch-layout-splitter] [getPxValue]", () => {
+  const values = [1, -1, 0.5, -0.5, 0.33, -0.33, 80, -80];
+
+  values.forEach(value => {
+    it("should get the correct px value (size)", async () => {
+      const pxValue = getPxValue(
+        {
+          id: "any",
+          size: `${value}px`
+        },
+        "size"
+      );
+
+      expect(pxValue).toEqual(value);
+    });
+  });
+
+  values.forEach(value => {
+    it("should get the correct px value (minSize)", async () => {
+      const pxValue = getPxValue(
+        {
+          id: "any",
+          size: `0.7px`,
+          minSize: `${value}px`
+        },
+        "min"
+      );
+
+      expect(pxValue).toEqual(value);
+    });
+  });
+});

--- a/src/components/layout-splitter/test/sizesToGridTemplate.spec.ts
+++ b/src/components/layout-splitter/test/sizesToGridTemplate.spec.ts
@@ -1,0 +1,68 @@
+import {
+  ItemExtended,
+  LayoutSplitterDistribution,
+  LayoutSplitterDistributionGroup
+} from "../types";
+import { fixAndUpdateLayoutModel, sizesToGridTemplate } from "../utils";
+
+describe("[ch-layout-splitter] [sizesToGridTemplate]", () => {
+  const model: LayoutSplitterDistribution = {
+    id: "root",
+    direction: "rows",
+    items: [
+      {
+        id: "sub-group-1",
+        size: "1fr",
+        direction: "columns",
+        items: [
+          { id: "start-component", size: "100px", minSize: "200px" },
+          {
+            id: "start-component-2",
+            size: "100px",
+            minSize: "200px",
+            dragBar: { hidden: true }
+          },
+          { id: "center-component", size: "1fr", minSize: "250px" },
+          { id: "end-component", size: "270px", minSize: "400px" },
+          {
+            id: "end-component-2",
+            size: "4fr",
+            minSize: "400px",
+            dragBar: { size: 9 }
+          },
+          {
+            id: "end-component-2",
+            size: "3fr",
+            dragBar: { size: 2, part: "visible" }
+          }
+        ]
+      },
+      { id: "end-end-component", size: "250px", minSize: "249px" },
+      { id: "end-end-component-2", size: "250px", minSize: "251px" }
+    ]
+  };
+
+  const itemsInfo: Map<string, ItemExtended> = new Map();
+
+  fixAndUpdateLayoutModel(model, itemsInfo);
+
+  it("should return the correct grid-template-columns", async () => {
+    const templateResult = sizesToGridTemplate(model.items, itemsInfo, 2);
+
+    expect(templateResult).toEqual(
+      "calc(100% + var(--ch-layout-splitter-fixed-sizes-sum) * -1) 0px 250px 0px 251px"
+    );
+  });
+
+  it("should return the correct grid-template-columns", async () => {
+    const templateResult = sizesToGridTemplate(
+      (model.items[0] as LayoutSplitterDistributionGroup).items,
+      itemsInfo,
+      5
+    );
+
+    expect(templateResult).toEqual(
+      "200px 0px 200px minmax(250px,calc(12.5% + var(--ch-layout-splitter-fixed-sizes-sum) * -0.125)) 0px 400px 0px calc(37.5% + var(--ch-layout-splitter-fixed-sizes-sum) * -0.375) 9px calc(37.5% + var(--ch-layout-splitter-fixed-sizes-sum) * -0.375)"
+    );
+  });
+});

--- a/src/components/layout-splitter/types.ts
+++ b/src/components/layout-splitter/types.ts
@@ -67,6 +67,7 @@ export type DragBarMouseDownEventInfo = {
   container: HTMLElement;
   containerSize: number;
   direction: LayoutSplitterDirection;
+  dragBarContainer: HTMLElement;
   fixedSizesSumRoot: number;
   itemStartId: string;
   itemEndId: string;

--- a/src/components/layout-splitter/types.ts
+++ b/src/components/layout-splitter/types.ts
@@ -19,6 +19,7 @@ export type LayoutSplitterDistributionLeaf = {
   dragBar?: LayoutSplitterDragBarConfig;
   fixedOffsetSize?: number;
   size: LayoutSplitterSize;
+  minSize?: `${number}px`;
 };
 
 export type LayoutSplitterDistributionGroup = LayoutSplitterDistributionLeaf & {

--- a/src/components/layout-splitter/types.ts
+++ b/src/components/layout-splitter/types.ts
@@ -68,7 +68,7 @@ export type DragBarMouseDownEventInfo = {
   container: HTMLElement;
   containerSize: number;
   direction: LayoutSplitterDirection;
-  dragBarContainer: HTMLElement;
+  dragBar: HTMLElement;
   fixedSizesSumRoot: number;
   itemStartId: string;
   itemEndId: string;

--- a/src/components/layout-splitter/utils.ts
+++ b/src/components/layout-splitter/utils.ts
@@ -3,7 +3,6 @@ import {
   DragBarMouseDownEventInfo,
   GroupExtended,
   ItemExtended,
-  LayoutSplitterDirection,
   LayoutSplitterDistribution,
   LayoutSplitterDistributionGroup,
   LayoutSplitterDistributionItem,
@@ -121,14 +120,13 @@ const checkAndSetInitialValue = (item: LayoutSplitterDistributionItem) => {
 };
 
 const getItemSizeUsingReference = (
-  dragBarContainer: HTMLElement,
-  itemUIModel: ItemExtended,
-  direction: LayoutSplitterDirection
+  info: DragBarMouseDownEventInfo,
+  itemUIModel: ItemExtended
 ): number => {
-  const itemRef = dragBarContainer.querySelector(
-    `[id="${itemUIModel.item.id}"]`
-  );
-  return direction === "columns" ? itemRef.clientWidth : itemRef.clientHeight;
+  const itemRef = info.container.querySelector(`[id="${itemUIModel.item.id}"]`);
+  return info.direction === "columns"
+    ? itemRef.clientWidth
+    : itemRef.clientHeight;
 };
 
 /**
@@ -142,8 +140,7 @@ const canResizeBothItems = (
   startItemSizeType: "px" | "fr",
   endItemSizeType: "px" | "fr",
   incrementInPx: number,
-  dragBarContainer: HTMLElement,
-  direction: LayoutSplitterDirection
+  info: DragBarMouseDownEventInfo
 ): {
   status: "ok" | "deny" | "not-enough-space";
   availableIncrement?: number;
@@ -154,11 +151,7 @@ const canResizeBothItems = (
     const size =
       startItemSizeType === "px"
         ? getPxValue(startItemUIModel.item)
-        : getItemSizeUsingReference(
-            dragBarContainer,
-            startItemUIModel,
-            direction
-          );
+        : getItemSizeUsingReference(info, startItemUIModel);
 
     const availableIncrement = size - minSize;
 
@@ -177,11 +170,7 @@ const canResizeBothItems = (
     const size =
       endItemSizeType === "px"
         ? getPxValue(endItemUIModel.item)
-        : getItemSizeUsingReference(
-            dragBarContainer,
-            endItemUIModel,
-            direction
-          );
+        : getItemSizeUsingReference(info, endItemUIModel);
 
     const availableIncrement = size - minSize;
 
@@ -303,8 +292,7 @@ const addSizeIncrementInComponents = (
   endItemUIModel: ItemExtended,
   incrementInPx: number,
   remainingRelativeSizeInPixels: number,
-  dragBarContainer: HTMLElement,
-  direction: LayoutSplitterDirection
+  info: DragBarMouseDownEventInfo
 ): boolean => {
   const startItemSizeType = hasAbsoluteValue(startItemUIModel.item)
     ? "px"
@@ -318,8 +306,7 @@ const addSizeIncrementInComponents = (
     startItemSizeType,
     endItemSizeType,
     incrementInPx,
-    dragBarContainer,
-    direction
+    info
   );
 
   if (resizeOperationStatus.status === "deny") {
@@ -371,8 +358,7 @@ export const updateComponentsAndDragBar = (
     endItemUIModel,
     incrementInPxRTL,
     remainingRelativeSizeInPixels,
-    info.container,
-    info.direction
+    info
   );
 
   // No resizing can be done, so there is no need to update the DOM

--- a/src/components/layout-splitter/utils.ts
+++ b/src/components/layout-splitter/utils.ts
@@ -306,7 +306,7 @@ const addSizeIncrementInComponents = (
   remainingRelativeSizeInPixels: number,
   dragBarContainer: HTMLElement,
   direction: LayoutSplitterDirection
-) => {
+): boolean => {
   let actualIncrement = incrementInPx;
 
   const resizeOperationStatus = canResizeBothItems(
@@ -320,7 +320,7 @@ const addSizeIncrementInComponents = (
   );
 
   if (resizeOperationStatus.status === "deny") {
-    return;
+    return false;
   }
   if (resizeOperationStatus.status === "not-enough-space") {
     actualIncrement =
@@ -338,6 +338,8 @@ const addSizeIncrementInComponents = (
     actualIncrement,
     remainingRelativeSizeInPixels
   );
+
+  return true;
 };
 
 export const updateComponentsAndDragBar = (
@@ -348,7 +350,7 @@ export const updateComponentsAndDragBar = (
 ) => {
   // - - - - - - - - - Increments - - - - - - - - -
   // When the language is RTL, the increment is in the opposite direction
-  let incrementInPxRTL =
+  const incrementInPxRTL =
     info.direction === "columns" && info.RTL ? -incrementInPx : incrementInPx;
 
   // Components at each position of the drag bar
@@ -366,7 +368,7 @@ export const updateComponentsAndDragBar = (
   const remainingRelativeSizeInPixels =
     info.containerSize - fixedSizesSumParent;
 
-  addSizeIncrementInComponents(
+  const mustUpdateTheDOM = addSizeIncrementInComponents(
     startItemUIModel,
     endItemUIModel,
     incrementInPxRTL,
@@ -374,6 +376,11 @@ export const updateComponentsAndDragBar = (
     info.dragBarContainer,
     info.direction
   );
+
+  // No resizing can be done, so there is no need to update the DOM
+  if (!mustUpdateTheDOM) {
+    return;
+  }
 
   // Update in the DOM the grid distribution
   info.container.style.setProperty(

--- a/src/components/layout-splitter/utils.ts
+++ b/src/components/layout-splitter/utils.ts
@@ -1,4 +1,4 @@
-import { ROOT_VIEW } from "../renders/flexible-layout/utils";
+import { ROOT_VIEW } from "../../common/utils";
 import {
   DragBarMouseDownEventInfo,
   GroupExtended,

--- a/src/components/layout-splitter/utils.ts
+++ b/src/components/layout-splitter/utils.ts
@@ -124,11 +124,10 @@ const getItemSizeUsingReference = (
   dragBarContainer: HTMLElement,
   itemUIModel: ItemExtended,
   direction: LayoutSplitterDirection
-) => {
+): number => {
   const itemRef = dragBarContainer.querySelector(
     `[id="${itemUIModel.item.id}"]`
   );
-
   return direction === "columns" ? itemRef.clientWidth : itemRef.clientHeight;
 };
 
@@ -180,7 +179,7 @@ const canResizeBothItems = (
         ? getPxValue(endItemUIModel.item)
         : getItemSizeUsingReference(
             dragBarContainer,
-            startItemUIModel,
+            endItemUIModel,
             direction
           );
 
@@ -307,13 +306,17 @@ const addSizeIncrementInComponents = (
   dragBarContainer: HTMLElement,
   direction: LayoutSplitterDirection
 ): boolean => {
+  const startItemSizeType = hasAbsoluteValue(startItemUIModel.item)
+    ? "px"
+    : "fr";
+  const endItemSizeType = hasAbsoluteValue(endItemUIModel.item) ? "px" : "fr";
   let actualIncrement = incrementInPx;
 
   const resizeOperationStatus = canResizeBothItems(
     startItemUIModel,
     endItemUIModel,
-    "px",
-    "px",
+    startItemSizeType,
+    endItemSizeType,
     incrementInPx,
     dragBarContainer,
     direction
@@ -326,11 +329,6 @@ const addSizeIncrementInComponents = (
     actualIncrement =
       resizeOperationStatus.availableIncrement * Math.sign(actualIncrement);
   }
-
-  const startItemSizeType = hasAbsoluteValue(startItemUIModel.item)
-    ? "px"
-    : "fr";
-  const endItemSizeType = hasAbsoluteValue(endItemUIModel.item) ? "px" : "fr";
 
   sizeIncrementDictionary[`${startItemSizeType}-${endItemSizeType}`](
     startItemUIModel,
@@ -373,7 +371,7 @@ export const updateComponentsAndDragBar = (
     endItemUIModel,
     incrementInPxRTL,
     remainingRelativeSizeInPixels,
-    info.dragBarContainer,
+    info.container,
     info.direction
   );
 
@@ -389,7 +387,7 @@ export const updateComponentsAndDragBar = (
   );
 
   // Update the current value in the drag bar
-  info.dragBarContainer.ariaValueText = startItemUIModel.actualSize;
+  info.dragBar.ariaValueText = startItemUIModel.actualSize;
 };
 
 export const getMousePosition = (

--- a/src/components/layout-splitter/utils.ts
+++ b/src/components/layout-splitter/utils.ts
@@ -3,6 +3,7 @@ import {
   DragBarMouseDownEventInfo,
   GroupExtended,
   ItemExtended,
+  LayoutSplitterDirection,
   LayoutSplitterDistribution,
   LayoutSplitterDistributionGroup,
   LayoutSplitterDistributionItem,
@@ -119,6 +120,18 @@ const checkAndSetInitialValue = (item: LayoutSplitterDistributionItem) => {
   }
 };
 
+const getItemSizeUsingReference = (
+  dragBarContainer: HTMLElement,
+  itemUIModel: ItemExtended,
+  direction: LayoutSplitterDirection
+) => {
+  const itemRef = dragBarContainer.querySelector(
+    `[id="${itemUIModel.item.id}"]`
+  );
+
+  return direction === "columns" ? itemRef.clientWidth : itemRef.clientHeight;
+};
+
 /**
  * Given the two items to resize and its increment (`incrementInPx`), return if
  * both items can be resized or the resize operation must be adjusted or
@@ -129,7 +142,9 @@ const canResizeBothItems = (
   endItemUIModel: ItemExtended,
   startItemSizeType: "px" | "fr",
   endItemSizeType: "px" | "fr",
-  incrementInPx: number
+  incrementInPx: number,
+  dragBarContainer: HTMLElement,
+  direction: LayoutSplitterDirection
 ): {
   status: "ok" | "deny" | "not-enough-space";
   availableIncrement?: number;
@@ -140,7 +155,11 @@ const canResizeBothItems = (
     const size =
       startItemSizeType === "px"
         ? getPxValue(startItemUIModel.item)
-        : getPxValue(startItemUIModel.item); // TODO: Get the DOM reference and update this value
+        : getItemSizeUsingReference(
+            dragBarContainer,
+            startItemUIModel,
+            direction
+          );
 
     const availableIncrement = size - minSize;
 
@@ -159,7 +178,11 @@ const canResizeBothItems = (
     const size =
       endItemSizeType === "px"
         ? getPxValue(endItemUIModel.item)
-        : getPxValue(endItemUIModel.item); // TODO: Get the DOM reference and update this value
+        : getItemSizeUsingReference(
+            dragBarContainer,
+            startItemUIModel,
+            direction
+          );
 
     const availableIncrement = size - minSize;
 
@@ -280,7 +303,9 @@ const addSizeIncrementInComponents = (
   startItemUIModel: ItemExtended,
   endItemUIModel: ItemExtended,
   incrementInPx: number,
-  remainingRelativeSizeInPixels: number
+  remainingRelativeSizeInPixels: number,
+  dragBarContainer: HTMLElement,
+  direction: LayoutSplitterDirection
 ) => {
   let actualIncrement = incrementInPx;
 
@@ -289,7 +314,9 @@ const addSizeIncrementInComponents = (
     endItemUIModel,
     "px",
     "px",
-    incrementInPx
+    incrementInPx,
+    dragBarContainer,
+    direction
   );
 
   if (resizeOperationStatus.status === "deny") {
@@ -343,7 +370,9 @@ export const updateComponentsAndDragBar = (
     startItemUIModel,
     endItemUIModel,
     incrementInPxRTL,
-    remainingRelativeSizeInPixels
+    remainingRelativeSizeInPixels,
+    info.dragBarContainer,
+    info.direction
   );
 
   // Update in the DOM the grid distribution

--- a/src/components/layout-splitter/utils.ts
+++ b/src/components/layout-splitter/utils.ts
@@ -1,29 +1,25 @@
 import { ROOT_VIEW } from "../renders/flexible-layout/utils";
 import {
   DragBarMouseDownEventInfo,
+  GroupExtended,
+  ItemExtended,
   LayoutSplitterDistribution,
   LayoutSplitterDistributionGroup,
   LayoutSplitterDistributionItem,
-  LayoutSplitterDistributionItemExtended,
   LayoutSplitterSize
 } from "./types";
 
 export const FIXED_SIZES_SUM_CUSTOM_VAR =
   "--ch-layout-splitter-fixed-sizes-sum";
 
-export const findItemInParent = (
-  itemToFind: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>
-) => {
+export const findItemInParent = (itemToFind: ItemExtended) => {
   const itemId = itemToFind.item.id;
   return itemToFind.parentItem.items.findIndex(item => item.id === itemId);
 };
 
 export const sizesToGridTemplate = (
   items: LayoutSplitterDistributionItem[],
-  itemsInfo: Map<
-    string,
-    LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>
-  >,
+  itemsInfo: Map<string, ItemExtended>,
   lastItemIndex: number
 ) =>
   items
@@ -62,40 +58,27 @@ const getComponentSize = (item: LayoutSplitterDistributionItem): string =>
     ? item.size
     : getItemFrSize(item);
 
-export const setPxSize = (
-  itemUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>,
-  newValue: number
-) => {
+export const setPxSize = (itemUIModel: ItemExtended, newValue: number) => {
   const newValueString: LayoutSplitterSize = `${newValue}px`;
 
   itemUIModel.item.size = newValueString;
   itemUIModel.actualSize = newValueString;
 };
 
-export const updatePxSize = (
-  itemUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>,
-  increment: number
-) => setPxSize(itemUIModel, getPxValue(itemUIModel.item) + increment);
+export const updatePxSize = (itemUIModel: ItemExtended, increment: number) =>
+  setPxSize(itemUIModel, getPxValue(itemUIModel.item) + increment);
 
-export const setFrSize = (
-  itemUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>,
-  newValue: number
-) => {
+export const setFrSize = (itemUIModel: ItemExtended, newValue: number) => {
   const newValueString: LayoutSplitterSize = `${newValue}fr`;
 
   itemUIModel.item.size = newValueString;
   itemUIModel.actualSize = getItemFrSize(itemUIModel.item);
 };
 
-export const updateFrSize = (
-  itemUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>,
-  increment: number
-) => setFrSize(itemUIModel, getFrValue(itemUIModel.item) + increment);
+export const updateFrSize = (itemUIModel: ItemExtended, increment: number) =>
+  setFrSize(itemUIModel, getFrValue(itemUIModel.item) + increment);
 
-export const setOffsetSize = (
-  itemUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>,
-  newValue: number
-) => {
+export const setOffsetSize = (itemUIModel: ItemExtended, newValue: number) => {
   const itemInfo = itemUIModel.item;
 
   itemInfo.fixedOffsetSize = newValue;
@@ -103,7 +86,7 @@ export const setOffsetSize = (
 };
 
 export const incrementOffsetSize = (
-  itemUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>,
+  itemUIModel: ItemExtended,
   increment: number
 ) =>
   setOffsetSize(
@@ -113,18 +96,12 @@ export const incrementOffsetSize = (
 
 export const fixAndUpdateLayoutModel = (
   layout: LayoutSplitterDistribution,
-  itemsInfo: Map<
-    string,
-    LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>
-  >
+  itemsInfo: Map<string, ItemExtended>
 ): number => fixAndUpdateSubModel(layout.items, itemsInfo, ROOT_VIEW);
 
 function fixAndUpdateSubModel(
   items: LayoutSplitterDistributionItem[],
-  itemsInfo: Map<
-    string,
-    LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>
-  >,
+  itemsInfo: Map<string, ItemExtended>,
   parentItem: LayoutSplitterDistributionGroup
 ): number {
   let frSum = 0;
@@ -161,21 +138,18 @@ function fixAndUpdateSubModel(
 
   // Update the actualSizes and fixedSizes maps
   items.forEach(item => {
-    const itemUIModel: LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem> =
-      {
-        item: item,
-        parentItem: parentItem,
-        actualSize: getComponentSize(item)
-      };
+    const itemUIModel: ItemExtended = {
+      item: item,
+      parentItem: parentItem,
+      actualSize: getComponentSize(item)
+    };
 
     if ((item as LayoutSplitterDistributionGroup).items != null) {
       // eslint-disable-next-line prettier/prettier
       const group = item as LayoutSplitterDistributionGroup;
       const fixedSizesSum = fixAndUpdateSubModel(group.items, itemsInfo, group);
 
-      (
-        itemUIModel as LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionGroup>
-      ).fixedSizesSum = fixedSizesSum;
+      (itemUIModel as GroupExtended).fixedSizesSum = fixedSizesSum;
     }
 
     itemsInfo.set(item.id, itemUIModel);
@@ -186,10 +160,7 @@ function fixAndUpdateSubModel(
 
 export const updateComponentsAndDragBar = (
   info: DragBarMouseDownEventInfo,
-  itemsInfo: Map<
-    string,
-    LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionItem>
-  >,
+  itemsInfo: Map<string, ItemExtended>,
   incrementInPx: number,
   gridTemplateDirectionCustomVar: string
 ) => {
@@ -205,11 +176,8 @@ export const updateComponentsAndDragBar = (
   const fixedSizesSumParent =
     startItemUIModel.parentItem === ROOT_VIEW
       ? info.fixedSizesSumRoot
-      : (
-          itemsInfo.get(
-            startItemUIModel.parentItem.id
-          ) as LayoutSplitterDistributionItemExtended<LayoutSplitterDistributionGroup>
-        ).fixedSizesSum;
+      : (itemsInfo.get(startItemUIModel.parentItem.id) as GroupExtended)
+          .fixedSizesSum;
 
   const layoutItems = info.layoutItems;
 

--- a/src/components/layout-splitter/utils.ts
+++ b/src/components/layout-splitter/utils.ts
@@ -214,6 +214,9 @@ export const updateComponentsAndDragBar = (
     gridTemplateDirectionCustomVar,
     sizesToGridTemplate(layoutItems, itemsInfo, layoutItems.length - 1)
   );
+
+  // Update the current value in the drag bar
+  info.dragBarContainer.ariaValueText = startItemUIModel.actualSize;
 };
 
 export const getMousePosition = (

--- a/src/components/renders/flexible-layout/utils.ts
+++ b/src/components/renders/flexible-layout/utils.ts
@@ -8,8 +8,7 @@ import {
   FlexibleLayoutLeaf,
   FlexibleLayoutLeafInfo
 } from "../../flexible-layout/types";
-
-export const ROOT_VIEW: null = null;
+import { ROOT_VIEW } from "../../../common/utils";
 
 export const createAndSetViewInfo = (
   flexibleLayoutLeaf: FlexibleLayoutLeaf,

--- a/src/components/test/test-flexible-layout/test-flexible-layout.scss
+++ b/src/components/test/test-flexible-layout/test-flexible-layout.scss
@@ -139,6 +139,13 @@ ch-test-flexible-layout {
   }
 }
 
+// - - - - - - - - - - - - - - - -
+//            Tree View
+// - - - - - - - - - - - - - - - -
+.tree-view > .ch-tree-view-container {
+  min-inline-size: max-content;
+}
+
 .ch-tree-view-item--success::part(action)::before {
   grid-area: first-img;
   content: "";

--- a/src/showcase/pages/layout-splitter.html
+++ b/src/showcase/pages/layout-splitter.html
@@ -143,12 +143,13 @@
               size: "1fr",
               direction: "columns",
               items: [
-                { id: "start-component", size: "300px" },
-                { id: "center-component", size: "1fr" },
-                { id: "end-component", size: "270px" }
+                { id: "start-component", size: "100px", minSize: "200px" },
+                { id: "center-component", size: "1fr", minSize: "250px" },
+                { id: "end-component", size: "270px", minSize: "400px" }
               ]
             },
-            { id: "end-end-component", size: "250px" }
+            { id: "end-end-component", size: "250px", minSize: "249px" },
+            { id: "end-end-component-2", size: "250px", minSize: "251px" }
           ]
         };
 

--- a/src/showcase/pages/layout-splitter.html
+++ b/src/showcase/pages/layout-splitter.html
@@ -141,15 +141,25 @@
             {
               id: "sub-group-1",
               size: "1fr",
+              minSize: "100px",
               direction: "columns",
               items: [
-                { id: "start-component", size: "100px", minSize: "200px" },
-                { id: "center-component", size: "1fr", minSize: "250px" },
+                {
+                  id: "start-component",
+                  size: "100px",
+                  minSize: "200px",
+                  dragBar: { hidden: true }
+                },
+                {
+                  id: "center-component",
+                  size: "1fr",
+                  minSize: "250px"
+                },
                 { id: "end-component", size: "270px", minSize: "400px" }
               ]
             },
             { id: "end-end-component", size: "250px", minSize: "249px" },
-            { id: "end-end-component-2", size: "250px", minSize: "251px" }
+            { id: "center-2-component", size: "250px", minSize: "251px" }
           ]
         };
 


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fixes:
   - **[Refactoring]** Use the `SyncWithRAF` class to sync computations with frames.

   - Improve code readability by using type aliases.

   - **[Performance]** Move `ROOT_VIEW` to `common/utils` to improve waterfall.

 - Features:
   - **[Accessibility]** Improve accessibility by adding `aria-valuetext`.

   - Bump puppeteer from `~15.2.0` to `~22.1.0`.

   - Add `"test.coverage"` script.

   - Add a script to run `"spec"` tests.

   - Add spec tests for the `ch-layout-splitter` control.

   - Add support for validating `minSize` when resizing components.