### PR TITLE
Add `ch-combo-box` control

### DIFF
--- a/src/common/_base.scss
+++ b/src/common/_base.scss
@@ -11,6 +11,29 @@ $default-decorative-image-size: 0.875em;
   }
 }
 
+@mixin button-reset() {
+  :where(button, a) {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+
+    // Disallow selecting the text
+    user-select: none;
+
+    // Avoid zooming on double tap on iOS devices
+    touch-action: manipulation;
+
+    // Allow user drag
+    // -webkit-user-drag: element;
+
+    cursor: pointer;
+  }
+
+  button:disabled {
+    pointer-events: none;
+  }
+}
+
 @mixin reset-browser-defaults-properties-1() {
   background-color: unset;
   border: none;
@@ -19,6 +42,21 @@ $default-decorative-image-size: 0.875em;
   margin: 0;
   padding: 0;
   outline: 0;
+}
+
+@mixin typography-reset() {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p {
+    font: inherit;
+    margin: 0;
+    padding: 0;
+    color: inherit;
+  }
 }
 
 @mixin line-clamp() {

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -6,7 +6,7 @@ export interface AccessibleNameComponent {
    * with an element to provide users of assistive technologies with a label
    * for the element.
    */
-  accessibleName: string;
+  accessibleName?: string;
 }
 
 export interface DisableableComponent {

--- a/src/common/reserverd-names.ts
+++ b/src/common/reserverd-names.ts
@@ -10,6 +10,7 @@ export const KEY_CODES = {
   ENTER: "Enter",
   ESCAPE: "Escape",
   HOME: "Home",
+  SPACE: "Space",
   TAB: "Tab"
 } as const;
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -28,6 +28,10 @@ export function debounce(
 }
 
 export const isRTL = () => document.documentElement.dir === "rtl";
+export const isMobileDevice = () =>
+  /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
 
 export const ROOT_VIEW: null = null;
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,7 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { ItemsOverflowBehavior } from "./components/action-group/action-group/types";
 import { DropdownPosition } from "./components/dropdown/types";
 import { ActionGroupItemModel } from "./components/renders/action-group/types";
+import { ComboBoxItem } from "./components/combobox/types";
 import { GxDataTransferInfo, ImageRender, LabelPosition } from "./common/types";
 import { DropdownItemModel } from "./components/renders/dropdown/types";
 import { DraggableViewInfo, FlexibleLayout, FlexibleLayoutGroup, FlexibleLayoutItem, FlexibleLayoutItemExtended, FlexibleLayoutLeaf, FlexibleLayoutLeafType, FlexibleLayoutRenders, FlexibleLayoutViewRemoveResult, FlexibleLayoutWidget, ViewItemCloseInfo, ViewSelectedItemInfo, WidgetReorderInfo } from "./components/flexible-layout/types";
@@ -45,6 +46,7 @@ import { GridChameleonColumnFilterChanged } from "./components/gx-grid/gx-grid-c
 export { ItemsOverflowBehavior } from "./components/action-group/action-group/types";
 export { DropdownPosition } from "./components/dropdown/types";
 export { ActionGroupItemModel } from "./components/renders/action-group/types";
+export { ComboBoxItem } from "./components/combobox/types";
 export { GxDataTransferInfo, ImageRender, LabelPosition } from "./common/types";
 export { DropdownItemModel } from "./components/renders/dropdown/types";
 export { DraggableViewInfo, FlexibleLayout, FlexibleLayoutGroup, FlexibleLayoutItem, FlexibleLayoutItemExtended, FlexibleLayoutLeaf, FlexibleLayoutLeafType, FlexibleLayoutRenders, FlexibleLayoutViewRemoveResult, FlexibleLayoutWidget, ViewItemCloseInfo, ViewSelectedItemInfo, WidgetReorderInfo } from "./components/flexible-layout/types";
@@ -285,6 +287,36 @@ export namespace Components {
           * The value of the control.
          */
         "value": string;
+    }
+    interface ChComboBox {
+        /**
+          * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
+         */
+        "accessibleName"?: string;
+        /**
+          * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+         */
+        "disabled": boolean;
+        /**
+          * Specifies the items of the control
+         */
+        "items": ComboBoxItem[];
+        /**
+          * This attribute indicates that multiple options can be selected in the list. If it is not specified, then only one option can be selected at a time. When multiple is specified, the control will show a scrolling list box instead of a single line dropdown.
+         */
+        "multiple": boolean;
+        /**
+          * A hint to the user of what can be entered in the control. Same as [placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder) attribute for `input` elements.
+         */
+        "placeholder": string;
+        /**
+          * This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements.
+         */
+        "readonly": boolean;
+        /**
+          * Specifies the value (selected item) of the control.
+         */
+        "value"?: string;
     }
     interface ChDropdown {
         /**
@@ -2003,7 +2035,7 @@ export namespace Components {
          */
         "expandOnClick": boolean;
         /**
-          * Specifies what kind of expandable button is displayed in the items by default.  - `"expandableButton"`: Expandable button that allows to expand/collapse     the items of the control.  - `"decorative"`: Only a decorative icon is rendered to display the state     of the item.
+          * Specifies what kind of expandable button is displayed in the items by default.  - `"action"`: Expandable button that allows to expand/collapse     the items of the control.  - `"decorative"`: Only a decorative icon is rendered to display the state     of the item.  - `"no"`: The expandable button won't be rendered.
          */
         "expandableButton": "action" | "decorative" | "no";
         /**
@@ -2269,6 +2301,10 @@ export interface ChCheckboxCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChCheckboxElement;
 }
+export interface ChComboBoxCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLChComboBoxElement;
+}
 export interface ChDropdownCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChDropdownElement;
@@ -2521,6 +2557,23 @@ declare global {
     var HTMLChCheckboxElement: {
         prototype: HTMLChCheckboxElement;
         new (): HTMLChCheckboxElement;
+    };
+    interface HTMLChComboBoxElementEventMap {
+        "input": string;
+    }
+    interface HTMLChComboBoxElement extends Components.ChComboBox, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLChComboBoxElementEventMap>(type: K, listener: (this: HTMLChComboBoxElement, ev: ChComboBoxCustomEvent<HTMLChComboBoxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLChComboBoxElementEventMap>(type: K, listener: (this: HTMLChComboBoxElement, ev: ChComboBoxCustomEvent<HTMLChComboBoxElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLChComboBoxElement: {
+        prototype: HTMLChComboBoxElement;
+        new (): HTMLChComboBoxElement;
     };
     interface HTMLChDropdownElementEventMap {
         "expandedChange": boolean;
@@ -3488,6 +3541,7 @@ declare global {
         "ch-alert": HTMLChAlertElement;
         "ch-barcode-scanner": HTMLChBarcodeScannerElement;
         "ch-checkbox": HTMLChCheckboxElement;
+        "ch-combo-box": HTMLChComboBoxElement;
         "ch-dropdown": HTMLChDropdownElement;
         "ch-dropdown-item-separator": HTMLChDropdownItemSeparatorElement;
         "ch-dropdown-render": HTMLChDropdownRenderElement;
@@ -3791,6 +3845,40 @@ declare namespace LocalJSX {
           * The value of the control.
          */
         "value": string;
+    }
+    interface ChComboBox {
+        /**
+          * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
+         */
+        "accessibleName"?: string;
+        /**
+          * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+         */
+        "disabled"?: boolean;
+        /**
+          * Specifies the items of the control
+         */
+        "items"?: ComboBoxItem[];
+        /**
+          * This attribute indicates that multiple options can be selected in the list. If it is not specified, then only one option can be selected at a time. When multiple is specified, the control will show a scrolling list box instead of a single line dropdown.
+         */
+        "multiple"?: boolean;
+        /**
+          * The `input` event is emitted when a change to the element's value is committed by the user.
+         */
+        "onInput"?: (event: ChComboBoxCustomEvent<string>) => void;
+        /**
+          * A hint to the user of what can be entered in the control. Same as [placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder) attribute for `input` elements.
+         */
+        "placeholder"?: string;
+        /**
+          * This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements.
+         */
+        "readonly"?: boolean;
+        /**
+          * Specifies the value (selected item) of the control.
+         */
+        "value"?: string;
     }
     interface ChDropdown {
         /**
@@ -5564,7 +5652,7 @@ declare namespace LocalJSX {
          */
         "expandOnClick"?: boolean;
         /**
-          * Specifies what kind of expandable button is displayed in the items by default.  - `"expandableButton"`: Expandable button that allows to expand/collapse     the items of the control.  - `"decorative"`: Only a decorative icon is rendered to display the state     of the item.
+          * Specifies what kind of expandable button is displayed in the items by default.  - `"action"`: Expandable button that allows to expand/collapse     the items of the control.  - `"decorative"`: Only a decorative icon is rendered to display the state     of the item.  - `"no"`: The expandable button won't be rendered.
          */
         "expandableButton"?: "action" | "decorative" | "no";
         /**
@@ -5805,6 +5893,7 @@ declare namespace LocalJSX {
         "ch-alert": ChAlert;
         "ch-barcode-scanner": ChBarcodeScanner;
         "ch-checkbox": ChCheckbox;
+        "ch-combo-box": ChComboBox;
         "ch-dropdown": ChDropdown;
         "ch-dropdown-item-separator": ChDropdownItemSeparator;
         "ch-dropdown-render": ChDropdownRender;
@@ -5889,6 +5978,7 @@ declare module "@stencil/core" {
              */
             "ch-barcode-scanner": LocalJSX.ChBarcodeScanner & JSXBase.HTMLAttributes<HTMLChBarcodeScannerElement>;
             "ch-checkbox": LocalJSX.ChCheckbox & JSXBase.HTMLAttributes<HTMLChCheckboxElement>;
+            "ch-combo-box": LocalJSX.ChComboBox & JSXBase.HTMLAttributes<HTMLChComboBoxElement>;
             "ch-dropdown": LocalJSX.ChDropdown & JSXBase.HTMLAttributes<HTMLChDropdownElement>;
             "ch-dropdown-item-separator": LocalJSX.ChDropdownItemSeparator & JSXBase.HTMLAttributes<HTMLChDropdownItemSeparatorElement>;
             "ch-dropdown-render": LocalJSX.ChDropdownRender & JSXBase.HTMLAttributes<HTMLChDropdownRenderElement>;

--- a/src/components/combobox/combo-box.scss
+++ b/src/components/combobox/combo-box.scss
@@ -1,0 +1,130 @@
+@import "../../common/_base";
+
+@include button-reset(); // Should be placed before the box-sizing reset
+@include box-sizing();
+
+:host {
+  --ch-combo-box-item__image-size: #{$default-decorative-image-size};
+  --ch-combo-box-item__background-image-size: 100%;
+
+  --ch-combo-box-separation: 0px;
+  --ch-combo-box-separation-x: var(--ch-combo-box-separation);
+  --ch-combo-box-separation-y: var(--ch-combo-box-separation);
+
+  --ch-combo-box__picker: url('data:image/svg+xml,<svg width="8" height="12" viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg"><path d="M4.16669 0.666626L7.66669 4.66663H0.666687L4.16669 0.666626ZM4.16669 11.3333L0.666687 7.33329H7.66669L4.16669 11.3333Z"/></svg>');
+  --ch-combo-box__picker-color: currentColor;
+  --ch-combo-box__picker-size: 1em;
+  --ch-combo-box__picker-mask-size: 1em;
+
+  --ch-combo-box-border-inline-start-width: 0px;
+  --ch-combo-box-border-inline-end-width: 0px;
+  --ch-combo-box-border-block-start-width: 0px;
+  --ch-combo-box-border-block-end-width: 0px;
+
+  display: grid;
+  grid-template: "value picker" 1fr / 1fr max-content;
+  align-items: center;
+  align-self: stretch;
+  position: relative;
+
+  // Remove outline of the focus state. This selector must not have higher
+  // specificity, since it should be overridden by the class applied to the control
+  outline: unset;
+
+  // Remove text selection on double click
+  user-select: none;
+
+  &::after {
+    content: "";
+    grid-area: picker;
+    inline-size: var(--ch-combo-box__picker-size);
+    block-size: var(--ch-combo-box__picker-size);
+    -webkit-mask: var(--ch-combo-box__picker) 50% 50% /
+      var(--ch-combo-box__picker-mask-size)
+      var(--ch-combo-box__picker-mask-size) no-repeat;
+    background-color: var(--ch-combo-box__picker-color);
+    pointer-events: none;
+  }
+}
+
+:host(.ch-disabled) {
+  pointer-events: none;
+}
+
+select {
+  all: unset;
+  display: grid;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.mask,
+select {
+  position: absolute;
+  inset-inline: var(--ch-combo-box-mask-inline-start)
+    var(--ch-combo-box-mask-inline-end);
+  inset-block: var(--ch-combo-box-mask-block-start)
+    var(--ch-combo-box-mask-block-end);
+
+  cursor: pointer;
+}
+
+.value {
+  grid-area: value;
+}
+
+// - - - - - - - - - - - - - - - -
+//           Separation
+// - - - - - - - - - - - - - - - -
+ch-popover {
+  --ch-combo-box-separation-x: var(--ch-dropdown-separation-x);
+  --ch-combo-box-separation-y: var(--ch-dropdown-separation-y);
+
+  // --ch-popover-min-inline-size: var(--ch-popover-action-width);
+
+  display: grid;
+  grid-auto-rows: max-content;
+
+  &:not(.hydrated) {
+    opacity: 0;
+  }
+}
+
+.group {
+  display: grid;
+  grid-auto-rows: max-content;
+}
+
+// - - - - - - - - - - - - - - - -
+//             Images
+// - - - - - - - - - - - - - - - -
+.img--start::before,
+.img--end::after {
+  content: "";
+  display: block;
+  inline-size: var(--ch-combo-box-item__image-size);
+  block-size: var(--ch-combo-box-item__image-size);
+  min-inline-size: var(--ch-combo-box-item__image-size);
+}
+
+.img--start {
+  --ch-combo-box-item-img: var(--ch-combo-box-item-start-img);
+}
+
+.img--end {
+  --ch-combo-box-item-img: var(--ch-combo-box-item-end-img);
+}
+
+.start-img-type--background::before,
+.end-img-type--background::after {
+  background: no-repeat center / var(--ch-combo-box-item__background-image-size)
+    var(--ch-combo-box-item-img);
+}
+
+.start-img-type--mask::before,
+.end-img-type--mask::after {
+  -webkit-mask: var(--ch-combo-box-item-img) 50% 50% /
+    var(--ch-combo-box-item__background-image-size)
+    var(--ch-combo-box-item__background-image-size) no-repeat;
+  background-color: currentColor;
+}

--- a/src/components/combobox/combo-box.tsx
+++ b/src/components/combobox/combo-box.tsx
@@ -580,6 +580,8 @@ export class ChComboBox
       ) : (
         <button
           key={item.value}
+          role="option"
+          aria-selected={item.value === this.currentSelectedValue}
           tabindex="-1"
           class={
             hasImages
@@ -695,10 +697,10 @@ export class ChComboBox
       <Host
         role={!mobileDevice ? "combobox" : null}
         aria-controls={!mobileDevice ? this.#popoverId : null}
-        aria-disabled={this.disabled ? "true" : null}
+        aria-disabled={!mobileDevice && this.disabled ? "true" : null}
         aria-expanded={!mobileDevice ? this.expanded.toString() : null}
-        aria-haspopup="true"
-        aria-placeholder={!mobileDevice ? this.placeholder : null}
+        aria-haspopup={!mobileDevice ? "true" : null}
+        // ComboBox controls do not have aria-placeholder attr
         tabindex={!mobileDevice ? "0" : null}
         class={this.disabled ? "ch-disabled" : null}
         onKeyDown={
@@ -735,6 +737,7 @@ export class ChComboBox
               <ch-popover
                 id={this.#popoverId}
                 role="listbox"
+                aria-hidden="false"
                 part="window"
                 actionById
                 actionElement={this.el as unknown as HTMLButtonElement} // This is a WA. We should remove it

--- a/src/components/combobox/combo-box.tsx
+++ b/src/components/combobox/combo-box.tsx
@@ -1,0 +1,752 @@
+import {
+  AttachInternals,
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Host,
+  Prop,
+  State,
+  Watch,
+  h
+} from "@stencil/core";
+import {
+  AccessibleNameComponent,
+  DisableableComponent
+} from "../../common/interfaces";
+import { ComboBoxItem, ComboBoxItemGroup, ComboBoxItemLeaf } from "./types";
+import { isMobileDevice } from "../../common/utils";
+import { KEY_CODES } from "../../common/reserverd-names";
+import { SyncWithRAF } from "../../common/sync-with-frames";
+import { ChPopoverCustomEvent } from "../../components";
+
+const SELECTED_PART = "selected";
+const DISABLED_PART = "disabled";
+
+const SELECTED_ITEM_SELECTOR = `button[part*='${SELECTED_PART}']`;
+
+const COMBO_BOX_MASK_BLOCK_START = "--ch-combo-box-mask-block-start";
+const COMBO_BOX_MASK_BLOCK_END = "--ch-combo-box-mask-block-end";
+const COMBO_BOX_MASK_INLINE_START = "--ch-combo-box-mask-inline-start";
+const COMBO_BOX_MASK_INLINE_END = "--ch-combo-box-mask-inline-end";
+
+const mobileDevice = isMobileDevice();
+
+let autoId = 0;
+
+const negateBorderValue = (borderSize: string) =>
+  borderSize === "0px" ? "0px" : `-${borderSize}`;
+
+// Keys
+type KeyDownEvents =
+  | typeof KEY_CODES.ARROW_UP
+  | typeof KEY_CODES.ARROW_DOWN
+  | typeof KEY_CODES.HOME
+  | typeof KEY_CODES.END
+  | typeof KEY_CODES.ENTER
+  | typeof KEY_CODES.SPACE
+  | typeof KEY_CODES.TAB;
+
+type SelectedIndex =
+  | {
+      type: "not-exists";
+    }
+  | {
+      type: "nested";
+      firstLevelIndex: number;
+      secondLevelIndex: number;
+    }
+  | {
+      type: "first-level";
+      firstLevelIndex: number;
+    };
+
+const SELECTED_VALUE_DOES_NOT_EXISTS: SelectedIndex = {
+  type: "not-exists"
+} as const;
+
+const isValidIndex = (array: any, index: number) =>
+  0 <= index && index < array.length;
+
+const findSelectedIndex = (
+  valueToItemInfo: Map<string, { caption: string; index: SelectedIndex }>,
+  selectedValue: string | undefined
+): SelectedIndex => {
+  if (!selectedValue) {
+    return SELECTED_VALUE_DOES_NOT_EXISTS;
+  }
+
+  return (
+    valueToItemInfo.get(selectedValue)?.index ?? SELECTED_VALUE_DOES_NOT_EXISTS
+  );
+};
+
+const findNextSelectedIndex = (
+  items: ComboBoxItem[],
+  currentIndex: SelectedIndex,
+  increment: 1 | -1
+): SelectedIndex => {
+  if (currentIndex.type === "not-exists") {
+    return SELECTED_VALUE_DOES_NOT_EXISTS;
+  }
+  const firstLevelIndex = currentIndex.firstLevelIndex;
+
+  if (currentIndex.type === "nested") {
+    let secondLevelIndex = currentIndex.secondLevelIndex + increment; // Start from the first valid index
+    const firstLevelItemItems = (items[firstLevelIndex] as ComboBoxItemGroup)
+      .items;
+
+    // Search in the nested level skipping disabled items
+    while (
+      isValidIndex(firstLevelItemItems, secondLevelIndex) &&
+      firstLevelItemItems[secondLevelIndex].disabled
+    ) {
+      secondLevelIndex += increment;
+    }
+
+    // If the index is not after the end of the array, the new selected value
+    // was found
+    if (isValidIndex(firstLevelItemItems, secondLevelIndex)) {
+      return {
+        type: "nested",
+        firstLevelIndex: firstLevelIndex,
+        secondLevelIndex: secondLevelIndex
+      };
+    }
+  }
+
+  // At this point, either all items in the nested level were disabled or the
+  // "currentIndex" was not nested. In any case, we must check the next item
+  // in the first level
+  let nextFirstLevelIndex = firstLevelIndex + increment;
+
+  // Search for the next first level item that is not disabled
+  while (
+    isValidIndex(items, nextFirstLevelIndex) &&
+    items[nextFirstLevelIndex].disabled === true
+  ) {
+    nextFirstLevelIndex += increment;
+  }
+
+  // With this flag, we also say that we are at the end of the combo-box
+  // and there isn't any new "next value" to select
+  if (!isValidIndex(items, nextFirstLevelIndex)) {
+    return SELECTED_VALUE_DOES_NOT_EXISTS;
+  }
+
+  const nestedLevel = (items[nextFirstLevelIndex] as ComboBoxItemGroup).items;
+
+  if (nestedLevel != null) {
+    return findNextSelectedIndex(
+      items,
+      {
+        type: "nested",
+        firstLevelIndex: nextFirstLevelIndex,
+        secondLevelIndex: increment === 1 ? -1 : nestedLevel.length // The algorithm will sum 1 (or -1) to the start index
+      },
+      increment
+    );
+  }
+
+  return {
+    type: "first-level",
+    firstLevelIndex: nextFirstLevelIndex
+  };
+};
+
+/**
+ * @part ... - ...
+ */
+@Component({
+  formAssociated: true,
+  shadow: true,
+  styleUrl: "combo-box.scss",
+  tag: "ch-combo-box"
+})
+export class ChComboBox
+  implements AccessibleNameComponent, DisableableComponent
+{
+  #accessibleNameFromExternalLabel: string | undefined;
+  #popoverId: string | undefined;
+  #firstExpanded = false;
+
+  #borderSizeRAF: SyncWithRAF | undefined;
+  #resizeObserver: ResizeObserver | undefined;
+
+  #lastMaskInlineStart = "0px";
+  #lastMaskInlineEnd = "0px";
+  #lastMaskBlockStart = "0px";
+  #lastMaskBlockEnd = "0px";
+
+  #valueToItemInfo: Map<string, { caption: string; index: SelectedIndex }> =
+    new Map();
+
+  /**
+   * When the control is used in a desktop environment, we need to manually
+   * focus the selected item when the control is expanded.
+   */
+  // eslint-disable-next-line @stencil-community/own-props-must-be-private
+  #focusSelectAfterNextRender = true;
+
+  #selectNextIndex = (
+    event: KeyboardEvent,
+    currentSelectedIndex: SelectedIndex,
+    increment: 1 | -1
+  ) => {
+    event.preventDefault(); // Stop ArrowDown key from scrolling
+
+    const nextSelectedIndex =
+      currentSelectedIndex.type === "not-exists"
+        ? findNextSelectedIndex(
+            this.items,
+            {
+              type: "first-level",
+              firstLevelIndex: increment === 1 ? -1 : this.items.length
+            },
+            increment
+          )
+        : findNextSelectedIndex(this.items, currentSelectedIndex, increment);
+
+    if (nextSelectedIndex.type === "not-exists") {
+      return;
+    }
+
+    // The new selected value is either in the first level or in the group
+    const newSelectedValue =
+      nextSelectedIndex.type === "first-level"
+        ? this.items[nextSelectedIndex.firstLevelIndex].value
+        : (this.items[nextSelectedIndex.firstLevelIndex] as ComboBoxItemGroup)
+            .items[nextSelectedIndex.secondLevelIndex].value;
+
+    if (this.currentSelectedValue !== newSelectedValue) {
+      this.currentSelectedValue = newSelectedValue;
+      this.#focusSelectAfterNextRender = true;
+    }
+  };
+
+  #keyEventsDictionary: {
+    [key in KeyDownEvents]: (event: KeyboardEvent) => void;
+  } = {
+    ArrowUp: (event: KeyboardEvent) =>
+      this.#selectNextIndex(
+        event,
+        findSelectedIndex(this.#valueToItemInfo, this.currentSelectedValue),
+        -1
+      ),
+
+    ArrowDown: (event: KeyboardEvent) =>
+      this.#selectNextIndex(
+        event,
+        findSelectedIndex(this.#valueToItemInfo, this.currentSelectedValue),
+        1
+      ),
+
+    Home: (event: KeyboardEvent) =>
+      this.#selectNextIndex(
+        event,
+        {
+          type: "first-level",
+          firstLevelIndex: -1
+        }, // The algorithm will sum 1 to the start index
+        1
+      ),
+
+    End: (event: KeyboardEvent) =>
+      this.#selectNextIndex(
+        event,
+        {
+          type: "first-level",
+          firstLevelIndex: this.items.length
+        }, // The algorithm will sum -1 to the start index
+        -1
+      ),
+
+    Enter: () => {
+      // The focus must return to the Host when closing the popover
+      if (this.expanded) {
+        this.el.focus();
+      }
+
+      this.expanded = !this.expanded;
+    },
+
+    Space: event => {
+      event.preventDefault(); // Stop space key from scrolling
+
+      // Only expands the ComboBox
+      this.expanded ||= true;
+    },
+
+    Tab: event => {
+      // The focus must return to the Host when tabbing with the popover
+      // expanded
+      if (this.expanded) {
+        event.preventDefault();
+
+        this.el.focus();
+        this.expanded = false;
+      }
+    }
+  };
+
+  // Refs
+  #maskRef!: HTMLDivElement;
+  #selectRef: HTMLSelectElement | undefined;
+
+  /**
+   * When the combo-box is expanded, the visually selected value must change,
+   * but in the interface the `value` property must only change when the
+   * popover is closed.
+   * This state help us to render the visually selected value, without updating
+   * the `value` property in the interface.
+   */
+  @State() currentSelectedValue: string;
+
+  @State() expanded = false;
+  @Watch("expanded")
+  handleExpandedChange(newExpandedValue: boolean) {
+    this.#firstExpanded = true;
+
+    if (newExpandedValue && !mobileDevice) {
+      this.#focusSelectAfterNextRender = true;
+    }
+  }
+
+  @AttachInternals() internals: ElementInternals;
+
+  @Element() el: HTMLChComboBoxElement;
+
+  /**
+   * Specifies a short string, typically 1 to 3 words, that authors associate
+   * with an element to provide users of assistive technologies with a label
+   * for the element.
+   */
+  @Prop() readonly accessibleName?: string;
+
+  /**
+   * This attribute lets you specify if the element is disabled.
+   * If disabled, it will not fire any user interaction related event
+   * (for example, click event).
+   */
+  @Prop() readonly disabled: boolean = false;
+
+  /**
+   * Specifies the items of the control
+   */
+  @Prop() readonly items: ComboBoxItem[] = [];
+  @Watch("items")
+  itemsChange(newItems: ComboBoxItem[]) {
+    this.#mapValuesToItemInfo(newItems);
+  }
+
+  /**
+   * This attribute indicates that multiple options can be selected in the list.
+   * If it is not specified, then only one option can be selected at a time.
+   * When multiple is specified, the control will show a scrolling list box
+   * instead of a single line dropdown.
+   */
+  @Prop() readonly multiple: boolean = false;
+
+  /**
+   * A hint to the user of what can be entered in the control. Same as
+   * [placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder)
+   * attribute for `input` elements.
+   */
+  @Prop() readonly placeholder: string;
+
+  /**
+   * This attribute indicates that the user cannot modify the value of the control.
+   * Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly)
+   * attribute for `input` elements.
+   */
+  @Prop() readonly readonly: boolean = false;
+
+  /**
+   * Specifies the value (selected item) of the control.
+   */
+  @Prop({ mutable: true }) value?: string;
+  @Watch("value")
+  valueChange(newValue: string) {
+    this.currentSelectedValue = newValue;
+  }
+
+  /**
+   * The `input` event is emitted when a change to the element's value is
+   * committed by the user.
+   */
+  @Event() input: EventEmitter<string>;
+
+  #mapValuesToItemInfo = (items: ComboBoxItem[]) => {
+    this.#valueToItemInfo.clear();
+
+    if (items == null) {
+      return;
+    }
+
+    items.forEach((item, firstLevelIndex) => {
+      const subItems = (item as ComboBoxItemGroup).items;
+
+      if (subItems != null) {
+        subItems.forEach((subItem, secondLevelIndex) => {
+          this.#valueToItemInfo.set(subItem.value, {
+            caption: subItem.caption,
+            index: {
+              type: "nested",
+              firstLevelIndex: firstLevelIndex,
+              secondLevelIndex: secondLevelIndex
+            }
+          });
+        });
+      } else {
+        this.#valueToItemInfo.set(item.value, {
+          caption: item.caption,
+          index: {
+            type: "first-level",
+            firstLevelIndex: firstLevelIndex
+          }
+        });
+      }
+    });
+  };
+
+  #checkAndEmitValueChange = () => {
+    if (!this.expanded && this.currentSelectedValue !== this.value) {
+      this.value = this.currentSelectedValue;
+
+      // Set form value
+      this.internals.setFormValue(this.value);
+
+      // Emit event
+      this.input.emit(this.value);
+    }
+  };
+
+  #itemLeafParts = (
+    item: ComboBoxItemLeaf,
+    insideAGroup: boolean,
+    isDisabled: boolean
+  ) =>
+    `item${insideAGroup ? " nested" : ""}${
+      isDisabled ? ` ${DISABLED_PART}` : ""
+    }${item.value === this.currentSelectedValue ? ` ${SELECTED_PART}` : ""}`;
+
+  #setResizeObserver = () => {
+    this.#borderSizeRAF = new SyncWithRAF();
+    this.#resizeObserver = new ResizeObserver(this.#updateBorderSizeRAF);
+
+    // Observe the size of the edges to know if the border
+    this.#resizeObserver.observe(this.el, { box: "border-box" });
+    this.#resizeObserver.observe(this.#maskRef ?? this.#selectRef);
+  };
+
+  #updateBorderSizeRAF = () => {
+    this.#borderSizeRAF.perform(this.#updateBorderSize);
+  };
+
+  #updateBorderSize = () => {
+    // - - - - - - - - - - - - - DOM read operations - - - - - - - - - - - - -
+    const computedStyle = getComputedStyle(this.el);
+
+    const negatedBorderInlineStartWidth = negateBorderValue(
+      computedStyle.borderInlineStartWidth
+    );
+    const negatedBorderInlineEndWidth = negateBorderValue(
+      computedStyle.borderInlineEndWidth
+    );
+    const negatedBorderBlockStartWidth = negateBorderValue(
+      computedStyle.borderBlockStartWidth
+    );
+    const negatedBorderBlockEndWidth = negateBorderValue(
+      computedStyle.borderBlockEndWidth
+    );
+
+    if (
+      this.#lastMaskInlineStart === negatedBorderInlineStartWidth &&
+      this.#lastMaskInlineEnd === negatedBorderInlineEndWidth &&
+      this.#lastMaskBlockStart === negatedBorderBlockStartWidth &&
+      this.#lastMaskBlockEnd === negatedBorderBlockEndWidth
+    ) {
+      return;
+    }
+
+    // - - - - - - - - - - - - - DOM write operations - - - - - - - - - - - - -
+    this.el.style.setProperty(
+      COMBO_BOX_MASK_INLINE_START,
+      negatedBorderInlineStartWidth
+    );
+
+    this.el.style.setProperty(
+      COMBO_BOX_MASK_INLINE_END,
+      negatedBorderInlineEndWidth
+    );
+
+    this.el.style.setProperty(
+      COMBO_BOX_MASK_BLOCK_START,
+      negatedBorderBlockStartWidth
+    );
+
+    this.el.style.setProperty(
+      COMBO_BOX_MASK_BLOCK_END,
+      negatedBorderBlockEndWidth
+    );
+
+    // Store borders to avoid an extra call from the resize observer due to
+    // the size of the mask is updated
+    this.#lastMaskInlineStart = negatedBorderInlineStartWidth;
+    this.#lastMaskInlineEnd = negatedBorderInlineEndWidth;
+    this.#lastMaskBlockStart = negatedBorderBlockStartWidth;
+    this.#lastMaskBlockEnd = negatedBorderBlockEndWidth;
+  };
+
+  #handleSelectChange = (event: Event) => {
+    event.preventDefault();
+
+    this.value = this.#selectRef.value;
+    this.currentSelectedValue = this.#selectRef.value;
+
+    // Set form value
+    this.internals.setFormValue(this.value);
+
+    // Emit event
+    this.input.emit(this.value);
+  };
+
+  #handleExpandedChange = (event: MouseEvent) => {
+    event.stopPropagation();
+
+    if (this.expanded) {
+      // The focus must return to the Host when the popover is closed using the
+      // Escape key
+      this.el.focus();
+    }
+    this.expanded = !this.expanded;
+  };
+
+  #handleExpandedChangeWithKeyBoard = (event: KeyboardEvent) => {
+    const keyboardHandler = this.#keyEventsDictionary[event.code];
+
+    if (keyboardHandler) {
+      keyboardHandler(event);
+      this.#checkAndEmitValueChange();
+    }
+  };
+
+  #handlePopoverClose = (event: ChPopoverCustomEvent<any>) => {
+    event.stopPropagation();
+
+    // The focus must return to the Host when the popover is closed using the
+    // Escape key
+    this.expanded = false;
+    this.el.focus();
+
+    this.#checkAndEmitValueChange();
+  };
+
+  #updateSelectedValue = (itemValue: string) => (event: MouseEvent) => {
+    event.stopPropagation();
+
+    this.expanded = false;
+    this.currentSelectedValue = itemValue;
+    this.#checkAndEmitValueChange();
+  };
+
+  #customItemRender =
+    (insideAGroup: boolean, disabled: boolean | undefined) =>
+    (item: ComboBoxItem, index: number) => {
+      const hasStartImg = !!item.startImgSrc;
+      const hasEndImg = !!item.endImgSrc;
+      const hasImages = hasStartImg || hasEndImg;
+
+      // This variable inherits the disabled state from group parents. Useful
+      // to propagate the disabled state in the child buttons
+      const isDisabled = disabled ?? item.disabled;
+
+      return (item as ComboBoxItemGroup).items != null ? (
+        <div
+          key={item.value}
+          aria-labelledby={index.toString()}
+          role="group"
+          class="group"
+          part={`group${isDisabled ? ` ${DISABLED_PART}` : ""}`}
+        >
+          <span id={index.toString()} part="group__caption">
+            {item.caption}
+          </span>
+
+          {(item as ComboBoxItemGroup).items.map(
+            this.#customItemRender(true, isDisabled)
+          )}
+        </div>
+      ) : (
+        <button
+          key={item.value}
+          tabindex="-1"
+          class={
+            hasImages
+              ? {
+                  [`start-img-type--${
+                    item.startImgType ?? "background"
+                  } img--start`]: hasStartImg,
+                  [`end-img-type--${item.endImgType ?? "background"} img--end`]:
+                    hasEndImg
+                }
+              : undefined
+          }
+          part={this.#itemLeafParts(item, insideAGroup, isDisabled)}
+          style={
+            hasImages
+              ? {
+                  "--ch-combo-box-item-start-img": hasStartImg
+                    ? `url("${item.startImgSrc}")`
+                    : undefined,
+                  "--ch-combo-box-item-end-img": hasEndImg
+                    ? `url("${item.endImgSrc}")`
+                    : undefined
+                }
+              : undefined
+          }
+          disabled={isDisabled}
+          type="button"
+          onClick={this.#updateSelectedValue(item.value)}
+        >
+          {item.caption}
+        </button>
+      );
+    };
+
+  #nativeItemRender = (item: ComboBoxItem) =>
+    (item as ComboBoxItemGroup).items != null ? (
+      <optgroup label={item.caption}>
+        {(item as ComboBoxItemGroup).items.map(this.#nativeItemRender)}
+      </optgroup>
+    ) : (
+      <option
+        key={item.value}
+        value={item.value}
+        disabled={item.disabled}
+        selected={item.value === this.value}
+      >
+        {item.caption}
+      </option>
+    );
+
+  #nativeRender = () => (
+    <select
+      aria-label={this.accessibleName ?? this.#accessibleNameFromExternalLabel}
+      disabled={this.disabled}
+      onChange={this.#handleSelectChange}
+      ref={el => (this.#selectRef = el)}
+    >
+      {this.items.map(this.#nativeItemRender)}
+    </select>
+  );
+
+  connectedCallback() {
+    this.#popoverId ??= `ch-combo-box-popover-${autoId++}`;
+
+    this.internals.setFormValue(this.value);
+    this.currentSelectedValue = this.value;
+
+    const labels = this.internals.labels;
+
+    // Get external aria-label
+    if (!this.accessibleName && labels?.length > 0) {
+      this.#accessibleNameFromExternalLabel = labels[0].textContent.trim();
+    }
+
+    this.#mapValuesToItemInfo(this.items);
+  }
+
+  componentDidLoad() {
+    this.#setResizeObserver();
+  }
+
+  componentDidRender() {
+    if (!this.#focusSelectAfterNextRender) {
+      return;
+    }
+    this.#focusSelectAfterNextRender = false;
+
+    const selectedElement = this.el.shadowRoot.querySelector(
+      SELECTED_ITEM_SELECTOR
+    ) as HTMLElement | undefined;
+
+    // Focus the selected element
+    if (selectedElement) {
+      // Wait until the JS has been executed to avoid race conditions when
+      // rendering elements in the top layer and trying to focus them
+      requestAnimationFrame(() => {
+        selectedElement.focus();
+      });
+    }
+  }
+
+  disconnectedCallback() {
+    if (this.#resizeObserver) {
+      this.#resizeObserver.disconnect();
+      this.#resizeObserver = undefined; // Free the memory
+    }
+
+    this.#borderSizeRAF = undefined; // Free the memory
+  }
+
+  render() {
+    return (
+      <Host
+        role={!mobileDevice ? "combobox" : null}
+        aria-controls={!mobileDevice ? this.#popoverId : null}
+        aria-disabled={this.disabled ? "true" : null}
+        aria-expanded={!mobileDevice ? this.expanded.toString() : null}
+        aria-haspopup="true"
+        aria-placeholder={!mobileDevice ? this.placeholder : null}
+        tabindex={!mobileDevice ? "0" : null}
+        class={this.disabled ? "ch-disabled" : null}
+        onKeyDown={
+          !mobileDevice && !this.disabled
+            ? this.#handleExpandedChangeWithKeyBoard
+            : null
+        }
+      >
+        <span
+          aria-hidden={!this.currentSelectedValue ? "true" : null}
+          class="value"
+        >
+          {this.currentSelectedValue
+            ? this.#valueToItemInfo.get(this.currentSelectedValue)?.caption ??
+              this.placeholder
+            : this.placeholder}
+        </span>
+
+        {!mobileDevice && (
+          <div
+            // This mask is used to capture click events that must open the
+            // popover. If we capture click events in the Host, clicking external
+            // label would open the combo-box's window
+            aria-hidden="true"
+            class="mask"
+            onClick={this.#handleExpandedChange}
+            ref={el => (this.#maskRef = el)}
+          ></div>
+        )}
+
+        {mobileDevice
+          ? this.#nativeRender()
+          : this.#firstExpanded && (
+              <ch-popover
+                id={this.#popoverId}
+                role="listbox"
+                part="window"
+                actionById
+                actionElement={this.el as unknown as HTMLButtonElement} // This is a WA. We should remove it
+                blockAlign="outside-end"
+                hidden={!this.expanded}
+                popover="auto"
+                onPopoverClosed={this.#handlePopoverClose}
+              >
+                {this.items.map(this.#customItemRender(false, undefined))}
+              </ch-popover>
+            )}
+      </Host>
+    );
+  }
+}

--- a/src/components/combobox/combo-box.tsx
+++ b/src/components/combobox/combo-box.tsx
@@ -19,6 +19,7 @@ import { isMobileDevice } from "../../common/utils";
 import { KEY_CODES } from "../../common/reserverd-names";
 import { SyncWithRAF } from "../../common/sync-with-frames";
 import { ChPopoverCustomEvent } from "../../components";
+import { focusComposedPath } from "../common/helpers";
 
 const SELECTED_PART = "selected";
 const DISABLED_PART = "disabled";
@@ -537,7 +538,12 @@ export class ChComboBox
     // The focus must return to the Host when the popover is closed using the
     // Escape key
     this.expanded = false;
-    this.el.focus();
+
+    // Return the focus to the control if the popover was closed with the
+    // escape key or by clicking again the combo-box
+    if (focusComposedPath().includes(this.el)) {
+      this.el.focus();
+    }
 
     this.#checkAndEmitValueChange();
   };

--- a/src/components/combobox/readme.md
+++ b/src/components/combobox/readme.md
@@ -1,0 +1,52 @@
+# ch-combo-box
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property         | Attribute         | Description                                                                                                                                                                                                                                                   | Type             | Default     |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ----------- |
+| `accessibleName` | `accessible-name` | Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.                                                                                             | `string`         | `undefined` |
+| `disabled`       | `disabled`        | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).                                                                                                      | `boolean`        | `false`     |
+| `items`          | --                | Specifies the items of the control                                                                                                                                                                                                                            | `ComboBoxItem[]` | `[]`        |
+| `multiple`       | `multiple`        | This attribute indicates that multiple options can be selected in the list. If it is not specified, then only one option can be selected at a time. When multiple is specified, the control will show a scrolling list box instead of a single line dropdown. | `boolean`        | `false`     |
+| `placeholder`    | `placeholder`     | A hint to the user of what can be entered in the control. Same as [placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder) attribute for `input` elements.                                                             | `string`         | `undefined` |
+| `readonly`       | `readonly`        | This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements.                                              | `boolean`        | `false`     |
+| `value`          | `value`           | Specifies the value (selected item) of the control.                                                                                                                                                                                                           | `string`         | `undefined` |
+
+
+## Events
+
+| Event   | Description                                                                                 | Type                  |
+| ------- | ------------------------------------------------------------------------------------------- | --------------------- |
+| `input` | The `input` event is emitted when a change to the element's value is committed by the user. | `CustomEvent<string>` |
+
+
+## Shadow Parts
+
+| Part               | Description |
+| ------------------ | ----------- |
+| `"..."`            | ...         |
+| `"group__caption"` |             |
+| `"window"`         |             |
+
+
+## Dependencies
+
+### Depends on
+
+- [ch-popover](../popover)
+
+### Graph
+```mermaid
+graph TD;
+  ch-combo-box --> ch-popover
+  style ch-combo-box fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/combobox/types.ts
+++ b/src/components/combobox/types.ts
@@ -1,0 +1,17 @@
+import { ImageRender } from "../../common/types";
+
+export type ComboBoxItem = ComboBoxItemGroup | ComboBoxItemLeaf;
+
+export type ComboBoxItemLeaf = {
+  caption: string;
+  disabled?: boolean;
+  endImgSrc?: string;
+  endImgType?: Exclude<ImageRender, "img">;
+  startImgSrc?: string;
+  startImgType?: Exclude<ImageRender, "img">;
+  value: string;
+};
+
+export type ComboBoxItemGroup = ComboBoxItemLeaf & {
+  items: ComboBoxItemLeaf[];
+};

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -52,15 +52,8 @@ ch-popover {
   --ch-popover-separation-x: var(--ch-dropdown-separation-x);
   --ch-popover-separation-y: var(--ch-dropdown-separation-y);
 
-  // Prevent initial flickering when the control is not hydrated. Since the
-  // popover bundle is separated from its use, the first display of the
-  // control at runtime may cause flickering, due to "position: fixed" not yet
-  // been downloaded
-  position: fixed;
-  opacity: 0;
-
-  &.hydrated {
-    opacity: 1;
+  &:not(.hydrated) {
+    opacity: 0;
   }
 }
 // Dummy separation to keep opened the popup when expand-behavior === "ClickOrHover"

--- a/src/showcase/models/components.js
+++ b/src/showcase/models/components.js
@@ -13,6 +13,7 @@ const components = [
   "barcode-scanner",
   "dropdown",
   "checkbox",
+  "combo-box",
   "flexible-layout",
   "grid",
   "layout-splitter",

--- a/src/showcase/pages/combo-box.html
+++ b/src/showcase/pages/combo-box.html
@@ -67,6 +67,7 @@
             name="combobox-1"
             id="combobox-1"
             placeholder="Choose a value..."
+            value="Value 1"
           ></ch-combo-box>
         </div>
 

--- a/src/showcase/pages/combo-box.html
+++ b/src/showcase/pages/combo-box.html
@@ -25,7 +25,7 @@
         background-color: aliceblue;
       }
 
-      ch-combo-box:focus-visible {
+      ch-combo-box:focus {
         border-color: blueviolet;
       }
 
@@ -47,6 +47,10 @@
       ch-combo-box::part(item) {
         border: 1px solid;
         background-color: rgb(215, 179, 136);
+      }
+
+      ch-combo-box::part(item selected) {
+        outline: 2px solid;
       }
 
       ch-combo-box::part(item):hover {

--- a/src/showcase/pages/combo-box.html
+++ b/src/showcase/pages/combo-box.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>ComboBox</title>
+    <script type="module" src="/build/chameleon.esm.js"></script>
+    <script nomodule src="/build/chameleon.js"></script>
+    <link href="/build/chameleon.css" rel="stylesheet" />
+
+    <style>
+      body {
+        display: grid;
+        grid-template-columns: 1fr 260px;
+        gap: var(--spacing-un-spacing--l);
+      }
+
+      ch-combo-box {
+        border: 8px solid;
+        padding: 8px;
+        margin: 4px;
+        background-color: aliceblue;
+      }
+
+      ch-combo-box:focus-visible {
+        border-color: blueviolet;
+      }
+
+      ch-combo-box::part(window) {
+        background-color: beige;
+        border: 1px solid;
+        padding: 8px;
+      }
+
+      ch-combo-box::part(item disabled),
+      ch-combo-box::part(group disabled) {
+        opacity: 0.5;
+      }
+
+      ch-combo-box::part(item nested) {
+        margin-inline-start: 1em;
+      }
+
+      ch-combo-box::part(item) {
+        border: 1px solid;
+        background-color: rgb(215, 179, 136);
+      }
+
+      ch-combo-box::part(item):hover {
+        filter: brightness(0.85);
+      }
+
+      ch-combo-box::part(group__caption) {
+        font-family: SourceSansPro_Bold;
+      }
+    </style>
+  </head>
+  <body class="white-label">
+    <div class="card">
+      <form id="myForm">
+        <div>
+          <label for="combobox-1">Label for combobox-1</label>
+          <ch-combo-box
+            name="combobox-1"
+            id="combobox-1"
+            placeholder="Choose a value..."
+          ></ch-combo-box>
+        </div>
+
+        <div>
+          <label>
+            Label for combobox-2
+            <ch-combo-box></ch-combo-box>
+          </label>
+        </div>
+
+        <label for="combobox-3">Label for combobox-3</label>
+        <ch-combo-box
+          accessible-name="Custom label 3"
+          id="combobox-3"
+          value="Value 3"
+        ></ch-combo-box>
+
+        <label>
+          Label for combobox-4
+          <ch-combo-box
+            name="checkboxxxxx"
+            accessible-name="Custom label 4"
+            value="Value 4"
+          ></ch-combo-box>
+        </label>
+
+        <label>
+          Native input checkbox
+          <input
+            name="native"
+            type="checkbox"
+            aria-label="Holaa"
+            value="nativeeee"
+          />
+        </label>
+
+        <div>
+          <label>
+            "Native" Select
+            <select id="native-select">
+              <option value="1">Value 1</option>
+              <option value="2">Value 2</option>
+              <option value="3">Value 3</option>
+              <option value="4">Value 4</option>
+            </select>
+          </label>
+        </div>
+
+        <div>
+          <label>
+            "Native" Web Component
+            <ch-native></ch-native>
+          </label>
+        </div>
+
+        <label for="lname">Last name:</label>
+        <input type="text" id="lname" name="lname" value="Doe" />
+
+        <div>
+          <label style="display: grid">
+            Last name 2:
+            <input type="checkbox" name="lname" value="Doe" />
+          </label>
+        </div>
+      </form>
+    </div>
+
+    <div class="card">
+      <div></div>
+    </div>
+
+    <script>
+      const comboBox1 = document.getElementById("combobox-1");
+      const nativeSelect = document.getElementById("native-select");
+
+      nativeSelect.addEventListener("input", () => {
+        console.log("Native select input... - - - Value:", nativeSelect.value);
+      });
+
+      nativeSelect.addEventListener("change", () => {
+        console.log("Native select change... - - - Value:", nativeSelect.value);
+      });
+
+      comboBox1.addEventListener("input", () => {
+        console.log("ComboBox 1 input... - - - Value:", comboBox1.value);
+      });
+
+      comboBox1.addEventListener("change", () => {
+        console.log("ComboBox 1 change... - - - Value:", comboBox1.value);
+      });
+
+      const comboBox1Items = [
+        { value: "Value 1", caption: "Etiqueta para el valor 1" },
+        {
+          value: "Value 2",
+          caption: "Etiqueta para el valor 2",
+          items: [
+            { value: "Value 2.1", caption: "Etiqueta para el valor 2.1" },
+            { value: "Value 2.2", caption: "Etiqueta para el valor 2.2" }
+          ]
+        },
+        {
+          value: "Value 3",
+          caption: "Etiqueta para el valor 3",
+          disabled: true
+        },
+        { value: "Value 4", caption: "Etiqueta para el valor 4" },
+        {
+          value: "Value 5",
+          caption: "Etiqueta para el valor 5",
+          disabled: true,
+          items: [
+            { value: "Value 5.1", caption: "Etiqueta para el valor 5.1" },
+            { value: "Value 5.2", caption: "Etiqueta para el valor 5.2" },
+            {
+              value: "Value 5.3",
+              caption: "Etiqueta para el valor 5.3",
+              disabled: false
+            },
+            { value: "Value 5.4", caption: "Etiqueta para el valor 5.4" }
+          ]
+        },
+        {
+          value: "Value 6",
+          caption: "Etiqueta para el valor 6",
+          items: [
+            {
+              value: "Value 6.1",
+              caption: "Etiqueta para el valor 6.1",
+              disabled: true
+            },
+            {
+              value: "Value 6.2",
+              caption: "Etiqueta para el valor 6.2",
+              disabled: true
+            },
+            {
+              value: "Value 6.3",
+              caption: "Etiqueta para el valor 6.3",
+              disabled: false
+            },
+            { value: "Value 6.4", caption: "Etiqueta para el valor 6.4" }
+          ]
+        },
+        {
+          value: "Value 7",
+          caption: "Etiqueta para el valor 7",
+          disabled: true
+        },
+        { value: "Value 8", caption: "Etiqueta para el valor 8" }
+      ];
+
+      comboBox1.items = comboBox1Items;
+
+      class PopupInfo extends HTMLElement {
+        static formAssociated = true;
+        #internals;
+
+        constructor() {
+          // Always call super first in constructor
+          super();
+          this.#internals = this.attachInternals();
+        }
+
+        connectedCallback() {
+          // Create a shadow root
+          const shadow = this.attachShadow({
+            mode: "open",
+            delegatesFocus: true
+          });
+
+          this.shadowRoot.innerHTML = "<textarea></textarea>";
+        }
+      }
+
+      customElements.define("ch-native", PopupInfo);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Added ch-combo-box control.
   - It supports keyboard navigation.

   - It supports integration with web forms.
   - Custom render when used in desktop devices.
   - Accessibility enabled.
   - Items are rendered using the `items` property.