### PR TITLE
Add `ch-segmented-control-render` and `ch-slider` controls

### DIFF
--- a/src/common/_base.scss
+++ b/src/common/_base.scss
@@ -34,6 +34,20 @@ $default-decorative-image-size: 0.875em;
   }
 }
 
+@mixin input-reset() {
+  input,
+  select,
+  textarea {
+    padding: 0;
+    margin: 0;
+    background-color: unset;
+    border: unset;
+    color: unset;
+    font: unset;
+    outline: unset;
+  }
+}
+
 @mixin reset-browser-defaults-properties-1() {
   background-color: unset;
   border: none;

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -10,6 +10,11 @@ export interface AccessibleNameComponent {
 }
 
 export interface DisableableComponent {
+  /**
+   * This attribute allows you specify if the element is disabled.
+   * If disabled, it will not trigger any user interaction related event
+   * (for example, click event).
+   */
   disabled: boolean;
 }
 

--- a/src/common/reserverd-names.ts
+++ b/src/common/reserverd-names.ts
@@ -57,3 +57,20 @@ export const DROPDOWN_PARTS_DICTIONARY = {
 } as const;
 
 export const DROPDOWN_EXPORT_PARTS = joinParts(DROPDOWN_PARTS_DICTIONARY);
+
+// - - - - - - - - - - - - - - - - - - - -
+//         Segmented control Parts
+// - - - - - - - - - - - - - - - - - - - -
+export const SEGMENTED_CONTROL_PARTS_DICTIONARY = {
+  ACTION: "action",
+  DISABLED: "disabled",
+  SELECTED: "selected",
+  UNSELECTED: "unselected",
+  FIRST: "first",
+  LAST: "last",
+  BETWEEN: "between"
+} as const;
+
+export const SEGMENTED_CONTROL_EXPORT_PARTS = joinParts(
+  SEGMENTED_CONTROL_PARTS_DICTIONARY
+);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -29,6 +29,7 @@ import { ChPaginatorNavigateClickedEvent, ChPaginatorNavigateType } from "./comp
 import { ChPaginatorPagesPageChangedEvent } from "./components/paginator/paginator-pages/ch-paginator-pages";
 import { ChPopoverAlign, PopoverActionElement } from "./components/popover/types";
 import { ecLevel } from "./components/qr/ch-qr";
+import { SegmentedControlItem } from "./components/renders/segmented-control/types";
 import { SuggestItemSelectedEvent } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
 import { FocusChangeAttempt, SuggestItemSelectedEvent as SuggestItemSelectedEvent1 } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
 import { SelectorCategoryData } from "./components/test/test-suggest/test-suggest";
@@ -67,6 +68,7 @@ export { ChPaginatorNavigateClickedEvent, ChPaginatorNavigateType } from "./comp
 export { ChPaginatorPagesPageChangedEvent } from "./components/paginator/paginator-pages/ch-paginator-pages";
 export { ChPopoverAlign, PopoverActionElement } from "./components/popover/types";
 export { ecLevel } from "./components/qr/ch-qr";
+export { SegmentedControlItem } from "./components/renders/segmented-control/types";
 export { SuggestItemSelectedEvent } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
 export { FocusChangeAttempt, SuggestItemSelectedEvent as SuggestItemSelectedEvent1 } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
 export { SelectorCategoryData } from "./components/test/test-suggest/test-suggest";
@@ -1501,6 +1503,77 @@ export namespace Components {
          */
         "text": string | undefined;
     }
+    /**
+     * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+     * This control represents and item of the ch-segmented-control-render
+     */
+    interface ChSegmentedControlItem {
+        /**
+          * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
+         */
+        "accessibleName"?: string;
+        /**
+          * `true` if the control is the not the first or last item in the ch-segmented-control-render.
+         */
+        "between": boolean;
+        /**
+          * Specifies the caption that the control will display.
+         */
+        "caption"?: string;
+        /**
+          * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+         */
+        "disabled"?: boolean;
+        /**
+          * Specifies the src of the end image.
+         */
+        "endImgSrc": string;
+        /**
+          * Specifies how the end image will be rendered.
+         */
+        "endImgType": Exclude<ImageRender, "img">;
+        /**
+          * `true` if the control is the first item in the ch-segmented-control-render.
+         */
+        "first": boolean;
+        /**
+          * `true` if the control is the last item in the ch-segmented-control-render.
+         */
+        "last": boolean;
+        /**
+          * Specifies if the control is selected.
+         */
+        "selected": boolean;
+        /**
+          * Specifies the src of the start image.
+         */
+        "startImgSrc": string;
+        /**
+          * Specifies how the start image will be rendered.
+         */
+        "startImgType": Exclude<ImageRender, "img">;
+    }
+    /**
+     * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+     */
+    interface ChSegmentedControlRender {
+        /**
+          * Specifies the parts that are exported by the internal segmented-control-item. This property is useful to override the exported parts.
+         */
+        "exportParts": string;
+        /**
+          * A CSS class to set as the `ch-segmented-control-item` element class. This default class is used for the items that don't have an explicit class.
+         */
+        "itemCssClass": string;
+        /**
+          * This property lets you define the items of the ch-segmented-control-render control.
+         */
+        "items"?: SegmentedControlItem[];
+        /**
+          * Specifies the ID of the selected item
+         */
+        "selectedId": string;
+    }
     interface ChSelect {
         "arrowIconSrc": string;
         /**
@@ -1614,6 +1687,43 @@ export namespace Components {
           * If this attribute is present the item will be initially uncollapsed
          */
         "uncollapsed": boolean;
+    }
+    /**
+     * The slider control is a input where the user selects a value from within a given range.
+     */
+    interface ChSlider {
+        /**
+          * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
+         */
+        "accessibleName"?: string;
+        /**
+          * This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).
+         */
+        "disabled": false;
+        /**
+          * Specifies an id for the internal input. Useful to label the internal input by using a label tag.
+         */
+        "inputId"?: string;
+        /**
+          * This attribute lets you specify maximum value of the slider.
+         */
+        "maxValue": number;
+        /**
+          * This attribute lets you specify minimum value of the slider.
+         */
+        "minValue": number;
+        /**
+          * This attribute lets you indicate whether the control should display a bubble with the current value upon interaction.
+         */
+        "showValue": false;
+        /**
+          * This attribute lets you specify the step of the slider.  This attribute is useful when the values of the slider can only take some discrete values. For example, if valid values are `[10, 20, 30]` set the `minValue` to `10`, the maxValue to `30`, and the step to `10`. If the step is `0`, the any intermediate value is valid.
+         */
+        "step": number;
+        /**
+          * The value of the control.
+         */
+        "value": number;
     }
     interface ChStepList {
     }
@@ -2466,6 +2576,14 @@ export interface ChPopoverCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChPopoverElement;
 }
