### PR TITLE
Fix browser crash when expandable items are off screen

### DIFF
--- a/src/components/tree-view/tree-view-item/tree-view-item.scss
+++ b/src/components/tree-view/tree-view-item/tree-view-item.scss
@@ -85,8 +85,6 @@
   block-size: var(--ch-tree-view-item__expandable-button-size);
   z-index: 1;
   cursor: pointer;
-  content-visibility: auto;
-  contain-intrinsic-size: auto var(--ch-tree-view-item__expandable-button-size);
 }
 
 .expandable-button {


### PR DESCRIPTION
When using the tree view with the Gemini's `gxg-tab` control, in some scenarios where the `ch-tree-view-render` has an expandable item that is off-screen, the browser would crash if the item or the tree view is detached from the DOM.

One of the reasons this happens is that the container for the expandable button has `display: flex` and the expandable button has `content-visibility: auto`. Removing the content-visibility property fixes this issue.

This issue does not occur if the container has `display: grid`, for example the `.header` has `display: grid` where its image has `content-visibility: auto`.