### PR TITLE
Add support for resizing the `ch-popover` control

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -81,3 +81,19 @@ export const removeDragImage = (event: DragEvent) =>
 
 export const isPseudoElementImg = (src?: string, imageType?: ImageRender) =>
   src && imageType !== "img";
+
+/**
+ * Force a value to follow CSS minimum and maximum rules. Note that the minimum
+ * value can be greater than the maximum value, as implemented by the CSS
+ * specification.
+ * The maximum value can be `NaN`. In this case only the minimum value rule
+ * will be apply.
+ */
+export const forceCSSMinMax = (
+  value: number,
+  minimum: number,
+  maximum: number
+): number =>
+  Number.isNaN(maximum)
+    ? Math.max(value, minimum)
+    : Math.max(Math.min(value, maximum), minimum);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1359,6 +1359,10 @@ export namespace Components {
          */
         "mode": "auto" | "manual";
         /**
+          * Specifies whether the control can be resized. If `true` the control can be resized at runtime by dragging the edges or corners.
+         */
+        "resizable": boolean;
+        /**
           * Specifies if the popover is automatically aligned is the content overflow the window.
          */
         "responsiveAlignment": boolean;
@@ -4808,6 +4812,10 @@ declare namespace LocalJSX {
           * Emitted when the popover is opened.
          */
         "onPopoverOpened"?: (event: ChPopoverCustomEvent<any>) => void;
+        /**
+          * Specifies whether the control can be resized. If `true` the control can be resized at runtime by dragging the edges or corners.
+         */
+        "resizable"?: boolean;
         /**
           * Specifies if the popover is automatically aligned is the content overflow the window.
          */

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -25,6 +25,29 @@ $ch-popover-y--same-layer: calc(
 
 :host {
   /**
+   * @prop --ch-popover-block-size:
+   * Specifies the block size of the popover. Useful for scenarios where the
+   * popover is resizable. of the threshold to resize the popover.
+   * @default max-content
+   */
+  --ch-popover-block-size: max-content;
+
+  /**
+   * @prop --ch-popover-inline-size:
+   * Specifies the inline size of the popover. Useful for scenarios where the
+   * popover is resizable. of the threshold to resize the popover.
+   * @default max-content
+   */
+  --ch-popover-inline-size: max-content;
+
+  /**
+   * @prop --ch-popover-resize-threshold:
+   * Specifies the size of the threshold to resize the popover.
+   * @default 4px
+   */
+  --ch-popover-resize-threshold: 8px;
+
+  /**
    * @prop --ch-popover-separation-x:
    * Specifies the separation between the action and popover in the x axis.
    * @default 0px
@@ -38,6 +61,10 @@ $ch-popover-y--same-layer: calc(
    */
   --ch-popover-separation-y: 0px;
 
+  --ch-popover-resize-threshold--half-negative: calc(
+    var(--ch-popover-resize-threshold) * -0.5
+  );
+
   --ch-popover-dragged-x: 0px;
   --ch-popover-dragged-y: 0px;
   --ch-popover-rtl: 1;
@@ -45,6 +72,9 @@ $ch-popover-y--same-layer: calc(
   // Necessary when the popover is not placed in a new top layer. For example,
   // when nesting dropdowns
   position: fixed;
+
+  inline-size: var(--ch-popover-inline-size);
+  block-size: var(--ch-popover-block-size);
 
   // Reset browser defaults
   margin: 0;
@@ -104,6 +134,81 @@ $ch-popover-y--same-layer: calc(
   ::slotted(*) {
     pointer-events: none;
     user-select: none;
+  }
+}
+
+// - - - - - - - - - - - - - - - -
+//            Resizable
+// - - - - - - - - - - - - - - - -
+.edge {
+  &__block-start,
+  &__block-end {
+    position: fixed;
+    inset-inline: 0;
+    block-size: var(--ch-popover-resize-threshold);
+    cursor: ns-resize;
+  }
+
+  &__inline-start,
+  &__inline-end {
+    position: fixed;
+    inset-block: 0;
+    inline-size: var(--ch-popover-resize-threshold);
+    cursor: ew-resize;
+  }
+
+  &__block-start {
+    inset-block-start: var(--ch-popover-resize-threshold--half-negative);
+  }
+
+  &__block-end {
+    inset-block-end: var(--ch-popover-resize-threshold--half-negative);
+  }
+
+  &__inline-start {
+    inset-inline-start: var(--ch-popover-resize-threshold--half-negative);
+  }
+
+  &__inline-end {
+    inset-inline-end: var(--ch-popover-resize-threshold--half-negative);
+  }
+}
+
+.corner {
+  &__block-start-inline-start,
+  &__block-end-inline-end {
+    position: fixed;
+    block-size: var(--ch-popover-resize-threshold);
+    inline-size: var(--ch-popover-resize-threshold);
+    cursor: nwse-resize;
+  }
+
+  &__block-start-inline-end,
+  &__block-end-inline-start {
+    position: fixed;
+    block-size: var(--ch-popover-resize-threshold);
+    inline-size: var(--ch-popover-resize-threshold);
+    cursor: nesw-resize;
+  }
+
+  &__block-start-inline-start {
+    inset-block-start: var(--ch-popover-resize-threshold--half-negative);
+    inset-inline-start: var(--ch-popover-resize-threshold--half-negative);
+  }
+
+  &__block-end-inline-end {
+    inset-block-end: var(--ch-popover-resize-threshold--half-negative);
+    inset-inline-end: var(--ch-popover-resize-threshold--half-negative);
+  }
+
+  &__block-start-inline-end {
+    inset-block-start: var(--ch-popover-resize-threshold--half-negative);
+    inset-inline-end: var(--ch-popover-resize-threshold--half-negative);
+  }
+
+  &__block-end-inline-start {
+    inset-block-end: var(--ch-popover-resize-threshold--half-negative);
+    inset-inline-start: var(--ch-popover-resize-threshold--half-negative);
   }
 }
 

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -169,7 +169,26 @@ $ch-popover-y--same-layer: calc(
   &__block-start,
   &__block-end {
     position: fixed;
-    inset-inline: 0;
+    // This calc improves edge positioning when the border-width is much larger
+    // than the threshold
+    inset-inline: min(
+        0px,
+        calc(
+          (
+              var(--ch-popover-resize-threshold) -
+                var(--ch-popover-border-inline-start-width)
+            ) / 2
+        )
+      )
+      min(
+        0px,
+        calc(
+          (
+              var(--ch-popover-resize-threshold) -
+                var(--ch-popover-border-inline-end-width)
+            ) / 2
+        )
+      );
     block-size: var(--ch-popover-resize-threshold);
     cursor: ns-resize;
   }
@@ -177,7 +196,26 @@ $ch-popover-y--same-layer: calc(
   &__inline-start,
   &__inline-end {
     position: fixed;
-    inset-block: 0;
+    // This calc improves edge positioning when the border-width is much larger
+    // than the threshold
+    inset-block: min(
+        0px,
+        calc(
+          (
+              var(--ch-popover-resize-threshold) -
+                var(--ch-popover-border-block-start-width)
+            ) / 2
+        )
+      )
+      min(
+        0px,
+        calc(
+          (
+              var(--ch-popover-resize-threshold) -
+                var(--ch-popover-border-block-end-width)
+            ) / 2
+        )
+      );
     inline-size: var(--ch-popover-resize-threshold);
     cursor: ew-resize;
   }

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -41,6 +41,22 @@ $ch-popover-y--same-layer: calc(
   --ch-popover-inline-size: max-content;
 
   /**
+   * @prop --ch-popover-max-block-size:
+   * Specifies the maximum block size of the popover. Useful for scenarios where the
+   * popover is resizable.
+   * @default auto
+   */
+  --ch-popover-max-block-size: auto;
+
+  /**
+     * @prop --ch-popover-max-inline-size:
+     * Specifies the maximum inline size of the popover. Useful for scenarios
+     * where the popover is resizable.
+     * @default auto
+     */
+  --ch-popover-max-inline-size: auto;
+
+  /**
    * @prop --ch-popover-min-block-size:
    * Specifies the minimum block size of the popover. Useful for scenarios where the
    * popover is resizable.
@@ -118,6 +134,8 @@ $ch-popover-y--same-layer: calc(
   block-size: var(--ch-popover-block-size);
   min-inline-size: var(--ch-popover-min-inline-size);
   min-block-size: var(--ch-popover-min-block-size);
+  max-inline-size: var(--ch-popover-max-inline-size);
+  max-block-size: var(--ch-popover-max-block-size);
 
   // Reset browser defaults
   margin: 0;

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -256,6 +256,7 @@ $ch-popover-y--same-layer: calc(
 .resize-layer {
   position: fixed;
   inset: 0;
+  pointer-events: none;
 }
 
 // - - - - - - - - - - - - - - - -

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -27,7 +27,7 @@ $ch-popover-y--same-layer: calc(
   /**
    * @prop --ch-popover-block-size:
    * Specifies the block size of the popover. Useful for scenarios where the
-   * popover is resizable. of the threshold to resize the popover.
+   * popover is resizable.
    * @default max-content
    */
   --ch-popover-block-size: max-content;
@@ -35,10 +35,26 @@ $ch-popover-y--same-layer: calc(
   /**
    * @prop --ch-popover-inline-size:
    * Specifies the inline size of the popover. Useful for scenarios where the
-   * popover is resizable. of the threshold to resize the popover.
+   * popover is resizable.
    * @default max-content
    */
   --ch-popover-inline-size: max-content;
+
+  /**
+   * @prop --ch-popover-min-block-size:
+   * Specifies the minimum block size of the popover. Useful for scenarios where the
+   * popover is resizable.
+   * @default auto
+   */
+  --ch-popover-min-block-size: auto;
+
+  /**
+    * @prop --ch-popover-min-inline-size:
+    * Specifies the minimum inline size of the popover. Useful for scenarios
+    * where the popover is resizable.
+    * @default auto
+    */
+  --ch-popover-min-inline-size: auto;
 
   /**
    * @prop --ch-popover-resize-threshold:
@@ -100,6 +116,8 @@ $ch-popover-y--same-layer: calc(
 
   inline-size: var(--ch-popover-inline-size);
   block-size: var(--ch-popover-block-size);
+  min-inline-size: var(--ch-popover-min-inline-size);
+  min-block-size: var(--ch-popover-min-block-size);
 
   // Reset browser defaults
   margin: 0;

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -252,6 +252,12 @@ $ch-popover-y--same-layer: calc(
   }
 }
 
+// Useful for observing changes in border size
+.resize-layer {
+  position: fixed;
+  inset: 0;
+}
+
 // - - - - - - - - - - - - - - - -
 //         Block alignment
 // - - - - - - - - - - - - - - - -

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -65,6 +65,31 @@ $ch-popover-y--same-layer: calc(
     var(--ch-popover-resize-threshold) * -0.5
   );
 
+  --ch-popover-border-inline-start-width: 0px;
+  --ch-popover-border-inline-end-width: 0px;
+  --ch-popover-border-block-start-width: 0px;
+  --ch-popover-border-block-end-width: 0px;
+
+  --ch-popover-resize__inline-start: calc(
+    var(--ch-popover-resize-threshold--half-negative) -
+      var(--ch-popover-border-inline-start-width) * 0.5
+  );
+
+  --ch-popover-resize__inline-end: calc(
+    var(--ch-popover-resize-threshold--half-negative) -
+      var(--ch-popover-border-inline-end-width) * 0.5
+  );
+
+  --ch-popover-resize__block-start: calc(
+    var(--ch-popover-resize-threshold--half-negative) -
+      var(--ch-popover-border-block-start-width) * 0.5
+  );
+
+  --ch-popover-resize__block-end: calc(
+    var(--ch-popover-resize-threshold--half-negative) -
+      var(--ch-popover-border-block-end-width) * 0.5
+  );
+
   --ch-popover-dragged-x: 0px;
   --ch-popover-dragged-y: 0px;
   --ch-popover-rtl: 1;
@@ -158,19 +183,19 @@ $ch-popover-y--same-layer: calc(
   }
 
   &__block-start {
-    inset-block-start: var(--ch-popover-resize-threshold--half-negative);
+    inset-block-start: var(--ch-popover-resize__block-start);
   }
 
   &__block-end {
-    inset-block-end: var(--ch-popover-resize-threshold--half-negative);
+    inset-block-end: var(--ch-popover-resize__block-end);
   }
 
   &__inline-start {
-    inset-inline-start: var(--ch-popover-resize-threshold--half-negative);
+    inset-inline-start: var(--ch-popover-resize__inline-start);
   }
 
   &__inline-end {
-    inset-inline-end: var(--ch-popover-resize-threshold--half-negative);
+    inset-inline-end: var(--ch-popover-resize__inline-end);
   }
 }
 
@@ -192,23 +217,23 @@ $ch-popover-y--same-layer: calc(
   }
 
   &__block-start-inline-start {
-    inset-block-start: var(--ch-popover-resize-threshold--half-negative);
-    inset-inline-start: var(--ch-popover-resize-threshold--half-negative);
+    inset-block-start: var(--ch-popover-resize__block-start);
+    inset-inline-start: var(--ch-popover-resize__inline-start);
   }
 
   &__block-end-inline-end {
-    inset-block-end: var(--ch-popover-resize-threshold--half-negative);
-    inset-inline-end: var(--ch-popover-resize-threshold--half-negative);
+    inset-block-end: var(--ch-popover-resize__block-end);
+    inset-inline-end: var(--ch-popover-resize__inline-end);
   }
 
   &__block-start-inline-end {
-    inset-block-start: var(--ch-popover-resize-threshold--half-negative);
-    inset-inline-end: var(--ch-popover-resize-threshold--half-negative);
+    inset-block-start: var(--ch-popover-resize__block-start);
+    inset-inline-end: var(--ch-popover-resize__inline-end);
   }
 
   &__block-end-inline-start {
-    inset-block-end: var(--ch-popover-resize-threshold--half-negative);
-    inset-inline-start: var(--ch-popover-resize-threshold--half-negative);
+    inset-block-end: var(--ch-popover-resize__block-end);
+    inset-inline-start: var(--ch-popover-resize__inline-start);
   }
 }
 

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -201,6 +201,11 @@ $ch-popover-y--same-layer: calc(
 // - - - - - - - - - - - - - - - -
 //            Resizable
 // - - - - - - - - - - - - - - - -
+:host(.ch-popover-resizing) {
+  pointer-events: none;
+  user-select: none;
+}
+
 .edge {
   &__block-start,
   &__block-end {

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -237,6 +237,21 @@ $ch-popover-y--same-layer: calc(
   }
 }
 
+// "Rotate" resize cursors for the corners
+:host(.ch-popover-rtl) {
+  .corner__block-start-inline-start,
+  .corner__block-end-inline-end {
+    cursor: nesw-resize;
+  }
+}
+
+:host(.ch-popover-rtl) {
+  .corner__block-start-inline-end,
+  .corner__block-end-inline-start {
+    cursor: nwse-resize;
+  }
+}
+
 // - - - - - - - - - - - - - - - -
 //         Block alignment
 // - - - - - - - - - - - - - - - -

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -129,7 +129,7 @@ export class ChPopover {
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
-      setProperty(this.el, POPOVER_BLOCK_SIZE, newBlockSize);
+      setProperty(this.el, POPOVER_BLOCK_SIZE, Math.max(newBlockSize, 0));
     },
 
     inline: (popoverRect: DOMRect, direction: "start" | "end") => {
@@ -154,7 +154,7 @@ export class ChPopover {
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
-      setProperty(this.el, POPOVER_INLINE_SIZE, newInlineSize);
+      setProperty(this.el, POPOVER_INLINE_SIZE, Math.max(newInlineSize, 0));
     }
   } as const;
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -106,6 +106,9 @@ export class ChPopover {
 
   // Resize
   #currentEdge: ChPopoverResizeElement;
+  #draggedDistanceXForResize: number = 0;
+  #draggedDistanceYForResize: number = 0;
+
   #resizeDictionary: {
     [key in ChPopoverResizeElement]: (popoverRect: DOMRect) => void;
   } = {
@@ -113,9 +116,12 @@ export class ChPopover {
       const currentDraggedDistanceY =
         this.#initialDragEvent.clientY - this.#lastDragEvent.clientY;
 
+      this.#draggedDistanceYForResize -= currentDraggedDistanceY;
+
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
+      setProperty(this.el, POPOVER_DRAGGED_Y, this.#draggedDistanceYForResize);
       setProperty(this.el, POPOVER_BLOCK_SIZE, newBlockSize);
     },
 
@@ -137,9 +143,12 @@ export class ChPopover {
         currentDraggedDistanceX = -currentDraggedDistanceX;
       }
 
+      this.#draggedDistanceXForResize -= currentDraggedDistanceX;
+
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
+      setProperty(this.el, POPOVER_DRAGGED_X, this.#draggedDistanceXForResize);
       setProperty(this.el, POPOVER_INLINE_SIZE, newInlineSize);
     },
 
@@ -167,10 +176,16 @@ export class ChPopover {
         currentDraggedDistanceX = -currentDraggedDistanceX;
       }
 
+      this.#draggedDistanceYForResize -= currentDraggedDistanceY;
+      this.#draggedDistanceXForResize -= currentDraggedDistanceX;
+
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
+      setProperty(this.el, POPOVER_DRAGGED_X, this.#draggedDistanceXForResize);
+      setProperty(this.el, POPOVER_DRAGGED_Y, this.#draggedDistanceYForResize);
+
       setProperty(this.el, POPOVER_BLOCK_SIZE, newBlockSize);
       setProperty(this.el, POPOVER_INLINE_SIZE, newInlineSize);
     },
@@ -185,10 +200,14 @@ export class ChPopover {
         currentDraggedDistanceX = -currentDraggedDistanceX;
       }
 
+      this.#draggedDistanceYForResize -= currentDraggedDistanceY;
+
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
+      setProperty(this.el, POPOVER_DRAGGED_Y, this.#draggedDistanceYForResize);
+
       setProperty(this.el, POPOVER_BLOCK_SIZE, newBlockSize);
       setProperty(this.el, POPOVER_INLINE_SIZE, newInlineSize);
     },
@@ -203,10 +222,14 @@ export class ChPopover {
         currentDraggedDistanceX = -currentDraggedDistanceX;
       }
 
+      this.#draggedDistanceXForResize -= currentDraggedDistanceX;
+
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
+      setProperty(this.el, POPOVER_DRAGGED_X, this.#draggedDistanceXForResize);
+
       setProperty(this.el, POPOVER_BLOCK_SIZE, newBlockSize);
       setProperty(this.el, POPOVER_INLINE_SIZE, newInlineSize);
     },
@@ -585,6 +608,12 @@ export class ChPopover {
     this.#currentEdge = edge;
     this.#initialDragEvent = event;
 
+    // Initialize drag variables to improve block-start and inline-start
+    // resizing. Otherwise, the popover will always remain in the same X and Y
+    // position, even when the block-start or inline-start edges are resized
+    this.#draggedDistanceXForResize = this.#draggedDistanceX;
+    this.#draggedDistanceYForResize = this.#draggedDistanceY;
+
     // Avoid repositioning the popover
     this.#removePositionWatcher();
 
@@ -632,6 +661,10 @@ export class ChPopover {
     if (this.#resizeRAF) {
       this.#resizeRAF.cancel();
     }
+
+    // Reset dragged distance to its original value
+    setProperty(this.el, POPOVER_DRAGGED_X, this.#draggedDistanceX);
+    setProperty(this.el, POPOVER_DRAGGED_Y, this.#draggedDistanceY);
 
     // Update the position of the popover when the resize ends
     this.#setPositionWatcher();

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -14,7 +14,7 @@ import {
   ChPopoverResizeElement,
   PopoverActionElement
 } from "./types";
-import { isRTL } from "../../common/utils";
+import { forceCSSMinMax, isRTL } from "../../common/utils";
 import { SyncWithRAF } from "../../common/sync-with-frames";
 import { getAlignmentValue } from "./utils";
 
@@ -109,6 +109,8 @@ export class ChPopover {
   #currentEdge: ChPopoverResizeElement;
   #draggedDistanceXForResize: number = 0;
   #draggedDistanceYForResize: number = 0;
+  #maxBlockSize: number = 0;
+  #maxInlineSize: number = 0;
   #minBlockSize: number = 0;
   #minInlineSize: number = 0;
 
@@ -134,7 +136,7 @@ export class ChPopover {
       setProperty(
         this.el,
         POPOVER_BLOCK_SIZE,
-        Math.max(newBlockSize, this.#minBlockSize)
+        forceCSSMinMax(newBlockSize, this.#minBlockSize, this.#maxBlockSize)
       );
     },
 
@@ -163,7 +165,7 @@ export class ChPopover {
       setProperty(
         this.el,
         POPOVER_INLINE_SIZE,
-        Math.max(newInlineSize, this.#minInlineSize)
+        forceCSSMinMax(newInlineSize, this.#minInlineSize, this.#maxInlineSize)
       );
     }
   } as const;
@@ -569,8 +571,10 @@ export class ChPopover {
     this.#draggedDistanceXForResize = this.#draggedDistanceX;
     this.#draggedDistanceYForResize = this.#draggedDistanceY;
 
-    // Get minimum sizes on first resize operation
+    // Get minimum and maximum sizes on first resize operation
     const computedStyle = getComputedStyle(this.el);
+    this.#maxBlockSize = fromPxToNumber(computedStyle.maxBlockSize);
+    this.#maxInlineSize = fromPxToNumber(computedStyle.maxInlineSize);
     this.#minBlockSize = fromPxToNumber(computedStyle.minBlockSize);
     this.#minInlineSize = fromPxToNumber(computedStyle.minInlineSize);
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -147,10 +147,28 @@ export class ChPopover {
       let currentDraggedDistanceY =
         this.#lastDragEvent.clientY - this.#initialDragEvent.clientY;
 
+      // Start direction inverts the increment
+      if (direction === "start") {
+        currentDraggedDistanceY = -currentDraggedDistanceY;
+      }
+
+      const newBlockSize = popoverRect.height + currentDraggedDistanceY;
+      const newRestrictedBlockSize = forceCSSMinMax(
+        newBlockSize,
+        this.#minBlockSize,
+        this.#maxBlockSize
+      );
+
+      // Do not apply resizes or translations if the control is at the minimum
+      // or maximum size
+      if (newRestrictedBlockSize === popoverRect.height) {
+        return;
+      }
+
+      // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
       // By resizing the start edge the control is translated to improve the UX
       if (direction === "start") {
-        this.#draggedDistanceYForResize += currentDraggedDistanceY;
-        currentDraggedDistanceY = -currentDraggedDistanceY;
+        this.#draggedDistanceYForResize -= currentDraggedDistanceY;
 
         setProperty(
           this.el,
@@ -159,13 +177,7 @@ export class ChPopover {
         );
       }
 
-      // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
-      const newBlockSize = popoverRect.height + currentDraggedDistanceY;
-      setProperty(
-        this.el,
-        POPOVER_BLOCK_SIZE,
-        forceCSSMinMax(newBlockSize, this.#minBlockSize, this.#maxBlockSize)
-      );
+      setProperty(this.el, POPOVER_BLOCK_SIZE, newRestrictedBlockSize);
     },
 
     inline: (popoverRect: DOMRect, direction: "start" | "end") => {
@@ -176,10 +188,28 @@ export class ChPopover {
         currentDraggedDistanceX = -currentDraggedDistanceX;
       }
 
+      // Start direction inverts the increment
+      if (direction === "start") {
+        currentDraggedDistanceX = -currentDraggedDistanceX;
+      }
+
+      const newInlineSize = popoverRect.width + currentDraggedDistanceX;
+      const newRestrictedInlineSize = forceCSSMinMax(
+        newInlineSize,
+        this.#minInlineSize,
+        this.#maxInlineSize
+      );
+
+      // Do not apply resizes or translations if the control is at the minimum
+      // or maximum size
+      if (newRestrictedInlineSize === popoverRect.width) {
+        return;
+      }
+
+      // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
       // By resizing the start edge the control is translated to improve the UX
       if (direction === "start") {
-        this.#draggedDistanceXForResize += currentDraggedDistanceX;
-        currentDraggedDistanceX = -currentDraggedDistanceX;
+        this.#draggedDistanceXForResize -= currentDraggedDistanceX;
 
         setProperty(
           this.el,
@@ -188,13 +218,7 @@ export class ChPopover {
         );
       }
 
-      // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
-      const newInlineSize = popoverRect.width + currentDraggedDistanceX;
-      setProperty(
-        this.el,
-        POPOVER_INLINE_SIZE,
-        forceCSSMinMax(newInlineSize, this.#minInlineSize, this.#maxInlineSize)
-      );
+      setProperty(this.el, POPOVER_INLINE_SIZE, newRestrictedInlineSize);
     }
   } as const;
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -253,7 +253,7 @@ export class ChPopover {
   /**
    * `true` if the control is not stacked with another top layer.
    */
-  @Prop() readonly firstLayer: boolean;
+  @Prop() readonly firstLayer: boolean = true;
 
   /**
    * Specifies whether the popover is hidden or visible.

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -109,6 +109,8 @@ export class ChPopover {
   #currentEdge: ChPopoverResizeElement;
   #draggedDistanceXForResize: number = 0;
   #draggedDistanceYForResize: number = 0;
+  #minBlockSize: number = 0;
+  #minInlineSize: number = 0;
 
   #resizeByDirectionDictionary = {
     block: (popoverRect: DOMRect, direction: "start" | "end") => {
@@ -129,7 +131,11 @@ export class ChPopover {
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
-      setProperty(this.el, POPOVER_BLOCK_SIZE, Math.max(newBlockSize, 0));
+      setProperty(
+        this.el,
+        POPOVER_BLOCK_SIZE,
+        Math.max(newBlockSize, this.#minBlockSize)
+      );
     },
 
     inline: (popoverRect: DOMRect, direction: "start" | "end") => {
@@ -154,7 +160,11 @@ export class ChPopover {
 
       // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
-      setProperty(this.el, POPOVER_INLINE_SIZE, Math.max(newInlineSize, 0));
+      setProperty(
+        this.el,
+        POPOVER_INLINE_SIZE,
+        Math.max(newInlineSize, this.#minInlineSize)
+      );
     }
   } as const;
 
@@ -558,6 +568,11 @@ export class ChPopover {
     // position, even when the block-start or inline-start edges are resized
     this.#draggedDistanceXForResize = this.#draggedDistanceX;
     this.#draggedDistanceYForResize = this.#draggedDistanceY;
+
+    // Get minimum sizes on first resize operation
+    const computedStyle = getComputedStyle(this.el);
+    this.#minBlockSize = fromPxToNumber(computedStyle.minBlockSize);
+    this.#minInlineSize = fromPxToNumber(computedStyle.minInlineSize);
 
     // Avoid repositioning the popover
     this.#removePositionWatcher();

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -155,7 +155,7 @@ export class ChPopover {
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
       setProperty(this.el, POPOVER_INLINE_SIZE, newInlineSize);
     }
-  };
+  } as const;
 
   #resizeEdgesAndCornersDictionary: {
     [key in ChPopoverResizeElement]: (popoverRect: DOMRect) => void;

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -45,6 +45,7 @@ const POPOVER_BORDER_INLINE_START_SIZE =
   "--ch-popover-border-inline-start-width";
 const POPOVER_BORDER_INLINE_END_SIZE = "--ch-popover-border-inline-end-width";
 
+const POPOVER_RTL_CLASS = "ch-popover-rtl";
 const POPOVER_RTL = "--ch-popover-rtl";
 const POPOVER_RTL_VALUE = "-1";
 
@@ -129,8 +130,12 @@ export class ChPopover {
     },
 
     "inline-start": popoverRect => {
-      const currentDraggedDistanceX =
+      let currentDraggedDistanceX =
         this.#initialDragEvent.clientX - this.#lastDragEvent.clientX;
+
+      if (this.#isRTLDirection) {
+        currentDraggedDistanceX = -currentDraggedDistanceX;
+      }
 
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
 
@@ -139,8 +144,12 @@ export class ChPopover {
     },
 
     "inline-end": popoverRect => {
-      const currentDraggedDistanceX =
+      let currentDraggedDistanceX =
         this.#lastDragEvent.clientX - this.#initialDragEvent.clientX;
+
+      if (this.#isRTLDirection) {
+        currentDraggedDistanceX = -currentDraggedDistanceX;
+      }
 
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
 
@@ -151,8 +160,12 @@ export class ChPopover {
     "block-start-inline-start": popoverRect => {
       const currentDraggedDistanceY =
         this.#initialDragEvent.clientY - this.#lastDragEvent.clientY;
-      const currentDraggedDistanceX =
+      let currentDraggedDistanceX =
         this.#initialDragEvent.clientX - this.#lastDragEvent.clientX;
+
+      if (this.#isRTLDirection) {
+        currentDraggedDistanceX = -currentDraggedDistanceX;
+      }
 
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
@@ -165,8 +178,12 @@ export class ChPopover {
     "block-start-inline-end": popoverRect => {
       const currentDraggedDistanceY =
         this.#initialDragEvent.clientY - this.#lastDragEvent.clientY;
-      const currentDraggedDistanceX =
+      let currentDraggedDistanceX =
         this.#lastDragEvent.clientX - this.#initialDragEvent.clientX;
+
+      if (this.#isRTLDirection) {
+        currentDraggedDistanceX = -currentDraggedDistanceX;
+      }
 
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
@@ -179,8 +196,12 @@ export class ChPopover {
     "block-end-inline-start": popoverRect => {
       const currentDraggedDistanceY =
         this.#lastDragEvent.clientY - this.#initialDragEvent.clientY;
-      const currentDraggedDistanceX =
+      let currentDraggedDistanceX =
         this.#initialDragEvent.clientX - this.#lastDragEvent.clientX;
+
+      if (this.#isRTLDirection) {
+        currentDraggedDistanceX = -currentDraggedDistanceX;
+      }
 
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
@@ -193,8 +214,12 @@ export class ChPopover {
     "block-end-inline-end": popoverRect => {
       const currentDraggedDistanceY =
         this.#lastDragEvent.clientY - this.#initialDragEvent.clientY;
-      const currentDraggedDistanceX =
+      let currentDraggedDistanceX =
         this.#lastDragEvent.clientX - this.#initialDragEvent.clientX;
+
+      if (this.#isRTLDirection) {
+        currentDraggedDistanceX = -currentDraggedDistanceX;
+      }
 
       const newInlineSize = popoverRect.width + currentDraggedDistanceX;
       const newBlockSize = popoverRect.height + currentDraggedDistanceY;
@@ -700,8 +725,10 @@ export class ChPopover {
 
       if (this.#isRTLDirection) {
         this.el.style.setProperty(POPOVER_RTL, POPOVER_RTL_VALUE);
+        this.el.classList.add(POPOVER_RTL_CLASS);
       } else {
         this.el.style.removeProperty(POPOVER_RTL);
+        this.el.classList.remove(POPOVER_RTL_CLASS);
       }
     });
 

--- a/src/components/popover/readme.md
+++ b/src/components/popover/readme.md
@@ -1,9 +1,6 @@
 # ch-popover
 
-
-
 <!-- Auto Generated Below -->
-
 
 ## Overview
 
@@ -18,12 +15,12 @@ relative to an element, but placed on the top layer using `position: fixed`.
 | `actionElement`       | --                     | Specifies a reference of the action that controls the popover control.                                                                                                                                                                                                                                       | `HTMLButtonElement \| HTMLInputElement`                                          | `undefined` |
 | `allowDrag`           | `allow-drag`           | Specifies the drag behavior of the popover. If `allowDrag === "header"`, a slot with the `"header"` name will be available to place the header content.                                                                                                                                                      | `"box" \| "header" \| "no"`                                                      | `"no"`      |
 | `blockAlign`          | `block-align`          | Specifies the block alignment of the window.                                                                                                                                                                                                                                                                 | `"center" \| "inside-end" \| "inside-start" \| "outside-end" \| "outside-start"` | `"center"`  |
-| `firstLayer`          | `first-layer`          | `true` if the control is not stacked with another top layer.                                                                                                                                                                                                                                                 | `boolean`                                                                        | `undefined` |
+| `firstLayer`          | `first-layer`          | `true` if the control is not stacked with another top layer.                                                                                                                                                                                                                                                 | `boolean`                                                                        | `true`      |
 | `hidden`              | `hidden`               | Specifies whether the popover is hidden or visible.                                                                                                                                                                                                                                                          | `boolean`                                                                        | `true`      |
 | `inlineAlign`         | `inline-align`         | Specifies the inline alignment of the window.                                                                                                                                                                                                                                                                | `"center" \| "inside-end" \| "inside-start" \| "outside-end" \| "outside-start"` | `"center"`  |
 | `mode`                | `mode`                 | Popovers that have the `"auto"` state can be "light dismissed" by selecting outside the popover area, and generally only allow one popover to be displayed on-screen at a time. By contrast, `"manual"` popovers must always be explicitly hidden, but allow for use cases such as nested popovers in menus. | `"auto" \| "manual"`                                                             | `"auto"`    |
+| `resizable`           | `resizable`            | Specifies whether the control can be resized. If `true` the control can be resized at runtime by dragging the edges or corners.                                                                                                                                                                              | `boolean`                                                                        | `false`     |
 | `responsiveAlignment` | `responsive-alignment` | Specifies if the popover is automatically aligned is the content overflow the window.                                                                                                                                                                                                                        | `boolean`                                                                        | `true`      |
-
 
 ## Events
 
@@ -32,35 +29,41 @@ relative to an element, but placed on the top layer using `position: fixed`.
 | `popoverClosed` | Emitted when the popover is closed. | `CustomEvent<any>` |
 | `popoverOpened` | Emitted when the popover is opened. | `CustomEvent<any>` |
 
-
 ## Shadow Parts
 
 | Part       | Description |
 | ---------- | ----------- |
 | `"header"` |             |
 
-
 ## CSS Custom Properties
 
-| Name                        | Description                                                                         |
-| --------------------------- | ----------------------------------------------------------------------------------- |
-| `--ch-popover-separation-x` | Specifies the separation between the action and popover in the x axis. @default 0px |
-| `--ch-popover-separation-y` | Specifies the separation between the action and popover in the y axis. @default 0px |
-
+| Name                            | Description                                                                                                          |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `--ch-popover-block-size`       | Specifies the block size of the popover. Useful for scenarios where the popover is resizable. @default max-content   |
+| `--ch-popover-inline-size`      | Specifies the inline size of the popover. Useful for scenarios where the popover is resizable. @default max-content  |
+| `--ch-popover-max-block-size`   | Specifies the maximum block size of the popover. Useful for scenarios where the popover is resizable. @default auto  |
+| `--ch-popover-max-inline-size`  | Specifies the maximum inline size of the popover. Useful for scenarios where the popover is resizable. @default auto |
+| `--ch-popover-min-block-size`   | Specifies the minimum block size of the popover. Useful for scenarios where the popover is resizable. @default auto  |
+| `--ch-popover-min-inline-size`  | Specifies the minimum inline size of the popover. Useful for scenarios where the popover is resizable. @default auto |
+| `--ch-popover-resize-threshold` | Specifies the size of the threshold to resize the popover. @default 4px                                              |
+| `--ch-popover-separation-x`     | Specifies the separation between the action and popover in the x axis. @default 0px                                  |
+| `--ch-popover-separation-y`     | Specifies the separation between the action and popover in the y axis. @default 0px                                  |
 
 ## Dependencies
 
 ### Used by
 
- - [ch-dropdown](../dropdown)
+- [ch-dropdown](../dropdown)
 
 ### Graph
+
 ```mermaid
 graph TD;
   ch-dropdown --> ch-popover
   style ch-popover fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_
+

--- a/src/components/popover/types.ts
+++ b/src/components/popover/types.ts
@@ -6,3 +6,13 @@ export type ChPopoverAlign =
   | "center"
   | "inside-end"
   | "outside-end";
+
+export type ChPopoverResizeElement =
+  | "block-start" // Top
+  | "inline-end" // Right
+  | "block-end" // Bottom
+  | "inline-start" // Left
+  | "block-start-inline-start" // Top Left
+  | "block-start-inline-end" // Top Right
+  | "block-end-inline-start" // Bottom Left
+  | "block-end-inline-end"; // Bottom Right

--- a/src/showcase/pages/popover.html
+++ b/src/showcase/pages/popover.html
@@ -38,6 +38,7 @@
       ch-popover {
         background-color: aliceblue;
         box-shadow: 0 0 1px 2px rgb(0, 0, 0, 0.2);
+        border: 10px solid black;
       }
 
       #action1,
@@ -142,6 +143,14 @@
             </label>
 
             <ch-checkbox
+              id="resizable"
+              checked-value="true"
+              un-checked-value="false"
+              value="false"
+              caption="Resizable"
+            ></ch-checkbox>
+
+            <ch-checkbox
               id="popover-1-visible"
               checked-value="true"
               un-checked-value="false"
@@ -222,6 +231,7 @@
         const actionElement2 = document.querySelector("#action2");
         const popoverElement1 = document.querySelector("#popover1");
         const popoverElement2 = document.querySelector("#popover2");
+        const checkboxResizable = document.querySelector("#resizable");
         const checkboxVisible1 = document.querySelector("#popover-1-visible");
         const checkboxVisible2 = document.querySelector("#popover-2-visible");
 
@@ -270,6 +280,10 @@
           checkboxVisible2.value = false;
         });
 
+        checkboxResizable.addEventListener("input", event => {
+          popoverElement1.resizable = event.target.checked;
+          popoverElement2.resizable = event.target.checked;
+        });
         checkboxVisible1.addEventListener("input", event => {
           popoverElement1.hidden = !event.target.checked;
         });

--- a/src/showcase/pages/popover.html
+++ b/src/showcase/pages/popover.html
@@ -43,9 +43,13 @@
 
       #action1,
       #action2 {
+        display: inline-flex;
+        justify-content: center;
         width: 120px;
         height: 60px;
         margin: auto 80px;
+        border: 1px solid;
+        text-align: center;
       }
 
       .scroll-container {


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fixes:
   - Fix initial flickering.

 - Features:
   - Added support for resizing the `ch-popover` control.
     - Supports resizing from every edge and corner.
     - Supports RTL.
     - It works well with dragging and positioning operations.

   - Added support for block and inline initial sizes.

   - Added support for block and inline minimum sizes.

   - Added support for block and inline maximum sizes.