+export interface ChSegmentedControlItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLChSegmentedControlItemElement;
+}
+export interface ChSegmentedControlRenderCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLChSegmentedControlRenderElement;
+}
 export interface ChSelectCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChSelectElement;
@@ -2485,6 +2603,10 @@ export interface ChSidebarMenuCustomEvent<T> extends CustomEvent<T> {
 export interface ChSidebarMenuListItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChSidebarMenuListItemElement;
+}
+export interface ChSliderCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLChSliderElement;
 }
 export interface ChStepListItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -3249,6 +3371,47 @@ declare global {
         prototype: HTMLChQrElement;
         new (): HTMLChQrElement;
     };
+    interface HTMLChSegmentedControlItemElementEventMap {
+        "selectedChange": string;
+    }
+    /**
+     * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+     * This control represents and item of the ch-segmented-control-render
+     */
+    interface HTMLChSegmentedControlItemElement extends Components.ChSegmentedControlItem, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLChSegmentedControlItemElementEventMap>(type: K, listener: (this: HTMLChSegmentedControlItemElement, ev: ChSegmentedControlItemCustomEvent<HTMLChSegmentedControlItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLChSegmentedControlItemElementEventMap>(type: K, listener: (this: HTMLChSegmentedControlItemElement, ev: ChSegmentedControlItemCustomEvent<HTMLChSegmentedControlItemElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLChSegmentedControlItemElement: {
+        prototype: HTMLChSegmentedControlItemElement;
+        new (): HTMLChSegmentedControlItemElement;
+    };
+    interface HTMLChSegmentedControlRenderElementEventMap {
+        "selectedItemChange": string;
+    }
+    /**
+     * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+     */
+    interface HTMLChSegmentedControlRenderElement extends Components.ChSegmentedControlRender, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLChSegmentedControlRenderElementEventMap>(type: K, listener: (this: HTMLChSegmentedControlRenderElement, ev: ChSegmentedControlRenderCustomEvent<HTMLChSegmentedControlRenderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLChSegmentedControlRenderElementEventMap>(type: K, listener: (this: HTMLChSegmentedControlRenderElement, ev: ChSegmentedControlRenderCustomEvent<HTMLChSegmentedControlRenderElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLChSegmentedControlRenderElement: {
+        prototype: HTMLChSegmentedControlRenderElement;
+        new (): HTMLChSegmentedControlRenderElement;
+    };
     interface HTMLChSelectElementEventMap {
         "onToggle": any;
         "optionClickedEvent": any;
@@ -3353,6 +3516,27 @@ declare global {
     var HTMLChSidebarMenuListItemElement: {
         prototype: HTMLChSidebarMenuListItemElement;
         new (): HTMLChSidebarMenuListItemElement;
+    };
+    interface HTMLChSliderElementEventMap {
+        "change": number;
+        "input": number;
+    }
+    /**
+     * The slider control is a input where the user selects a value from within a given range.
+     */
+    interface HTMLChSliderElement extends Components.ChSlider, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLChSliderElementEventMap>(type: K, listener: (this: HTMLChSliderElement, ev: ChSliderCustomEvent<HTMLChSliderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLChSliderElementEventMap>(type: K, listener: (this: HTMLChSliderElement, ev: ChSliderCustomEvent<HTMLChSliderElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLChSliderElement: {
+        prototype: HTMLChSliderElement;
+        new (): HTMLChSliderElement;
     };
     interface HTMLChStepListElement extends Components.ChStepList, HTMLStencilElement {
     }
@@ -3696,6 +3880,8 @@ declare global {
         "ch-paginator-pages": HTMLChPaginatorPagesElement;
         "ch-popover": HTMLChPopoverElement;
         "ch-qr": HTMLChQrElement;
+        "ch-segmented-control-item": HTMLChSegmentedControlItemElement;
+        "ch-segmented-control-render": HTMLChSegmentedControlRenderElement;
         "ch-select": HTMLChSelectElement;
         "ch-select-option": HTMLChSelectOptionElement;
         "ch-shortcuts": HTMLChShortcutsElement;
@@ -3704,6 +3890,7 @@ declare global {
         "ch-sidebar-menu": HTMLChSidebarMenuElement;
         "ch-sidebar-menu-list": HTMLChSidebarMenuListElement;
         "ch-sidebar-menu-list-item": HTMLChSidebarMenuListItemElement;
+        "ch-slider": HTMLChSliderElement;
         "ch-step-list": HTMLChStepListElement;
         "ch-step-list-item": HTMLChStepListItemElement;
         "ch-style": HTMLChStyleElement;
@@ -5188,6 +5375,85 @@ declare namespace LocalJSX {
          */
         "text"?: string | undefined;
     }
+    /**
+     * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+     * This control represents and item of the ch-segmented-control-render
+     */
+    interface ChSegmentedControlItem {
+        /**
+          * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
+         */
+        "accessibleName"?: string;
+        /**
+          * `true` if the control is the not the first or last item in the ch-segmented-control-render.
+         */
+        "between"?: boolean;
+        /**
+          * Specifies the caption that the control will display.
+         */
+        "caption"?: string;
+        /**
+          * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+         */
+        "disabled"?: boolean;
+        /**
+          * Specifies the src of the end image.
+         */
+        "endImgSrc"?: string;
+        /**
+          * Specifies how the end image will be rendered.
+         */
+        "endImgType"?: Exclude<ImageRender, "img">;
+        /**
+          * `true` if the control is the first item in the ch-segmented-control-render.
+         */
+        "first"?: boolean;
+        /**
+          * `true` if the control is the last item in the ch-segmented-control-render.
+         */
+        "last"?: boolean;
+        /**
+          * Fired when the control is selected by user interaction.
+         */
+        "onSelectedChange"?: (event: ChSegmentedControlItemCustomEvent<string>) => void;
+        /**
+          * Specifies if the control is selected.
+         */
+        "selected"?: boolean;
+        /**
+          * Specifies the src of the start image.
+         */
+        "startImgSrc"?: string;
+        /**
+          * Specifies how the start image will be rendered.
+         */
+        "startImgType"?: Exclude<ImageRender, "img">;
+    }
+    /**
+     * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+     */
+    interface ChSegmentedControlRender {
+        /**
+          * Specifies the parts that are exported by the internal segmented-control-item. This property is useful to override the exported parts.
+         */
+        "exportParts"?: string;
+        /**
+          * A CSS class to set as the `ch-segmented-control-item` element class. This default class is used for the items that don't have an explicit class.
+         */
+        "itemCssClass"?: string;
+        /**
+          * This property lets you define the items of the ch-segmented-control-render control.
+         */
+        "items"?: SegmentedControlItem[];
+        /**
+          * Fired when the selected item change. It contains the information about the new selected id.
+         */
+        "onSelectedItemChange"?: (event: ChSegmentedControlRenderCustomEvent<string>) => void;
+        /**
+          * Specifies the ID of the selected item
+         */
+        "selectedId"?: string;
+    }
     interface ChSelect {
         "arrowIconSrc"?: string;
         /**
@@ -5323,6 +5589,51 @@ declare namespace LocalJSX {
           * If this attribute is present the item will be initially uncollapsed
          */
         "uncollapsed"?: boolean;
+    }
+    /**
+     * The slider control is a input where the user selects a value from within a given range.
+     */
+    interface ChSlider {
+        /**
+          * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
+         */
+        "accessibleName"?: string;
+        /**
+          * This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).
+         */
+        "disabled"?: false;
+        /**
+          * Specifies an id for the internal input. Useful to label the internal input by using a label tag.
+         */
+        "inputId"?: string;
+        /**
+          * This attribute lets you specify maximum value of the slider.
+         */
+        "maxValue"?: number;
+        /**
+          * This attribute lets you specify minimum value of the slider.
+         */
+        "minValue"?: number;
+        /**
+          * The `change` event is emitted when a change to the element's value is committed by the user.
+         */
+        "onChange"?: (event: ChSliderCustomEvent<number>) => void;
+        /**
+          * The `input` event is fired synchronously when the value is changed.
+         */
+        "onInput"?: (event: ChSliderCustomEvent<number>) => void;
+        /**
+          * This attribute lets you indicate whether the control should display a bubble with the current value upon interaction.
+         */
+        "showValue"?: false;
+        /**
+          * This attribute lets you specify the step of the slider.  This attribute is useful when the values of the slider can only take some discrete values. For example, if valid values are `[10, 20, 30]` set the `minValue` to `10`, the maxValue to `30`, and the step to `10`. If the step is `0`, the any intermediate value is valid.
+         */
+        "step"?: number;
+        /**
+          * The value of the control.
+         */
+        "value"?: number;
     }
     interface ChStepList {
     }
@@ -6127,6 +6438,8 @@ declare namespace LocalJSX {
         "ch-paginator-pages": ChPaginatorPages;
         "ch-popover": ChPopover;
         "ch-qr": ChQr;
+        "ch-segmented-control-item": ChSegmentedControlItem;
+        "ch-segmented-control-render": ChSegmentedControlRender;
         "ch-select": ChSelect;
         "ch-select-option": ChSelectOption;
         "ch-shortcuts": ChShortcuts;
@@ -6135,6 +6448,7 @@ declare namespace LocalJSX {
         "ch-sidebar-menu": ChSidebarMenu;
         "ch-sidebar-menu-list": ChSidebarMenuList;
         "ch-sidebar-menu-list-item": ChSidebarMenuListItem;
+        "ch-slider": ChSlider;
         "ch-step-list": ChStepList;
         "ch-step-list-item": ChStepListItem;
         "ch-style": ChStyle;
@@ -6293,6 +6607,15 @@ declare module "@stencil/core" {
              */
             "ch-popover": LocalJSX.ChPopover & JSXBase.HTMLAttributes<HTMLChPopoverElement>;
             "ch-qr": LocalJSX.ChQr & JSXBase.HTMLAttributes<HTMLChQrElement>;
+            /**
+             * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+             * This control represents and item of the ch-segmented-control-render
+             */
+            "ch-segmented-control-item": LocalJSX.ChSegmentedControlItem & JSXBase.HTMLAttributes<HTMLChSegmentedControlItemElement>;
+            /**
+             * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+             */
+            "ch-segmented-control-render": LocalJSX.ChSegmentedControlRender & JSXBase.HTMLAttributes<HTMLChSegmentedControlRenderElement>;
             "ch-select": LocalJSX.ChSelect & JSXBase.HTMLAttributes<HTMLChSelectElement>;
             "ch-select-option": LocalJSX.ChSelectOption & JSXBase.HTMLAttributes<HTMLChSelectOptionElement>;
             "ch-shortcuts": LocalJSX.ChShortcuts & JSXBase.HTMLAttributes<HTMLChShortcutsElement>;
@@ -6301,6 +6624,10 @@ declare module "@stencil/core" {
             "ch-sidebar-menu": LocalJSX.ChSidebarMenu & JSXBase.HTMLAttributes<HTMLChSidebarMenuElement>;
             "ch-sidebar-menu-list": LocalJSX.ChSidebarMenuList & JSXBase.HTMLAttributes<HTMLChSidebarMenuListElement>;
             "ch-sidebar-menu-list-item": LocalJSX.ChSidebarMenuListItem & JSXBase.HTMLAttributes<HTMLChSidebarMenuListItemElement>;
+            /**
+             * The slider control is a input where the user selects a value from within a given range.
+             */
+            "ch-slider": LocalJSX.ChSlider & JSXBase.HTMLAttributes<HTMLChSliderElement>;
             "ch-step-list": LocalJSX.ChStepList & JSXBase.HTMLAttributes<HTMLChStepListElement>;
             "ch-step-list-item": LocalJSX.ChStepListItem & JSXBase.HTMLAttributes<HTMLChStepListItemElement>;
             /**

--- a/src/components/renders/segmented-control/readme.md
+++ b/src/components/renders/segmented-control/readme.md
@@ -1,0 +1,44 @@
+# ch-segmented-control-render
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+
+## Properties
+
+| Property       | Attribute        | Description                                                                                                                                      | Type                     | Default                          |
+| -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------- |
+| `exportParts`  | `export-parts`   | Specifies the parts that are exported by the internal segmented-control-item. This property is useful to override the exported parts.            | `string`                 | `SEGMENTED_CONTROL_EXPORT_PARTS` |
+| `itemCssClass` | `item-css-class` | A CSS class to set as the `ch-segmented-control-item` element class. This default class is used for the items that don't have an explicit class. | `string`                 | `"segmented-control-item"`       |
+| `items`        | --               | This property lets you define the items of the ch-segmented-control-render control.                                                              | `SegmentedControlItem[]` | `undefined`                      |
+| `selectedId`   | `selected-id`    | Specifies the ID of the selected item                                                                                                            | `string`                 | `undefined`                      |
+
+
+## Events
+
+| Event                | Description                                                                                 | Type                  |
+| -------------------- | ------------------------------------------------------------------------------------------- | --------------------- |
+| `selectedItemChange` | Fired when the selected item change. It contains the information about the new selected id. | `CustomEvent<string>` |
+
+
+## Dependencies
+
+### Depends on
+
+- [ch-segmented-control-item](../../segmented-control-item)
+
+### Graph
+```mermaid
+graph TD;
+  ch-segmented-control-render --> ch-segmented-control-item
+  style ch-segmented-control-render fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/renders/segmented-control/segmented-control-render.scss
+++ b/src/components/renders/segmented-control/segmented-control-render.scss
@@ -1,0 +1,5 @@
+ch-segmented-control-render {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+}

--- a/src/components/renders/segmented-control/segmented-control-render.tsx
+++ b/src/components/renders/segmented-control/segmented-control-render.tsx
@@ -1,0 +1,91 @@
+import {
+  Component,
+  Event,
+  EventEmitter,
+  Host,
+  Listen,
+  Prop,
+  h
+} from "@stencil/core";
+import { SegmentedControlItem } from "./types";
+import { ChSegmentedControlItemCustomEvent } from "../../../components";
+import { SEGMENTED_CONTROL_EXPORT_PARTS } from "../../../common/reserverd-names";
+
+/**
+ * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+ */
+@Component({
+  shadow: false,
+  styleUrl: "segmented-control-render.scss",
+  tag: "ch-segmented-control-render"
+})
+export class ChSegmentedControl {
+  /**
+   * Specifies the parts that are exported by the internal
+   * segmented-control-item. This property is useful to override the exported
+   * parts.
+   */
+  @Prop() readonly exportParts: string = SEGMENTED_CONTROL_EXPORT_PARTS;
+
+  /**
+   * A CSS class to set as the `ch-segmented-control-item` element class.
+   * This default class is used for the items that don't have an explicit class.
+   */
+  @Prop() readonly itemCssClass: string = "segmented-control-item";
+
+  /**
+   * This property lets you define the items of the ch-segmented-control-render
+   * control.
+   */
+  @Prop() readonly items?: SegmentedControlItem[];
+
+  /**
+   * Specifies the ID of the selected item
+   */
+  @Prop({ mutable: true }) selectedId: string;
+
+  /**
+   * Fired when the selected item change. It contains the information about the
+   * new selected id.
+   */
+  @Event() selectedItemChange: EventEmitter<string>;
+
+  @Listen("selectedChange")
+  handleSelectedChange(event: ChSegmentedControlItemCustomEvent<string>) {
+    event.stopPropagation();
+
+    this.selectedId === event.detail;
+    this.selectedItemChange.emit(event.detail);
+
+    console.log(this.selectedId, event.detail);
+  }
+
+  #itemRender = (item: SegmentedControlItem, index: number) => {
+    const first = index === 0;
+    const last = index === this.items.length - 1;
+    const between = !first && !last;
+
+    return (
+      <ch-segmented-control-item
+        id={item.id}
+        accessibleName={item.accessibleName}
+        between={between}
+        caption={item.caption}
+        class={item.class || this.itemCssClass}
+        disabled={item.disabled}
+        exportparts={this.exportParts}
+        endImgSrc={item.endImgSrc}
+        endImgType={item.endImgType}
+        first={first}
+        last={last}
+        selected={this.selectedId === item.id}
+        startImgSrc={item.startImgSrc}
+        startImgType={item.startImgType}
+      ></ch-segmented-control-item>
+    );
+  };
+
+  render() {
+    return <Host role="list">{this.items?.map(this.#itemRender)}</Host>;
+  }
+}

--- a/src/components/renders/segmented-control/types.ts
+++ b/src/components/renders/segmented-control/types.ts
@@ -1,0 +1,13 @@
+import { ImageRender } from "../../../common/types";
+
+export type SegmentedControlItem = {
+  accessibleName?: string;
+  caption?: string;
+  class?: string;
+  disabled?: boolean;
+  endImgSrc?: string;
+  endImgType?: Exclude<ImageRender, "img">;
+  id: string;
+  startImgSrc?: string;
+  startImgType?: Exclude<ImageRender, "img">;
+};

--- a/src/components/segmented-control-item/readme.md
+++ b/src/components/segmented-control-item/readme.md
@@ -1,0 +1,59 @@
+# ch-segmented-control-item
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+This control represents and item of the ch-segmented-control-render
+
+## Properties
+
+| Property         | Attribute         | Description                                                                                                                                                       | Type                     | Default        |
+| ---------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------- |
+| `accessibleName` | `accessible-name` | Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element. | `string`                 | `undefined`    |
+| `between`        | `between`         | `true` if the control is the not the first or last item in the ch-segmented-control-render.                                                                       | `boolean`                | `false`        |
+| `caption`        | `caption`         | Specifies the caption that the control will display.                                                                                                              | `string`                 | `undefined`    |
+| `disabled`       | `disabled`        | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).          | `boolean`                | `false`        |
+| `endImgSrc`      | `end-img-src`     | Specifies the src of the end image.                                                                                                                               | `string`                 | `undefined`    |
+| `endImgType`     | `end-img-type`    | Specifies how the end image will be rendered.                                                                                                                     | `"background" \| "mask"` | `"background"` |
+| `first`          | `first`           | `true` if the control is the first item in the ch-segmented-control-render.                                                                                       | `boolean`                | `false`        |
+| `last`           | `last`            | `true` if the control is the last item in the ch-segmented-control-render.                                                                                        | `boolean`                | `false`        |
+| `selected`       | `selected`        | Specifies if the control is selected.                                                                                                                             | `boolean`                | `undefined`    |
+| `startImgSrc`    | `start-img-src`   | Specifies the src of the start image.                                                                                                                             | `string`                 | `undefined`    |
+| `startImgType`   | `start-img-type`  | Specifies how the start image will be rendered.                                                                                                                   | `"background" \| "mask"` | `"background"` |
+
+
+## Events
+
+| Event            | Description                                             | Type                  |
+| ---------------- | ------------------------------------------------------- | --------------------- |
+| `selectedChange` | Fired when the control is selected by user interaction. | `CustomEvent<string>` |
+
+
+## Shadow Parts
+
+| Part         | Description |
+| ------------ | ----------- |
+| `"selected"` | ...         |
+
+
+## Dependencies
+
+### Used by
+
+ - [ch-segmented-control-render](../renders/segmented-control)
+
+### Graph
+```mermaid
+graph TD;
+  ch-segmented-control-render --> ch-segmented-control-item
+  style ch-segmented-control-item fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/segmented-control-item/segmented-control-item.scss
+++ b/src/components/segmented-control-item/segmented-control-item.scss
@@ -1,0 +1,47 @@
+@import "../../common/_base";
+
+@include button-reset();
+
+// Must be placed after the button-reset()
+@include box-sizing();
+
+:host {
+  --ch-segmented-control-item__image-size: #{$default-decorative-image-size};
+  --ch-segmented-control-item__background-image-size: 100%;
+
+  display: contents;
+}
+
+// - - - - - - - - - - - - - - - -
+//             Images
+// - - - - - - - - - - - - - - - -
+.img--start::before,
+.img--end::after {
+  content: "";
+  display: block;
+  inline-size: var(--ch-segmented-control-item__image-size);
+  block-size: var(--ch-segmented-control-item__image-size);
+  min-inline-size: var(--ch-segmented-control-item__image-size);
+}
+
+.img--start {
+  --ch-img: var(--ch-start-img);
+}
+
+.img--end {
+  --ch-img: var(--ch-end-img);
+}
+
+.start-img-type--background::before,
+.end-img-type--background::after {
+  background: no-repeat center /
+    var(--ch-segmented-control-item__background-image-size) var(--ch-img);
+}
+
+.start-img-type--mask::before,
+.end-img-type--mask::after {
+  -webkit-mask: var(--ch-img) 50% 50% /
+    var(--ch-segmented-control-item__background-image-size)
+    var(--ch-segmented-control-item__background-image-size) no-repeat;
+  background-color: currentColor;
+}

--- a/src/components/segmented-control-item/segmented-control-item.tsx
+++ b/src/components/segmented-control-item/segmented-control-item.tsx
@@ -1,0 +1,152 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Host,
+  Prop,
+  h
+} from "@stencil/core";
+
+import { AccessibleNameComponent } from "../../common/interfaces";
+import { ImageRender } from "../../common/types";
+import { SEGMENTED_CONTROL_PARTS_DICTIONARY } from "../../common/reserverd-names";
+
+/**
+ * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
+ * This control represents and item of the ch-segmented-control-render
+ *
+ * @part selected - ...
+ */
+@Component({
+  shadow: true,
+  styleUrl: "segmented-control-item.scss",
+  tag: "ch-segmented-control-item"
+})
+export class ChSegmentedControlItem implements AccessibleNameComponent {
+  @Element() el: HTMLChSegmentedControlItemElement;
+
+  /**
+   * Specifies a short string, typically 1 to 3 words, that authors associate
+   * with an element to provide users of assistive technologies with a label
+   * for the element.
+   */
+  @Prop() readonly accessibleName?: string;
+
+  /**
+   * `true` if the control is the not the first or last item in the
+   * ch-segmented-control-render.
+   */
+  @Prop() readonly between: boolean = false;
+
+  /**
+   * Specifies the caption that the control will display.
+   */
+  @Prop() readonly caption?: string;
+
+  /**
+   * This attribute lets you specify if the element is disabled.
+   * If disabled, it will not fire any user interaction related event
+   * (for example, click event).
+   */
+  @Prop() readonly disabled?: boolean = false;
+
+  /**
+   * Specifies the src of the end image.
+   */
+  @Prop() readonly endImgSrc: string;
+
+  /**
+   * Specifies how the end image will be rendered.
+   */
+  @Prop() readonly endImgType: Exclude<ImageRender, "img"> = "background";
+
+  /**
+   * `true` if the control is the first item in the ch-segmented-control-render.
+   */
+  @Prop() readonly first: boolean = false;
+
+  /**
+   * `true` if the control is the last item in the ch-segmented-control-render.
+   */
+  @Prop() readonly last: boolean = false;
+
+  /**
+   * Specifies if the control is selected.
+   */
+  @Prop() readonly selected: boolean;
+
+  /**
+   * Specifies the src of the start image.
+   */
+  @Prop() readonly startImgSrc: string;
+
+  /**
+   * Specifies how the start image will be rendered.
+   */
+  @Prop() readonly startImgType: Exclude<ImageRender, "img"> = "background";
+
+  /**
+   * Fired when the control is selected by user interaction.
+   */
+  @Event() selectedChange: EventEmitter<string>;
+
+  #parts = () =>
+    `action${
+      this.disabled ? ` ${SEGMENTED_CONTROL_PARTS_DICTIONARY.DISABLED}` : ""
+    } ${
+      this.selected
+        ? SEGMENTED_CONTROL_PARTS_DICTIONARY.SELECTED
+        : SEGMENTED_CONTROL_PARTS_DICTIONARY.UNSELECTED
+    }${this.first ? ` ${SEGMENTED_CONTROL_PARTS_DICTIONARY.FIRST}` : ""}${
+      this.last ? ` ${SEGMENTED_CONTROL_PARTS_DICTIONARY.LAST}` : ""
+    }${this.between ? ` ${SEGMENTED_CONTROL_PARTS_DICTIONARY.BETWEEN}` : ""}`;
+
+  #handleSelectedChange = (event: MouseEvent) => {
+    event.stopPropagation();
+    this.selectedChange.emit(this.el.id);
+  };
+
+  render() {
+    const hasStartImg = !!this.startImgSrc;
+    const hasEndImg = !!this.endImgSrc;
+    const hasImages = hasStartImg || hasEndImg;
+
+    return (
+      <Host role="listitem">
+        <button
+          aria-label={this.accessibleName || null}
+          aria-selected={this.selected ? "true" : null}
+          class={
+            hasImages
+              ? {
+                  [`start-img-type--${
+                    this.startImgType ?? "background"
+                  } img--start`]: hasStartImg,
+                  [`end-img-type--${this.endImgType ?? "background"} img--end`]:
+                    hasEndImg
+                }
+              : undefined
+          }
+          part={this.#parts()}
+          style={
+            hasImages
+              ? {
+                  "--ch-start-img": hasStartImg
+                    ? `url("${this.startImgSrc}")`
+                    : undefined,
+                  "--ch-end-img": hasEndImg
+                    ? `url("${this.endImgSrc}")`
+                    : undefined
+                }
+              : undefined
+          }
+          type="button"
+          onClick={this.#handleSelectedChange}
+        >
+          {this.caption}
+        </button>
+      </Host>
+    );
+  }
+}

--- a/src/components/slider/readme.md
+++ b/src/components/slider/readme.md
@@ -1,0 +1,43 @@
+# ch-segmented-control-item
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+The slider control is a input where the user selects a value from within a given range.
+
+## Properties
+
+| Property         | Attribute         | Description                                                                                                                                                                                                                                                                                                                          | Type      | Default     |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | ----------- |
+| `accessibleName` | `accessible-name` | Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.                                                                                                                                                                    | `string`  | `undefined` |
+| `disabled`       | `disabled`        | This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).                                                                                                                                                                        | `boolean` | `false`     |
+| `inputId`        | `input-id`        | Specifies an id for the internal input. Useful to label the internal input by using a label tag.                                                                                                                                                                                                                                     | `string`  | `undefined` |
+| `maxValue`       | `max-value`       | This attribute lets you specify maximum value of the slider.                                                                                                                                                                                                                                                                         | `number`  | `5`         |
+| `minValue`       | `min-value`       | This attribute lets you specify minimum value of the slider.                                                                                                                                                                                                                                                                         | `number`  | `0`         |
+| `showValue`      | `show-value`      | This attribute lets you indicate whether the control should display a bubble with the current value upon interaction.                                                                                                                                                                                                                | `boolean` | `false`     |
+| `step`           | `step`            | This attribute lets you specify the step of the slider.  This attribute is useful when the values of the slider can only take some discrete values. For example, if valid values are `[10, 20, 30]` set the `minValue` to `10`, the maxValue to `30`, and the step to `10`. If the step is `0`, the any intermediate value is valid. | `number`  | `1`         |
+| `value`          | `value`           | The value of the control.                                                                                                                                                                                                                                                                                                            | `number`  | `0`         |
+
+
+## Events
+
+| Event    | Description                                                                                  | Type                  |
+| -------- | -------------------------------------------------------------------------------------------- | --------------------- |
+| `change` | The `change` event is emitted when a change to the element's value is committed by the user. | `CustomEvent<number>` |
+| `input`  | The `input` event is fired synchronously when the value is changed.                          | `CustomEvent<number>` |
+
+
+## Shadow Parts
+
+| Part      | Description |
+| --------- | ----------- |
+| `"input"` | ...         |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -1,0 +1,87 @@
+@import "../../common/_base";
+
+@include box-sizing();
+
+@mixin slider-thumb() {
+  appearance: none;
+  background-color: var(--ch-slider-thumb-color);
+  border: unset; // Required reset due to Mozilla
+  inline-size: var(--ch-slider-thumb-size);
+  block-size: var(--ch-slider-thumb-size);
+  border-radius: 50%;
+}
+
+ch-slider {
+  // Track defaults
+  --ch-slider-selected-track-background-color: color-mix(
+    in srgb,
+    currentColor 15%,
+    transparent
+  );
+
+  --ch-slider-unselected-track-background-color: color-mix(
+    in srgb,
+    currentColor 15%,
+    transparent
+  );
+
+  // Thumb defaults
+  --ch-slider-thumb-size: clamp(8px, 1.5em, 24px);
+
+  --ch-slider-thumb-color: currentColor;
+
+  --ch-slider-track-block-size: clamp(3px, 0.25em, 16px);
+
+  display: inline-grid;
+  position: relative;
+
+  & > .ch-slider__slider {
+    display: grid;
+    block-size: var(--ch-slider-track-block-size);
+    cursor: pointer;
+    z-index: 1; // Necessary to show the thumb above the track
+
+    // Reset browser defaults
+    appearance: none;
+
+    // &::after {
+    //   inline-size: var(--slider-unselected-value);
+    //   inset-inline-end: 0;
+    // }
+
+    // - - - - - - - - - - - - - - - -
+    //              Thumb
+    // - - - - - - - - - - - - - - - -
+    &::-webkit-slider-thumb {
+      @include slider-thumb;
+    }
+
+    &::-moz-range-thumb {
+      @include slider-thumb;
+    }
+  }
+
+  // - - - - - - - - - - - - - - - -
+  //              Track
+  // - - - - - - - - - - - - - - - -
+  > .ch-slider__track {
+    display: flex;
+    position: absolute;
+    color: inherit;
+    inline-size: 100%;
+    block-size: var(--ch-slider-track-block-size);
+    overflow: hidden;
+
+    > .ch-slider__track--selected {
+      background-color: var(--ch-slider-selected-track-background-color);
+      inline-size: var(--slider-selected-value);
+      block-size: 100%;
+    }
+
+    > .ch-slider__track--unselected {
+      background-color: var(--ch-slider-unselected-track-background-color);
+      inline-size: var(--slider-unselected-value);
+      block-size: 100%;
+    }
+  }
+}

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -1,0 +1,182 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Host,
+  Prop,
+  h
+} from "@stencil/core";
+
+import { AccessibleNameComponent } from "../../common/interfaces";
+import { SyncWithRAF } from "../../common/sync-with-frames";
+
+const DEFAULT_PERCENTAGE_VALUE_WHEN_MIN_EQUALS_MAX = 0;
+
+/**
+ * The slider control is a input where the user selects a value from within a given range.
+ *
+ * @part input - ...
+ */
+@Component({
+  shadow: false,
+  styleUrl: "slider.scss",
+  tag: "ch-slider"
+})
+export class ChSlider implements AccessibleNameComponent {
+  #lastModifiedValue = 0;
+  #valuePositionRAF = new SyncWithRAF();
+
+  @Element() el: HTMLChSliderElement;
+
+  /**
+   * Specifies a short string, typically 1 to 3 words, that authors associate
+   * with an element to provide users of assistive technologies with a label
+   * for the element.
+   */
+  @Prop() readonly accessibleName?: string;
+
+  /**
+   * This attribute allows you specify if the element is disabled.
+   * If disabled, it will not trigger any user interaction related event
+   * (for example, click event).
+   */
+  @Prop() readonly disabled = false;
+
+  /**
+   * Specifies an id for the internal input. Useful to label the internal input
+   * by using a label tag.
+   */
+  @Prop() readonly inputId?: string;
+
+  /**
+   * This attribute lets you specify maximum value of the slider.
+   */
+  @Prop() readonly maxValue: number = 5;
+
+  /**
+   * This attribute lets you specify minimum value of the slider.
+   */
+  @Prop() readonly minValue: number = 0;
+
+  /**
+   * This attribute lets you indicate whether the control should display a
+   * bubble with the current value upon interaction.
+   */
+  @Prop() readonly showValue = false;
+
+  /**
+   * This attribute lets you specify the step of the slider.
+   *
+   * This attribute is useful when the values of the slider can only take some
+   * discrete values. For example, if valid values are `[10, 20, 30]` set the
+   * `minValue` to `10`, the maxValue to `30`, and the step to `10`. If the
+   * step is `0`, the any intermediate value is valid.
+   */
+  @Prop() readonly step: number = 1;
+
+  /**
+   * The value of the control.
+   */
+  @Prop({ mutable: true }) value = 0;
+
+  /**
+   * The `change` event is emitted when a change to the element's value is
+   * committed by the user.
+   */
+  @Event() change: EventEmitter<number>;
+
+  /**
+   * The `input` event is fired synchronously when the value is changed.
+   */
+  @Event() input: EventEmitter<number>;
+
+  #handleChange = (event: UIEvent) => {
+    event.stopPropagation();
+    const value = (event.target as HTMLInputElement).value;
+
+    // Toggle the value property
+    this.value = Number(value);
+
+    this.change.emit(this.value);
+  };
+
+  #handleInput = (event: UIEvent) => {
+    event.stopPropagation();
+
+    // Update the last value modified by the user interaction
+    this.#lastModifiedValue = Number((event.target as HTMLInputElement).value);
+
+    this.#valuePositionRAF.perform(this.#updateValue);
+  };
+
+  #updateValue = () => {
+    this.value = this.#lastModifiedValue;
+    this.input.emit(this.#lastModifiedValue);
+  };
+
+  #ensureValueIsInBetween = (
+    minValue: number,
+    value: number,
+    maxValue: number
+  ) => Math.min(Math.max(minValue, value), maxValue);
+
+  #getValuePercentage = (
+    minValue: number,
+    value: number,
+    maxValue: number
+  ): number => {
+    const selectedValue = (value - minValue) / (maxValue - minValue);
+
+    return selectedValue * 100;
+  };
+
+  disconnectedCallback() {
+    this.#valuePositionRAF.cancel();
+  }
+
+  render() {
+    const actualMaxValue = Math.max(this.minValue, this.maxValue);
+    const actualValue = this.#ensureValueIsInBetween(
+      this.minValue,
+      this.value,
+      actualMaxValue
+    );
+
+    const valueInPercentage =
+      this.minValue < actualMaxValue
+        ? this.#getValuePercentage(this.minValue, actualValue, actualMaxValue)
+        : DEFAULT_PERCENTAGE_VALUE_WHEN_MIN_EQUALS_MAX;
+
+    return (
+      <Host>
+        <div class="ch-slider__track" aria-hidden="true">
+          <div
+            class="ch-slider__track--selected"
+            style={{ "--slider-selected-value": `${valueInPercentage}%` }}
+          ></div>
+          <div
+            class="ch-slider__track--unselected"
+            style={{
+              "--slider-unselected-value": `${100 - valueInPercentage}%`
+            }}
+          ></div>
+        </div>
+
+        <input
+          id={this.inputId || null}
+          aria-label={this.accessibleName || null}
+          class="ch-slider__slider"
+          disabled={this.disabled}
+          type="range"
+          min={this.minValue}
+          max={actualMaxValue}
+          step={this.step}
+          value={actualValue}
+          onChange={this.#handleChange}
+          onInput={this.#handleInput}
+        />
+      </Host>
+    );
+  }
+}

--- a/src/showcase/models/components.js
+++ b/src/showcase/models/components.js
@@ -23,6 +23,7 @@ const components = [
   "paginator",
   "popover",
   ["qr", "QR"],
+  "segmented-control",
   "select",
   "shortcuts",
   "sidebar",

--- a/src/showcase/models/components.js
+++ b/src/showcase/models/components.js
@@ -28,6 +28,7 @@ const components = [
   "shortcuts",
   "sidebar",
   "sidebar-old",
+  "slider",
   "step-list",
   "style",
   "suggest",

--- a/src/showcase/pages/segmented-control.html
+++ b/src/showcase/pages/segmented-control.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Checkbox</title>
+    <script type="module" src="/build/chameleon.esm.js"></script>
+    <script nomodule src="/build/chameleon.js"></script>
+    <link href="/build/chameleon.css" rel="stylesheet" />
+
+    <style>
+      body {
+        display: grid;
+        grid-template-columns: 1fr 260px;
+        gap: var(--spacing-un-spacing--l);
+      }
+
+      .segmented-control-item::part(action) {
+        padding-block: var(--spacing-un-spacing--m);
+        padding-inline: var(--spacing-un-spacing--l);
+      }
+    </style>
+  </head>
+  <body class="white-label">
+    <div class="card">
+      <ch-segmented-control-render
+        style="height: 80px"
+      ></ch-segmented-control-render>
+    </div>
+
+    <div class="card">
+      <div></div>
+    </div>
+
+    <script>
+      const segmentedControl = document.querySelector(
+        "ch-segmented-control-render"
+      );
+
+      const segmentedControlItems = [
+        { id: "Value 1", caption: "Label for the value 1" },
+        {
+          id: "Value 2",
+          caption: "Label for the value 2"
+        },
+        {
+          id: "Value 3",
+          caption: "Label for the value 3",
+          disabled: true
+        },
+        { id: "Value 4", caption: "Label for the value 4" },
+        {
+          id: "Value 5",
+          caption: "Label for the value 5",
+          disabled: true
+        },
+        {
+          id: "Value 6",
+          caption: "Label for the value 6"
+        },
+        {
+          id: "Value 7",
+          caption: "Label for the value 7",
+          disabled: true
+        },
+        { id: "Value 8", caption: "Label for the value 8" }
+      ];
+
+      segmentedControl.items = segmentedControlItems;
+    </script>
+  </body>
+</html>

--- a/src/showcase/pages/slider.html
+++ b/src/showcase/pages/slider.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Checkbox</title>
+    <script type="module" src="/build/chameleon.esm.js"></script>
+    <script nomodule src="/build/chameleon.js"></script>
+    <link href="/build/chameleon.css" rel="stylesheet" />
+
+    <style>
+      body {
+        display: grid;
+        grid-template-columns: 1fr 260px;
+        gap: var(--spacing-un-spacing--l);
+      }
+
+      ch-slider .ch-slider__slider::-webkit-slider-thumb {
+        border: 2px solid red;
+      }
+    </style>
+  </head>
+  <body class="white-label">
+    <div class="card">
+      <label>
+        Slider test 1
+
+        <ch-slider value="2" step="2" max-value="50"></ch-slider>
+      </label>
+
+      <label for="slider-2"> Slider test 2 </label>
+      <ch-slider id="slider-2" value="2" step="2" max-value="50"></ch-slider>
+    </div>
+
+    <div class="card">
+      <div></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Add `ch-segmented-control` control.
 Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
 This control is not intended to be used in form layouts, as it is a simple `ul` `li` and `button` pattern.
 

 - Add `ch-slider` control.
 The slider control is an input where the user selects a value from within a given range.