### PR TITLE
[ch-grid] Add property keyboardNavigationMode

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -536,6 +536,10 @@ export namespace Components {
          */
         "expandRow": (rowId: string) => Promise<void>;
         /**
+          * Retrieves information about the currently focused cell.
+         */
+        "getFocusedCell": () => Promise<{ cellId: string; rowId: string; columnId: string; }>;
+        /**
           * Retrieves the rowId of the currently focused row.
          */
         "getFocusedRow": () => Promise<string>;
@@ -571,6 +575,10 @@ export namespace Components {
           * Retrieves the list of rowId of the selected rows.
          */
         "getSelectedRows": () => Promise<string[]>;
+        /**
+          * Specifies the keyboard navigation mode for the component. - "none": Disables keyboard navigation for the grid rows. - "select": Allows keyboard navigation by changing the selection of grid rows. - "focus": Allows keyboard navigation by focusing on grid rows, but does not change the selection.
+         */
+        "keyboardNavigationMode": "none" | "select" | "focus";
         /**
           * An object that contains localized strings for the grid.
          */
@@ -634,6 +642,10 @@ export namespace Components {
           * @param selected - A boolean indicating whether to select or deselect the row.
          */
         "selectRow": (rowId: string, selected?: boolean) => Promise<void>;
+        /**
+          * Synchronizes the state of a row in the grid.
+         */
+        "syncRowState": (el: HTMLElement) => Promise<void>;
     }
     /**
      * The `ch-grid-action-refresh` component represents a refresh button for a grid action bar.
@@ -3938,6 +3950,10 @@ declare namespace LocalJSX {
           * One of "single" or "splitter", indicating the behavior of column resizing. "single", resize a single column at a time. "splitter", when adjusts the width of one column, the neighboring columns    are also resized proportionally, maintaining the overall width.
          */
         "columnResizeMode"?: "single" | "splitter";
+        /**
+          * Specifies the keyboard navigation mode for the component. - "none": Disables keyboard navigation for the grid rows. - "select": Allows keyboard navigation by changing the selection of grid rows. - "focus": Allows keyboard navigation by focusing on grid rows, but does not change the selection.
+         */
+        "keyboardNavigationMode"?: "none" | "select" | "focus";
         /**
           * An object that contains localized strings for the grid.
          */

--- a/src/components/grid/ch-grid-manager-selection.ts
+++ b/src/components/grid/ch-grid-manager-selection.ts
@@ -5,6 +5,7 @@ import { ChGridManager } from "./ch-grid-manager";
 export type ManagerSelectionState = {
   rowFocused: HTMLChGridRowElement;
   rowsSelected: HTMLChGridRowElement[];
+  cellFocused: HTMLChGridCellElement;
   cellSelected: HTMLChGridCellElement;
 };
 
@@ -16,7 +17,12 @@ export class ChGridManagerSelection {
   private selectionStateNone: ManagerSelectionState = {
     rowFocused: null,
     rowsSelected: [],
+    cellFocused: null,
     cellSelected: null
+  };
+  private touch: {
+    clientX: number;
+    clientY: number;
   };
 
   selecting: boolean;
@@ -27,26 +33,52 @@ export class ChGridManagerSelection {
     this.manager = manager;
   }
 
+  touchStart(touchEvent: TouchEvent) {
+    this.touch = {
+      clientX: touchEvent.touches[0].clientX,
+      clientY: touchEvent.touches[0].clientY
+    };
+  }
+
+  isTouchEndSelection(touchEvent: TouchEvent): boolean {
+    return (
+      Math.abs(this.touch.clientX - touchEvent.changedTouches[0].clientX) <
+        10 &&
+      Math.abs(this.touch.clientY - touchEvent.changedTouches[0].clientY) <
+        10 &&
+      touchEvent.cancelable
+    );
+  }
+
   select(
     state: ManagerSelectionState,
     row: HTMLChGridRowElement,
     cell: HTMLChGridCellElement,
+    select: boolean,
     append: boolean,
     range: boolean,
     context: boolean
   ): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
+    const grid = this.manager.grid;
+
+    if (
+      grid.keyboardNavigationMode === "none" &&
+      grid.rowSelectionMode === "none"
+    ) {
       return this.selectionStateNone;
-    } else if (this.manager.grid.rowSelectionMode !== "multiple") {
+    }
+    if (grid.rowSelectionMode === "none") {
+      select = false;
+    }
+    if (grid.rowSelectionMode !== "multiple") {
       append = false;
       range = false;
     }
 
-    let rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
+    let { rowFocused, rowsSelected, cellFocused, cellSelected } = state;
 
     rowFocused = row;
+    cellFocused = cell;
     if (range) {
       const rangeRows = this.manager.getRowsRange(this.rangeStart ?? row, row);
 
@@ -54,8 +86,10 @@ export class ChGridManagerSelection {
         if (append) {
           rowsSelected = Array.from(new Set(rowsSelected.concat(rangeRows)));
         } else {
-          rowsSelected =
-            rowsSelected.length === rangeRows.length ? rowsSelected : rangeRows;
+          rowsSelected = this.preserveInstanceIfSame(
+            rangeRows,
+            state.rowsSelected
+          );
         }
         cellSelected =
           cell ||
@@ -72,7 +106,7 @@ export class ChGridManagerSelection {
 
       if (rowsSelected.includes(row)) {
         rowsSelected = rowsSelected.filter(rowSelected => rowSelected !== row);
-        cellSelected = null;
+        cellSelected = state.cellSelected?.row === row ? null : cellSelected;
       } else {
         rowsSelected = [...rowsSelected, row];
         cellSelected =
@@ -83,18 +117,17 @@ export class ChGridManagerSelection {
       this.rangeStart = row;
       this.rangeValue = true;
 
-      if (
-        !(rowsSelected.length === 1 && rowsSelected[0] === row) &&
-        !(context && rowsSelected.includes(row))
-      ) {
-        rowsSelected = [row];
+      if (select) {
+        if (!(context && state.rowsSelected.includes(row))) {
+          rowsSelected = this.preserveInstanceIfSame([row], state.rowsSelected);
+        }
+        cellSelected =
+          cell ||
+          row.getCell(cellSelected?.column || this.manager.getFirstColumn());
       }
-      cellSelected =
-        cell ||
-        row.getCell(cellSelected?.column || this.manager.getFirstColumn());
     }
 
-    return { rowFocused, rowsSelected, cellSelected };
+    return { rowFocused, rowsSelected, cellFocused, cellSelected };
   }
 
   selectAll(state: ManagerSelectionState, value = true): ManagerSelectionState {
@@ -105,21 +138,23 @@ export class ChGridManagerSelection {
     const rows = this.manager.getRows();
     let rowFocused = state.rowFocused;
     let rowsSelected = state.rowsSelected;
+    let cellFocused = state.cellFocused;
     let cellSelected = state.cellSelected;
 
+    rowFocused ??= this.manager.getFirstRow();
+    cellFocused ??= rowFocused.getCell(
+      state.cellFocused?.column || this.manager.getFirstColumn()
+    );
+
     if (value) {
-      rowFocused = rowFocused ?? this.manager.getFirstRow();
       rowsSelected = rows;
-      cellSelected = rowFocused.getCell(
-        state.cellSelected?.column || this.manager.getFirstColumn()
-      );
+      cellSelected = cellFocused;
     } else {
-      rowFocused = rowFocused ?? this.manager.getFirstRow();
       rowsSelected = [];
       cellSelected = null;
     }
 
-    return { rowFocused, rowsSelected, cellSelected };
+    return { rowFocused, rowsSelected, cellFocused, cellSelected };
   }
 
   selectSet(
@@ -132,15 +167,18 @@ export class ChGridManagerSelection {
 
     if (this.manager.grid.rowSelectionMode === "none") {
       return this.selectionStateNone;
-    } else if (this.manager.grid.rowSelectionMode !== "multiple") {
+    }
+    if (this.manager.grid.rowSelectionMode !== "multiple") {
       append = false;
     }
 
     let rowFocused = state.rowFocused;
     let rowsSelected = state.rowsSelected;
+    let cellFocused = state.cellFocused;
     let cellSelected = state.cellSelected;
 
     rowFocused = row;
+    cellFocused = cell;
     if (value) {
       if (append) {
         rowsSelected = rowsSelected.includes(row)
@@ -157,296 +195,189 @@ export class ChGridManagerSelection {
       cellSelected = null;
     }
 
-    return { rowFocused, rowsSelected, cellSelected };
+    return { rowFocused, rowsSelected, cellFocused, cellSelected };
   }
 
-  selectFirstRow(
+  moveFirstRow(
     state: ManagerSelectionState,
+    select: boolean,
+    range: boolean,
     append: boolean
   ): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
-      return this.selectionStateNone;
-    } else if (this.manager.grid.rowSelectionMode !== "multiple") {
-      append = false;
-    }
-
     const firstRow = this.manager.getFirstRow();
-    let rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
 
     if (firstRow) {
-      if (append) {
-        const rangeRows = this.manager.getRowsRange(
-          rowFocused ?? firstRow,
-          firstRow
-        );
-        rowsSelected = Array.from(new Set(rowsSelected.concat(rangeRows)));
-      } else {
-        rowsSelected = [firstRow];
-      }
-      rowFocused = firstRow;
-      cellSelected = firstRow.getCell(
-        state.cellSelected?.column || this.manager.getFirstColumn()
+      return this.select(
+        state,
+        firstRow,
+        firstRow.getCell(state.cellFocused.column),
+        select,
+        append,
+        range,
+        false
       );
     }
-
-    return { rowFocused, rowsSelected, cellSelected };
+    return state;
   }
 
-  selectPreviousRow(
+  movePreviousRow(
     state: ManagerSelectionState,
+    select: boolean,
+    range: boolean,
     append: boolean
   ): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
-      return this.selectionStateNone;
-    } else if (this.manager.grid.rowSelectionMode !== "multiple") {
-      append = false;
-    }
-
     const previousRow = this.manager.getPreviousRow(state.rowFocused);
-    let rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
 
     if (previousRow) {
-      if (append) {
-        const sortedRowsSelected = this.sortRowsSelected(rowsSelected);
-        const isContiguousSelection =
-          this.isContiguousSelection(sortedRowsSelected);
-
-        if (isContiguousSelection && rowFocused === sortedRowsSelected[0]) {
-          rowsSelected = [...rowsSelected, previousRow];
-        } else if (
-          isContiguousSelection &&
-          rowFocused === sortedRowsSelected[sortedRowsSelected.length - 1]
-        ) {
-          rowsSelected = rowsSelected.slice(0, -1);
-        } else {
-          rowsSelected = [rowFocused, previousRow];
-        }
-      } else {
-        rowsSelected = [previousRow];
-      }
-      rowFocused = previousRow;
-      cellSelected = previousRow.getCell(
-        cellSelected?.column || this.manager.getFirstColumn()
+      return this.select(
+        state,
+        previousRow,
+        previousRow.getCell(state.cellFocused.column),
+        select,
+        append,
+        range,
+        false
       );
     }
-
-    return { rowFocused, rowsSelected, cellSelected };
+    return state;
   }
 
-  selectNextRow(
+  moveNextRow(
     state: ManagerSelectionState,
+    select: boolean,
+    range: boolean,
     append: boolean
   ): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
-      return this.selectionStateNone;
-    } else if (this.manager.grid.rowSelectionMode !== "multiple") {
-      append = false;
-    }
-
     const nextRow = this.manager.getNextRow(state.rowFocused);
-    let rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
 
     if (nextRow) {
-      if (append) {
-        const sortedRowsSelected = this.sortRowsSelected(rowsSelected);
-        const isContiguousSelection =
-          this.isContiguousSelection(sortedRowsSelected);
-
-        if (
-          isContiguousSelection &&
-          rowFocused === sortedRowsSelected[sortedRowsSelected.length - 1]
-        ) {
-          rowsSelected = [...rowsSelected, nextRow];
-        } else if (
-          isContiguousSelection &&
-          rowFocused === sortedRowsSelected[0]
-        ) {
-          rowsSelected = rowsSelected.slice(1);
-        } else {
-          rowsSelected = [rowFocused, nextRow];
-        }
-      } else {
-        rowsSelected = [nextRow];
-      }
-      rowFocused = nextRow;
-      cellSelected = nextRow.getCell(
-        cellSelected?.column || this.manager.getFirstColumn()
+      return this.select(
+        state,
+        nextRow,
+        nextRow.getCell(state.cellFocused.column),
+        select,
+        append,
+        range,
+        false
       );
     }
-
-    return { rowFocused, rowsSelected, cellSelected };
+    return state;
   }
 
-  selectLastRow(
+  moveLastRow(
     state: ManagerSelectionState,
+    select: boolean,
+    range: boolean,
     append: boolean
   ): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
-      return this.selectionStateNone;
-    } else if (this.manager.grid.rowSelectionMode !== "multiple") {
-      append = false;
-    }
+    const lastRow = this.manager.getLastRow();
 
-    const firstRow = this.manager.getLastRow();
-    let rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
-
-    if (firstRow) {
-      if (append) {
-        const rangeRows = this.manager.getRowsRange(
-          rowFocused ?? firstRow,
-          firstRow
-        );
-        rowsSelected = Array.from(new Set(rowsSelected.concat(rangeRows)));
-      } else {
-        rowsSelected = [firstRow];
-      }
-      rowFocused = firstRow;
-      cellSelected = firstRow.getCell(
-        state.cellSelected?.column || this.manager.getFirstColumn()
+    if (lastRow) {
+      return this.select(
+        state,
+        lastRow,
+        lastRow.getCell(state.cellFocused.column),
+        select,
+        append,
+        range,
+        false
       );
     }
-
-    return { rowFocused, rowsSelected, cellSelected };
+    return state;
   }
 
-  selectPreviousPageRow(
+  movePreviousPageRow(
     state: ManagerSelectionState,
+    select: boolean,
+    range: boolean,
     append: boolean
   ): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
-      return this.selectionStateNone;
-    } else if (this.manager.grid.rowSelectionMode !== "multiple") {
-      append = false;
-    }
-
     const rows = this.manager.getRows();
     const rowsPerPage = this.manager.getRowsPerPage();
-    let rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
-
     const previousPageRow =
-      rows[Math.max(rows.indexOf(rowFocused) - rowsPerPage, 0)];
+      rows[Math.max(rows.indexOf(state.rowFocused) - rowsPerPage, 0)];
+
     if (previousPageRow) {
-      if (append) {
-        const rangeRows = this.manager.getRowsRange(
-          rowFocused ?? previousPageRow,
-          previousPageRow
-        );
-        rowsSelected = Array.from(new Set(rowsSelected.concat(rangeRows)));
-      } else {
-        rowsSelected =
-          rowsSelected.length === 1 && rowsSelected[0] === previousPageRow
-            ? rowsSelected
-            : [previousPageRow];
-      }
-      rowFocused = previousPageRow;
-      cellSelected = previousPageRow.getCell(
-        state.cellSelected?.column || this.manager.getFirstColumn()
+      return this.select(
+        state,
+        previousPageRow,
+        previousPageRow.getCell(state.cellFocused.column),
+        select,
+        append,
+        range,
+        false
       );
     }
-
-    return { rowFocused, rowsSelected, cellSelected };
+    return state;
   }
 
-  selectNextPageRow(
+  moveNextPageRow(
     state: ManagerSelectionState,
+    select: boolean,
+    range: boolean,
     append: boolean
   ): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
-      return this.selectionStateNone;
-    } else if (this.manager.grid.rowSelectionMode !== "multiple") {
-      append = false;
-    }
-
     const rows = this.manager.getRows();
     const rowsPerPage = this.manager.getRowsPerPage();
-    let rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
-
     const nextPageRow =
-      rows[Math.min(rows.indexOf(rowFocused) + rowsPerPage, rows.length - 1)];
+      rows[
+        Math.min(rows.indexOf(state.rowFocused) + rowsPerPage, rows.length - 1)
+      ];
+
     if (nextPageRow) {
-      if (append) {
-        const rangeRows = this.manager.getRowsRange(
-          rowFocused ?? nextPageRow,
-          nextPageRow
-        );
-        rowsSelected = Array.from(new Set(rowsSelected.concat(rangeRows)));
-      } else {
-        rowsSelected =
-          rowsSelected.length === 1 && rowsSelected[0] === nextPageRow
-            ? rowsSelected
-            : [nextPageRow];
-      }
-      rowFocused = nextPageRow;
-      cellSelected = nextPageRow.getCell(
-        state.cellSelected?.column || this.manager.getFirstColumn()
+      return this.select(
+        state,
+        nextPageRow,
+        nextPageRow.getCell(state.cellFocused.column),
+        select,
+        append,
+        range,
+        false
       );
     }
-
-    return { rowFocused, rowsSelected, cellSelected };
+    return state;
   }
 
-  selectPreviousCell(state: ManagerSelectionState): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
-      return this.selectionStateNone;
+  movePreviousCell(
+    state: ManagerSelectionState,
+    select: boolean,
+    range: boolean
+  ): ManagerSelectionState {
+    const previousCell = this.manager.getPreviousCell(state.cellFocused);
+
+    if (previousCell) {
+      return this.select(
+        state,
+        state.rowFocused,
+        previousCell,
+        select,
+        false,
+        range,
+        false
+      );
     }
-
-    const rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
-
-    if (cellSelected) {
-      const nextCell = this.manager.getPreviousCell(cellSelected);
-      if (nextCell) {
-        cellSelected = nextCell;
-      }
-    } else {
-      if (!rowsSelected.includes(rowFocused)) {
-        rowsSelected = [...rowsSelected, rowFocused];
-      }
-      if (!cellSelected) {
-        cellSelected = rowFocused.getCell(this.manager.getFirstColumn());
-      }
-    }
-
-    return { rowFocused, rowsSelected, cellSelected };
+    return state;
   }
 
-  selectNextCell(state: ManagerSelectionState): ManagerSelectionState {
-    if (this.manager.grid.rowSelectionMode === "none") {
-      return this.selectionStateNone;
+  moveNextCell(
+    state: ManagerSelectionState,
+    select: boolean,
+    range: boolean
+  ): ManagerSelectionState {
+    const nextCell = this.manager.getNextCell(state.cellFocused);
+
+    if (nextCell) {
+      return this.select(
+        state,
+        state.rowFocused,
+        nextCell,
+        select,
+        false,
+        range,
+        false
+      );
     }
-
-    const rowFocused = state.rowFocused;
-    let rowsSelected = state.rowsSelected;
-    let cellSelected = state.cellSelected;
-
-    if (cellSelected) {
-      const nextCell = this.manager.getNextCell(cellSelected);
-      if (nextCell) {
-        cellSelected = nextCell;
-      }
-    } else {
-      if (!rowsSelected.includes(rowFocused)) {
-        rowsSelected = [...rowsSelected, rowFocused];
-      }
-      if (!cellSelected) {
-        cellSelected = rowFocused.getCell(this.manager.getFirstColumn());
-      }
-    }
-
-    return { rowFocused, rowsSelected, cellSelected };
+    return state;
   }
 
   markRow(
@@ -466,29 +397,42 @@ export class ChGridManagerSelection {
           return currentRowsMarked.concat(
             rows.filter(row => !currentRowsMarked.includes(row))
           );
-        } else {
-          return currentRowsMarked.filter(row => !rows.includes(row));
         }
-      } else {
-        this.lastRowMarked = row;
+        return currentRowsMarked.filter(row => !rows.includes(row));
+      }
+      this.lastRowMarked = row;
 
-        if (checked && !currentRowsMarked.includes(row)) {
-          return currentRowsMarked.concat([row]);
-        } else if (!checked && currentRowsMarked.includes(row)) {
-          return currentRowsMarked.filter(r => r !== row);
-        }
+      if (checked && !currentRowsMarked.includes(row)) {
+        return currentRowsMarked.concat([row]);
+      }
+      if (!checked && currentRowsMarked.includes(row)) {
+        return currentRowsMarked.filter(r => r !== row);
       }
     }
 
     return currentRowsMarked;
   }
 
+  markRows(
+    rowFocused: HTMLChGridRowElement,
+    rowsMarked: HTMLChGridRowElement[],
+    rowsSelected: HTMLChGridRowElement[]
+  ): HTMLChGridRowElement[] {
+    const rows = rowsSelected.includes(rowFocused)
+      ? rowsSelected
+      : [rowFocused];
+
+    if (rows.some(row => !row.marked)) {
+      return Array.from(new Set(rowsMarked.concat(rows)));
+    }
+    return rowsMarked.filter(row => !rows.includes(row));
+  }
+
   markAllRows(value = true): HTMLChGridRowElement[] {
     if (value) {
       return this.manager.getRows();
-    } else {
-      return [];
     }
+    return [];
   }
 
   syncRowSelector(
@@ -517,55 +461,29 @@ export class ChGridManagerSelection {
         cell.setSelectorChecked(true);
       });
 
-      if (rows.length === 0) {
-        columnSelector.richRowSelectorState = "";
-      } else if (rows.length === this.manager.getRows().length) {
-        columnSelector.richRowSelectorState = "checked";
-      } else {
-        columnSelector.richRowSelectorState = "indeterminate";
-      }
+      this.syncColumnSelector(rows.length, columnSelector);
     }
   }
 
-  private sortRowsSelected(
-    rowsSelected: HTMLChGridRowElement[]
-  ): HTMLChGridRowElement[] {
-    const rows = Array.from(
-      this.manager.grid.querySelectorAll("ch-grid-row")
-    ) as HTMLChGridRowElement[];
+  syncColumnSelector(length: number, columnSelector?: HTMLChGridColumnElement) {
+    columnSelector ??= this.manager.columns.getColumnSelector();
 
-    return rowsSelected.sort((rowA, rowB) => {
-      const rowAIndex = rows.indexOf(rowA);
-      const rowBIndex = rows.indexOf(rowB);
-      if (rowAIndex < rowBIndex) {
-        return -1;
-      }
-      if (rowAIndex > rowBIndex) {
-        return 1;
-      }
-      return 0;
-    });
-  }
-
-  private isContiguousSelection(
-    sortedRowsSelected: HTMLChGridRowElement[]
-  ): boolean {
-    const rows = (
-      Array.from(
-        this.manager.grid.querySelectorAll("ch-grid-row")
-      ) as HTMLChGridRowElement[]
-    ).filter(row => row.isVisible());
-
-    if (sortedRowsSelected.length === 0) {
-      return false;
-    } else if (sortedRowsSelected.length === 1) {
-      return true;
+    if (length === 0) {
+      columnSelector.richRowSelectorState = "";
+    } else if (length === this.manager.getRows().length) {
+      columnSelector.richRowSelectorState = "checked";
     } else {
-      const startIndex = rows.indexOf(sortedRowsSelected[0]);
-      const endIndex = rows.indexOf(
-        sortedRowsSelected[sortedRowsSelected.length - 1]
-      );
-      return endIndex - startIndex + 1 === sortedRowsSelected.length;
+      columnSelector.richRowSelectorState = "indeterminate";
     }
+  }
+
+  private preserveInstanceIfSame(
+    newSelection: HTMLChGridRowElement[],
+    oldSelection: HTMLChGridRowElement[]
+  ): HTMLChGridRowElement[] {
+    return newSelection.length === oldSelection.length &&
+      newSelection.every(item => oldSelection.includes(item))
+      ? oldSelection
+      : newSelection;
   }
 }

--- a/src/components/grid/ch-grid-manager.ts
+++ b/src/components/grid/ch-grid-manager.ts
@@ -194,15 +194,8 @@ export class ChGridManager {
 
     if (state === "visible") {
       return rows.filter(row => row.isVisible());
-    } else {
-      return rows;
     }
-  }
-
-  getRowsSelected(): HTMLChGridRowElement[] {
-    return Array.from(
-      this.grid.querySelectorAll(`ch-grid-row[selected]`)
-    ) as HTMLChGridRowElement[];
+    return rows;
   }
 
   getRowsRange(
@@ -243,7 +236,8 @@ export class ChGridManager {
   ): HTMLChGridCellElement {
     if (cellId) {
       return this.grid.querySelector(`ch-grid-cell[cellid="${cellId}"]`);
-    } else if (rowId && columnId) {
+    }
+    if (rowId && columnId) {
       const row = this.getRow(rowId);
       const column = this.columns.getColumn(columnId);
 

--- a/src/components/grid/ch-grid-types.ts
+++ b/src/components/grid/ch-grid-types.ts
@@ -1,5 +1,8 @@
 export interface ChGridSelectionChangedEvent {
   rowsId: string[];
+  addedRowsId: string[];
+  removedRowsId: string[];
+  unalteredRowsId: string[];
 }
 
 export interface ChGridMarkingChangedEvent {

--- a/src/components/grid/grid-cell/ch-grid-cell.ts
+++ b/src/components/grid/grid-cell/ch-grid-cell.ts
@@ -52,12 +52,15 @@ export default class HTMLChGridCellElement extends HTMLElement {
       this.cellType = value as ChGridCellType;
     }
     if (name === "row-drag") {
+      this.cellType = ChGridCellType.Rich;
       this.rowDrag = value !== null ? value !== "false" : false;
     }
     if (name === "row-selector") {
+      this.cellType = ChGridCellType.Rich;
       this.rowSelector = value !== null ? value !== "false" : false;
     }
     if (name === "row-actions") {
+      this.cellType = ChGridCellType.Rich;
       this.rowActions = value !== null ? value !== "false" : false;
     }
   }
@@ -122,6 +125,21 @@ export default class HTMLChGridCellElement extends HTMLElement {
       this.setAttribute("selected", "");
     } else {
       this.removeAttribute("selected");
+    }
+  }
+
+  /**
+   * A boolean value indicating whether the cell is focused.
+   */
+  get focused(): boolean {
+    return this.hasAttribute("focused");
+  }
+
+  set focused(value: boolean) {
+    if (value === true) {
+      this.setAttribute("focused", "");
+    } else {
+      this.removeAttribute("focused");
     }
   }
 
@@ -280,6 +298,9 @@ export default class HTMLChGridCellElement extends HTMLElement {
         this.selector.addEventListener("mousedown", (eventInfo: MouseEvent) =>
           eventInfo.stopPropagation()
         );
+        this.selector.addEventListener("touchend", (eventInfo: TouchEvent) =>
+          eventInfo.stopPropagation()
+        );
         this.selector.addEventListener(
           "click",
           this.selectorClickHandler.bind(this)
@@ -290,6 +311,10 @@ export default class HTMLChGridCellElement extends HTMLElement {
         );
         this.selectorLabel.addEventListener(
           "mousedown",
+          (eventInfo: MouseEvent) => eventInfo.stopPropagation()
+        );
+        this.selectorLabel.addEventListener(
+          "touchend",
           (eventInfo: MouseEvent) => eventInfo.stopPropagation()
         );
         this.selectorLabel.addEventListener(

--- a/src/components/grid/grid-column/ch-grid-column.tsx
+++ b/src/components/grid/grid-column/ch-grid-column.tsx
@@ -372,6 +372,10 @@ export class ChGridColumn {
     eventInfo.stopPropagation();
   };
 
+  private selectorTouchEndHandler = (eventInfo: TouchEvent) => {
+    eventInfo.stopPropagation();
+  };
+
   render() {
     return (
       <Host>
@@ -416,6 +420,7 @@ export class ChGridColumn {
               .filter(part => part !== "")
               .join(" ")}
             onClick={this.selectorClickHandler}
+            onTouchEnd={this.selectorTouchEndHandler}
             checked={this.richRowSelectorState === "checked"}
             indeterminate={this.richRowSelectorState === "indeterminate"}
           />

--- a/src/components/grid/grid-row/ch-grid-row.ts
+++ b/src/components/grid/grid-row/ch-grid-row.ts
@@ -10,12 +10,31 @@ export default class HTMLChGridRowElement
 {
   private parentGrid: HTMLChGridElement;
 
+  static get observedAttributes() {
+    return ["selected", "marked"];
+  }
+
   constructor() {
     super();
   }
 
   connectedCallback() {
     this.addEventListener("cellCaretClicked", this.cellCaretClickedHandler);
+
+    if (this.selected || this.marked) {
+      this.grid.syncRowState(this);
+    }
+  }
+
+  attributeChangedCallback(name: string, _oldValue: string, value: string) {
+    if (name === "selected") {
+      this.selected = value !== null ? value !== "false" : false;
+    }
+    if (name === "marked") {
+      this.marked = value !== null ? value !== "false" : false;
+    }
+
+    this.grid?.syncRowState(this);
   }
 
   /**
@@ -66,7 +85,9 @@ export default class HTMLChGridRowElement
     const selectedClasses = this.grid.rowSelectedClass?.split(" ");
 
     if (value === true) {
-      this.setAttribute("selected", "");
+      if (!this.hasAttribute("selected")) {
+        this.setAttribute("selected", "");
+      }
       if (this.grid.rowSelectedClass) {
         this.classList.add(...selectedClasses);
       }
@@ -89,7 +110,9 @@ export default class HTMLChGridRowElement
     const markedClasses = this.grid.rowMarkedClass?.split(" ");
 
     if (value === true) {
-      this.setAttribute("marked", "");
+      if (!this.hasAttribute("marked")) {
+        this.setAttribute("marked", "");
+      }
       if (this.grid.rowMarkedClass) {
         this.classList.add(...markedClasses);
       }

--- a/src/components/grid/readme.md
+++ b/src/components/grid/readme.md
@@ -9,17 +9,18 @@ The `ch-grid` component represents a Grid/TreeGrid of data, with rows and cells.
 
 ## Properties
 
-| Property              | Attribute               | Description                                                                                                                                                                                                                                                         | Type                               | Default     |
-| --------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- |
-| `allowColumnReorder`  | `allow-column-reorder`  | A boolean indicating whether the user can drag column headers to reorder columns.                                                                                                                                                                                   | `boolean`                          | `true`      |
-| `columnResizeMode`    | `column-resize-mode`    | One of "single" or "splitter", indicating the behavior of column resizing. "single", resize a single column at a time. "splitter", when adjusts the width of one column, the neighboring columns    are also resized proportionally, maintaining the overall width. | `"single" \| "splitter"`           | `"single"`  |
-| `localization`        | --                      | An object that contains localized strings for the grid.                                                                                                                                                                                                             | `GridLocalization`                 | `undefined` |
-| `rowFocusedClass`     | `row-focused-class`     | A CSS class name applied to a row when it is focused.                                                                                                                                                                                                               | `string`                           | `undefined` |
-| `rowHighlightEnabled` | `row-highlight-enabled` | One of "false", "true" or "auto", indicating whether or not rows can be highlighted. "auto", row highlighting will be enabled if the row selection mode is set to "single" or "multiple".                                                                           | `"auto" \| boolean`                | `"auto"`    |
-| `rowHighlightedClass` | `row-highlighted-class` | A CSS class name applied to a row when it is hovered.                                                                                                                                                                                                               | `string`                           | `undefined` |
-| `rowMarkedClass`      | `row-marked-class`      | A CSS class name applied to a row when it is marked.                                                                                                                                                                                                                | `string`                           | `undefined` |
-| `rowSelectedClass`    | `row-selected-class`    | A CSS class name applied to a row when it is selected.                                                                                                                                                                                                              | `string`                           | `undefined` |
-| `rowSelectionMode`    | `row-selection-mode`    | One of "none", "single" or "multiple", indicating how rows can be selected. It can be set to "none" if no rows should be selectable, "single" if only one row can be selected at a time, or "multiple" if multiple rows can be selected at once.                    | `"multiple" \| "none" \| "single"` | `"single"`  |
+| Property                 | Attribute                  | Description                                                                                                                                                                                                                                                                                           | Type                               | Default     |
+| ------------------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- |
+| `allowColumnReorder`     | `allow-column-reorder`     | A boolean indicating whether the user can drag column headers to reorder columns.                                                                                                                                                                                                                     | `boolean`                          | `true`      |
+| `columnResizeMode`       | `column-resize-mode`       | One of "single" or "splitter", indicating the behavior of column resizing. "single", resize a single column at a time. "splitter", when adjusts the width of one column, the neighboring columns    are also resized proportionally, maintaining the overall width.                                   | `"single" \| "splitter"`           | `"single"`  |
+| `keyboardNavigationMode` | `keyboard-navigation-mode` | Specifies the keyboard navigation mode for the component. - "none": Disables keyboard navigation for the grid rows. - "select": Allows keyboard navigation by changing the selection of grid rows. - "focus": Allows keyboard navigation by focusing on grid rows, but does not change the selection. | `"focus" \| "none" \| "select"`    | `"select"`  |
+| `localization`           | --                         | An object that contains localized strings for the grid.                                                                                                                                                                                                                                               | `GridLocalization`                 | `undefined` |
+| `rowFocusedClass`        | `row-focused-class`        | A CSS class name applied to a row when it is focused.                                                                                                                                                                                                                                                 | `string`                           | `undefined` |
+| `rowHighlightEnabled`    | `row-highlight-enabled`    | One of "false", "true" or "auto", indicating whether or not rows can be highlighted. "auto", row highlighting will be enabled if the row selection mode is set to "single" or "multiple".                                                                                                             | `"auto" \| boolean`                | `"auto"`    |
+| `rowHighlightedClass`    | `row-highlighted-class`    | A CSS class name applied to a row when it is hovered.                                                                                                                                                                                                                                                 | `string`                           | `undefined` |
+| `rowMarkedClass`         | `row-marked-class`         | A CSS class name applied to a row when it is marked.                                                                                                                                                                                                                                                  | `string`                           | `undefined` |
+| `rowSelectedClass`       | `row-selected-class`       | A CSS class name applied to a row when it is selected.                                                                                                                                                                                                                                                | `string`                           | `undefined` |
+| `rowSelectionMode`       | `row-selection-mode`       | One of "none", "single" or "multiple", indicating how rows can be selected. It can be set to "none" if no rows should be selectable, "single" if only one row can be selected at a time, or "multiple" if multiple rows can be selected at once.                                                      | `"multiple" \| "none" \| "single"` | `"single"`  |
 
 
 ## Events
@@ -82,6 +83,16 @@ Expands a row, showing its children.
 #### Returns
 
 Type: `Promise<void>`
+
+
+
+### `getFocusedCell() => Promise<{ cellId: string; rowId: string; columnId: string; }>`
+
+Retrieves information about the currently focused cell.
+
+#### Returns
+
+Type: `Promise<{ cellId: string; rowId: string; columnId: string; }>`
 
 
 
@@ -271,6 +282,22 @@ Selects or deselects a row.
 | ---------- | --------- | ------------------------------------------------------------- |
 | `rowId`    | `string`  | - The rowId of the row to select or deselect.                 |
 | `selected` | `boolean` | - A boolean indicating whether to select or deselect the row. |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `syncRowState(el: HTMLElement) => Promise<void>`
+
+Synchronizes the state of a row in the grid.
+
+#### Parameters
+
+| Name | Type          | Description |
+| ---- | ------------- | ----------- |
+| `el` | `HTMLElement` |             |
 
 #### Returns
 

--- a/src/showcase/pages/assets/styles/grid.css
+++ b/src/showcase/pages/assets/styles/grid.css
@@ -1,18 +1,3 @@
-ch-grid::part(main)::-webkit-scrollbar {
-  width: 12px;
-  background-color: red;
-}
-
-ch-grid::part(main)::-webkit-scrollbar-track {
-  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-  border-radius: 10px;
-}
-
-ch-grid::part(main)::-webkit-scrollbar-thumb {
-  border-radius: 10px;
-  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
-}
-
 ch-grid:focus {
   border: none;
 }
@@ -56,6 +41,14 @@ ch-grid-row[selected] {
 }
 ch-grid-cell[selected] {
   background-color: gold;
+}
+
+ch-grid-cell {
+  color: black;
+}
+ch-grid-cell[focused] {
+  outline: 1px solid grey;
+  outline-offset: -1px;
 }
 
 ch-grid-cell::part(node-icon) {

--- a/src/showcase/pages/grid.html
+++ b/src/showcase/pages/grid.html
@@ -16,7 +16,7 @@
   <body>
     <div class="container">
       <section class="section-dev basic" data-title="basic">
-        <ch-grid row-selection-mode="none">
+        <ch-grid row-selection-mode="none" keyboard-navigation-mode="focus">
           <ch-grid-columnset>
             <ch-grid-column
               column-id="code"
@@ -212,9 +212,9 @@
 
       <section
         class="section-dev selection-simple"
-        data-title="selection-simple"
+        data-title="selection-simple | keyboard-focus"
       >
-        <ch-grid row-selection-mode="simple">
+        <ch-grid row-selection-mode="simple" keyboard-navigation-mode="focus">
           <ch-grid-columnset>
             <ch-grid-column
               column-id="code"
@@ -296,10 +296,95 @@
       </section>
 
       <section
+      class="section-dev selection-simple"
+      data-title="selection-simple | keyboard-select"
+    >
+      <ch-grid row-selection-mode="simple" keyboard-navigation-mode="select">
+        <ch-grid-columnset>
+          <ch-grid-column
+            column-id="code"
+            column-name="Country Code"
+            settingable="false"
+          ></ch-grid-column>
+          <ch-grid-column
+            column-id="name"
+            column-name="Country Name"
+            settingable="false"
+          ></ch-grid-column>
+          <ch-grid-column
+            column-id="population"
+            column-name="Country Population"
+            settingable="false"
+          ></ch-grid-column>
+          <ch-grid-column
+            column-id="language"
+            column-name="Country Language"
+            settingable="false"
+          ></ch-grid-column>
+        </ch-grid-columnset>
+
+        <ch-grid-row rowid="ar">
+          <ch-grid-cell>AR</ch-grid-cell>
+          <ch-grid-cell>Argentina</ch-grid-cell>
+          <ch-grid-cell>45.400.000</ch-grid-cell>
+          <ch-grid-cell>Español</ch-grid-cell>
+        </ch-grid-row>
+        <ch-grid-row rowid="bo">
+          <ch-grid-cell>BO</ch-grid-cell>
+          <ch-grid-cell>Bolivia</ch-grid-cell>
+          <ch-grid-cell>11.800.000</ch-grid-cell>
+          <ch-grid-cell>Español</ch-grid-cell>
+        </ch-grid-row>
+        <ch-grid-row rowid="br">
+          <ch-grid-cell>BR</ch-grid-cell>
+          <ch-grid-cell>Brasil</ch-grid-cell>
+          <ch-grid-cell>212.600.000</ch-grid-cell>
+          <ch-grid-cell>Português</ch-grid-cell>
+        </ch-grid-row>
+        <ch-grid-row rowid="cl">
+          <ch-grid-cell>CL</ch-grid-cell>
+          <ch-grid-cell>Chile</ch-grid-cell>
+          <ch-grid-cell>19.500.000</ch-grid-cell>
+          <ch-grid-cell>Español</ch-grid-cell>
+        </ch-grid-row>
+        <ch-grid-row rowid="ec">
+          <ch-grid-cell>EC</ch-grid-cell>
+          <ch-grid-cell>Ecuador</ch-grid-cell>
+          <ch-grid-cell>17.600.000</ch-grid-cell>
+          <ch-grid-cell>Español</ch-grid-cell>
+        </ch-grid-row>
+        <ch-grid-row rowid="py">
+          <ch-grid-cell>PY</ch-grid-cell>
+          <ch-grid-cell>Paraguay</ch-grid-cell>
+          <ch-grid-cell>7.500.000</ch-grid-cell>
+          <ch-grid-cell>Español</ch-grid-cell>
+        </ch-grid-row>
+        <ch-grid-row rowid="pe">
+          <ch-grid-cell>PE</ch-grid-cell>
+          <ch-grid-cell>Perú</ch-grid-cell>
+          <ch-grid-cell>32.800.000</ch-grid-cell>
+          <ch-grid-cell>Español</ch-grid-cell>
+        </ch-grid-row>
+        <ch-grid-row rowid="uy">
+          <ch-grid-cell>UY</ch-grid-cell>
+          <ch-grid-cell>Uruguay</ch-grid-cell>
+          <ch-grid-cell>3.500.000</ch-grid-cell>
+          <ch-grid-cell>Español</ch-grid-cell>
+        </ch-grid-row>
+        <ch-grid-row rowid="ve">
+          <ch-grid-cell>VE</ch-grid-cell>
+          <ch-grid-cell>Venezuela</ch-grid-cell>
+          <ch-grid-cell>28.500.000</ch-grid-cell>
+          <ch-grid-cell>Español</ch-grid-cell>
+        </ch-grid-row>
+      </ch-grid>
+    </section>
+
+      <section
         class="section-dev selection-multiple"
-        data-title="selection-multiple"
+        data-title="selection-multiple | keyboard-focus"
       >
-        <ch-grid row-selection-mode="multiple">
+        <ch-grid row-selection-mode="multiple" keyboard-navigation-mode="focus">
           <ch-grid-columnset>
             <ch-grid-column
               column-id="code"
@@ -382,8 +467,95 @@
         </ch-grid>
       </section>
 
-      <section class="section-dev row-mark" data-title="row-mark" id="ch-grid-row-mark">
-        <ch-grid row-selection-mode="multiple">
+      <section
+        class="section-dev selection-multiple"
+        data-title="selection-multiple | keyboard-select"
+      >
+        <ch-grid row-selection-mode="multiple" keyboard-navigation-mode="select">
+          <ch-grid-columnset>
+            <ch-grid-column
+              column-id="code"
+              column-name="Country Code"
+              column-type="rich"
+              rich-row-selector
+              settingable="false"
+            ></ch-grid-column>
+            <ch-grid-column
+              column-id="name"
+              column-name="Country Name"
+              settingable="false"
+            ></ch-grid-column>
+            <ch-grid-column
+              column-id="population"
+              column-name="Country Population"
+              settingable="false"
+            ></ch-grid-column>
+            <ch-grid-column
+              column-id="language"
+              column-name="Country Language"
+              settingable="false"
+            ></ch-grid-column>
+          </ch-grid-columnset>
+
+          <ch-grid-row rowid="ar">
+            <ch-grid-cell>AR</ch-grid-cell>
+            <ch-grid-cell>Argentina</ch-grid-cell>
+            <ch-grid-cell>45.400.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="bo">
+            <ch-grid-cell>BO</ch-grid-cell>
+            <ch-grid-cell>Bolivia</ch-grid-cell>
+            <ch-grid-cell>11.800.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="br">
+            <ch-grid-cell>BR</ch-grid-cell>
+            <ch-grid-cell>Brasil</ch-grid-cell>
+            <ch-grid-cell>212.600.000</ch-grid-cell>
+            <ch-grid-cell>Português</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="cl">
+            <ch-grid-cell>CL</ch-grid-cell>
+            <ch-grid-cell>Chile</ch-grid-cell>
+            <ch-grid-cell>19.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="ec">
+            <ch-grid-cell>EC</ch-grid-cell>
+            <ch-grid-cell>Ecuador</ch-grid-cell>
+            <ch-grid-cell>17.600.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="py">
+            <ch-grid-cell>PY</ch-grid-cell>
+            <ch-grid-cell>Paraguay</ch-grid-cell>
+            <ch-grid-cell>7.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="pe">
+            <ch-grid-cell>PE</ch-grid-cell>
+            <ch-grid-cell>Perú</ch-grid-cell>
+            <ch-grid-cell>32.800.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="uy">
+            <ch-grid-cell>UY</ch-grid-cell>
+            <ch-grid-cell>Uruguay</ch-grid-cell>
+            <ch-grid-cell>3.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="ve">
+            <ch-grid-cell>VE</ch-grid-cell>
+            <ch-grid-cell>Venezuela</ch-grid-cell>
+            <ch-grid-cell>28.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+        </ch-grid>
+      </section>
+
+      <section class="section-dev row-mark" data-title="row-mark | keyboard-select" id="ch-grid-row-mark">
+        <ch-grid row-selection-mode="multiple" keyboard-navigation-mode="select">
           <ch-grid-columnset>
             <ch-grid-column
               column-id="code"
@@ -465,13 +637,91 @@
             <ch-grid-cell>Español</ch-grid-cell>
           </ch-grid-row>
         </ch-grid>
+      </section>
 
-        <script>
-          const chGridRowMark = document.getElementById("ch-grid-row-mark");
-          chGridRowMark.addEventListener("rowMarkingChanged", e => {
-            console.log(e.detail);
-          })
-        </script>
+      <section class="section-dev row-mark" data-title="row-mark | keyboard-focus" id="ch-grid-row-mark">
+        <ch-grid row-selection-mode="multiple" keyboard-navigation-mode="focus">
+          <ch-grid-columnset>
+            <ch-grid-column
+              column-id="code"
+              column-name="Country Code"
+              column-type="rich"
+              rich-row-selector
+              rich-row-selector-mode="mark"
+              settingable="false"
+            ></ch-grid-column>
+            <ch-grid-column
+              column-id="name"
+              column-name="Country Name"
+              settingable="false"
+            ></ch-grid-column>
+            <ch-grid-column
+              column-id="population"
+              column-name="Country Population"
+              settingable="false"
+            ></ch-grid-column>
+            <ch-grid-column
+              column-id="language"
+              column-name="Country Language"
+              settingable="false"
+            ></ch-grid-column>
+          </ch-grid-columnset>
+
+          <ch-grid-row rowid="ar">
+            <ch-grid-cell>AR</ch-grid-cell>
+            <ch-grid-cell>Argentina</ch-grid-cell>
+            <ch-grid-cell>45.400.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="bo">
+            <ch-grid-cell>BO</ch-grid-cell>
+            <ch-grid-cell>Bolivia</ch-grid-cell>
+            <ch-grid-cell>11.800.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="br">
+            <ch-grid-cell>BR</ch-grid-cell>
+            <ch-grid-cell>Brasil</ch-grid-cell>
+            <ch-grid-cell>212.600.000</ch-grid-cell>
+            <ch-grid-cell>Português</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="cl">
+            <ch-grid-cell>CL</ch-grid-cell>
+            <ch-grid-cell>Chile</ch-grid-cell>
+            <ch-grid-cell>19.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="ec">
+            <ch-grid-cell>EC</ch-grid-cell>
+            <ch-grid-cell>Ecuador</ch-grid-cell>
+            <ch-grid-cell>17.600.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="py">
+            <ch-grid-cell>PY</ch-grid-cell>
+            <ch-grid-cell>Paraguay</ch-grid-cell>
+            <ch-grid-cell>7.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="pe">
+            <ch-grid-cell>PE</ch-grid-cell>
+            <ch-grid-cell>Perú</ch-grid-cell>
+            <ch-grid-cell>32.800.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="uy">
+            <ch-grid-cell>UY</ch-grid-cell>
+            <ch-grid-cell>Uruguay</ch-grid-cell>
+            <ch-grid-cell>3.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+          <ch-grid-row rowid="ve">
+            <ch-grid-cell>VE</ch-grid-cell>
+            <ch-grid-cell>Venezuela</ch-grid-cell>
+            <ch-grid-cell>28.500.000</ch-grid-cell>
+            <ch-grid-cell>Español</ch-grid-cell>
+          </ch-grid-row>
+        </ch-grid>
       </section>
 
       <section class="section-dev row-reorder" data-title="row-reorder">
@@ -1168,12 +1418,16 @@
     <script>
       document.addEventListener("rowClicked", eventInfo =>
         console.log(
-          `[rowClicked] rowId:${eventInfo.detail.rowId}, cellId:${eventInfo.detail.cellId}`
+          `[rowClicked] rowId:${eventInfo.detail.rowId}, cellId:${eventInfo.detail.cellId}, columnId:${eventInfo.detail.columnId}`
         )
       );
       document.addEventListener("selectionChanged", eventInfo =>
         console.log(`[selectionChanged] rowsId:${eventInfo.detail.rowsId}`)
       );
+      document.addEventListener("rowMarkingChanged", eventInfo => {
+        console.log(`[rowMarkingChanged] rowsId:${eventInfo.detail.rowsId}`);
+      })
+
     </script>
     <script src="./assets/scripts/common.js"></script>
   </body>


### PR DESCRIPTION
  Specifies the keyboard navigation mode for the grid.
  - "none": Disables keyboard navigation for the grid rows.
  - "select": Allows keyboard navigation by changing the selection of grid rows.
  - "focus": Allows keyboard navigation by focusing on grid rows, but does not change the selection.
  