### PR TITLE
Add support for Shadow DOM in `ch-slider`

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1701,10 +1701,6 @@ export namespace Components {
          */
         "disabled": false;
         /**
-          * Specifies an id for the internal input. Useful to label the internal input by using a label tag.
-         */
-        "inputId"?: string;
-        /**
           * This attribute lets you specify maximum value of the slider.
          */
         "maxValue": number;
@@ -5602,10 +5598,6 @@ declare namespace LocalJSX {
           * This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).
          */
         "disabled"?: false;
-        /**
-          * Specifies an id for the internal input. Useful to label the internal input by using a label tag.
-         */
-        "inputId"?: string;
         /**
           * This attribute lets you specify maximum value of the slider.
          */

--- a/src/components/slider/readme.md
+++ b/src/components/slider/readme.md
@@ -43,12 +43,13 @@ The slider control is a input where the user selects a value from within a given
 
 ## CSS Custom Properties
 
-| Name                                             | Description                                                                                                                     |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `--ch-slider-thumb-background-color`             | Specifies the background-color of the thumb. @default currentColor                                                              |
-| `--ch-slider-thumb-size`                         | Specifies the size of the thumb. @default clamp(8px, 1.5em, 24px)                                                               |
-| `--ch-slider-track__selected-background-color`   | Specifies the background-color of the selected portion of the track. @default color-mix(in srgb, currentColor 15%, transparent) |
-| `--ch-slider-track__unselected-background-color` | Specifies the block size of the track. @default clamp(3px, 0.25em, 16px)                                                        |
+| Name                                             | Description                                                                                                                       |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `--ch-slider-thumb-background-color`             | Specifies the background-color of the thumb. @default currentColor                                                                |
+| `--ch-slider-thumb-size`                         | Specifies the size of the thumb. @default clamp(8px, 1.5em, 24px)                                                                 |
+| `--ch-slider-track-block-size`                   | Specifies the block size of the track. @default clamp(3px, 0.25em, 16px)                                                          |
+| `--ch-slider-track__selected-background-color`   | Specifies the background-color of the selected portion of the track. @default color-mix(in srgb, currentColor 15%, transparent)   |
+| `--ch-slider-track__unselected-background-color` | Specifies the background-color of the unselected portion of the track. @default color-mix(in srgb, currentColor 15%, transparent) |
 
 
 ----------------------------------------------

--- a/src/components/slider/readme.md
+++ b/src/components/slider/readme.md
@@ -15,7 +15,6 @@ The slider control is a input where the user selects a value from within a given
 | ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | ----------- |
 | `accessibleName` | `accessible-name` | Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.                                                                                                                                                                    | `string`  | `undefined` |
 | `disabled`       | `disabled`        | This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).                                                                                                                                                                        | `boolean` | `false`     |
-| `inputId`        | `input-id`        | Specifies an id for the internal input. Useful to label the internal input by using a label tag.                                                                                                                                                                                                                                     | `string`  | `undefined` |
 | `maxValue`       | `max-value`       | This attribute lets you specify maximum value of the slider.                                                                                                                                                                                                                                                                         | `number`  | `5`         |
 | `minValue`       | `min-value`       | This attribute lets you specify minimum value of the slider.                                                                                                                                                                                                                                                                         | `number`  | `0`         |
 | `showValue`      | `show-value`      | This attribute lets you indicate whether the control should display a bubble with the current value upon interaction.                                                                                                                                                                                                                | `boolean` | `false`     |
@@ -33,9 +32,23 @@ The slider control is a input where the user selects a value from within a given
 
 ## Shadow Parts
 
-| Part      | Description |
-| --------- | ----------- |
-| `"input"` | ...         |
+| Part                  | Description                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"disabled"`          | Present in all parts when the control is disabled (`disabled` === `true`).                                                                              |
+| `"thumb"`             | The thumb of the slider element.                                                                                                                        |
+| `"track"`             | The track of the slider element.                                                                                                                        |
+| `"track__selected"`   | Represents the portion of the track that is selected, that is, the portion of the track that starts at the min value and goes to the current value.     |
+| `"track__unselected"` | Represents the portion of the track that is not selected, that is, the portion of the track that starts at the current value and goes to the max value. |
+
+
+## CSS Custom Properties
+
+| Name                                             | Description                                                                                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `--ch-slider-thumb-background-color`             | Specifies the background-color of the thumb. @default currentColor                                                              |
+| `--ch-slider-thumb-size`                         | Specifies the size of the thumb. @default clamp(8px, 1.5em, 24px)                                                               |
+| `--ch-slider-track__selected-background-color`   | Specifies the background-color of the selected portion of the track. @default color-mix(in srgb, currentColor 15%, transparent) |
+| `--ch-slider-track__unselected-background-color` | Specifies the block size of the track. @default clamp(3px, 0.25em, 16px)                                                        |
 
 
 ----------------------------------------------

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -4,23 +4,48 @@
 @include box-sizing();
 
 :host {
-  // Track defaults
+  /**
+   * @prop --ch-slider-thumb-background-color:
+   * Specifies the background-color of the thumb. 
+   * @default currentColor
+   */
+  --ch-slider-thumb-background-color: currentColor;
+
+  /**
+    * @prop --ch-slider-thumb-size:
+    * Specifies the size of the thumb. 
+    * @default clamp(8px, 1.5em, 24px)
+    */
+  --ch-slider-thumb-size: clamp(8px, 1.5em, 24px);
+
+  /**
+   * @prop --ch-slider-track__unselected-background-color:
+   * Specifies the block size of the track. 
+   * @default clamp(3px, 0.25em, 16px)
+   */
+  --ch-slider-track-block-size: clamp(3px, 0.25em, 16px);
+
+  /**
+   * @prop --ch-slider-track__selected-background-color:
+   * Specifies the background-color of the selected portion of the track. 
+   * @default color-mix(in srgb, currentColor 15%, transparent)
+   */
   --ch-slider-track__selected-background-color: color-mix(
     in srgb,
     currentColor 15%,
     transparent
   );
 
+  /**
+   * @prop --ch-slider-track__unselected-background-color:
+   * Specifies the background-color of the unselected portion of the track. 
+   * @default color-mix(in srgb, currentColor 15%, transparent)
+   */
   --ch-slider-track__unselected-background-color: color-mix(
     in srgb,
     currentColor 15%,
     transparent
   );
-  --ch-slider-track-block-size: clamp(3px, 0.25em, 16px);
-
-  // Thumb defaults
-  --ch-slider-thumb-background-color: currentColor;
-  --ch-slider-thumb-size: clamp(8px, 1.5em, 24px);
 
   display: inline-grid;
 }

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -42,13 +42,8 @@
   appearance: none;
   opacity: 0;
 
-  // &::after {
-  //   inline-size: var(--slider-unselected-value);
-  //   inset-inline-end: 0;
-  // }
-
   // - - - - - - - - - - - - - - - -
-  //              Thumb
+  //           Thumb reset
   // - - - - - - - - - - - - - - - -
   &::-webkit-slider-thumb {
     appearance: none;
@@ -71,7 +66,6 @@
 .track {
   display: flex;
   position: absolute;
-  color: inherit;
   inline-size: 100%;
   block-size: var(--ch-slider-track-block-size);
   overflow: hidden;

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -19,7 +19,7 @@
   --ch-slider-thumb-size: clamp(8px, 1.5em, 24px);
 
   /**
-   * @prop --ch-slider-track__unselected-background-color:
+   * @prop --ch-slider-track-block-size:
    * Specifies the block size of the track. 
    * @default clamp(3px, 0.25em, 16px)
    */

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -1,17 +1,9 @@
 @import "../../common/_base";
 
+@include input-reset();
 @include box-sizing();
 
-@mixin slider-thumb() {
-  appearance: none;
-  background-color: var(--ch-slider-thumb-color);
-  border: unset; // Required reset due to Mozilla
-  inline-size: var(--ch-slider-thumb-size);
-  block-size: var(--ch-slider-thumb-size);
-  border-radius: 50%;
-}
-
-ch-slider {
+:host {
   // Track defaults
   --ch-slider-selected-track-background-color: color-mix(
     in srgb,
@@ -28,60 +20,91 @@ ch-slider {
   // Thumb defaults
   --ch-slider-thumb-size: clamp(8px, 1.5em, 24px);
 
-  --ch-slider-thumb-color: currentColor;
+  --ch-slider-thumb-background-color: currentColor;
 
   --ch-slider-track-block-size: clamp(3px, 0.25em, 16px);
 
   display: inline-grid;
+}
+
+.position-absolute-wrapper {
+  display: grid;
   position: relative;
+  block-size: fit-content;
+}
 
-  & > .ch-slider__slider {
-    display: grid;
-    block-size: var(--ch-slider-track-block-size);
-    cursor: pointer;
-    z-index: 1; // Necessary to show the thumb above the track
+.slider {
+  display: grid;
+  block-size: var(--ch-slider-track-block-size);
+  cursor: pointer;
 
-    // Reset browser defaults
+  // Reset browser defaults
+  appearance: none;
+  opacity: 0;
+
+  // &::after {
+  //   inline-size: var(--slider-unselected-value);
+  //   inset-inline-end: 0;
+  // }
+
+  // - - - - - - - - - - - - - - - -
+  //              Thumb
+  // - - - - - - - - - - - - - - - -
+  &::-webkit-slider-thumb {
     appearance: none;
-
-    // &::after {
-    //   inline-size: var(--slider-unselected-value);
-    //   inset-inline-end: 0;
-    // }
-
-    // - - - - - - - - - - - - - - - -
-    //              Thumb
-    // - - - - - - - - - - - - - - - -
-    &::-webkit-slider-thumb {
-      @include slider-thumb;
-    }
-
-    &::-moz-range-thumb {
-      @include slider-thumb;
-    }
+    inline-size: var(--ch-slider-thumb-size);
+    block-size: var(--ch-slider-thumb-size);
+    opacity: 0;
   }
 
-  // - - - - - - - - - - - - - - - -
-  //              Track
-  // - - - - - - - - - - - - - - - -
-  > .ch-slider__track {
-    display: flex;
-    position: absolute;
-    color: inherit;
-    inline-size: 100%;
-    block-size: var(--ch-slider-track-block-size);
-    overflow: hidden;
-
-    > .ch-slider__track--selected {
-      background-color: var(--ch-slider-selected-track-background-color);
-      inline-size: var(--slider-selected-value);
-      block-size: 100%;
-    }
-
-    > .ch-slider__track--unselected {
-      background-color: var(--ch-slider-unselected-track-background-color);
-      inline-size: var(--slider-unselected-value);
-      block-size: 100%;
-    }
+  &::-moz-range-thumb {
+    appearance: none;
+    inline-size: var(--ch-slider-thumb-size);
+    block-size: var(--ch-slider-thumb-size);
+    opacity: 0;
   }
+}
+
+// - - - - - - - - - - - - - - - -
+//              Track
+// - - - - - - - - - - - - - - - -
+.track {
+  display: flex;
+  position: absolute;
+  color: inherit;
+  inline-size: 100%;
+  block-size: var(--ch-slider-track-block-size);
+  overflow: hidden;
+  pointer-events: none; // Remove pointer-events to allow the hidden input to be interactive
+}
+
+.track--selected {
+  background-color: var(--ch-slider-selected-track-background-color);
+  inline-size: var(--slider-selected-value);
+  block-size: 100%;
+}
+
+.track--unselected {
+  background-color: var(--ch-slider-unselected-track-background-color);
+  inline-size: var(--slider-unselected-value);
+  block-size: 100%;
+}
+
+// - - - - - - - - - - - - - - - -
+//              Thumb
+// - - - - - - - - - - - - - - - -
+.thumb {
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-start: calc(
+    var(--slider-thumb-position) - var(--ch-slider-thumb-size) *
+      var(--slider-value)
+  );
+  transform: translateY(-50%);
+
+  inline-size: var(--ch-slider-thumb-size);
+  block-size: var(--ch-slider-thumb-size);
+  background-color: var(--ch-slider-thumb-background-color);
+  border-radius: 50%;
+  pointer-events: none; // Remove pointer-events to allow the hidden input to be interactive
 }

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -5,24 +5,22 @@
 
 :host {
   // Track defaults
-  --ch-slider-selected-track-background-color: color-mix(
+  --ch-slider-track__selected-background-color: color-mix(
     in srgb,
     currentColor 15%,
     transparent
   );
 
-  --ch-slider-unselected-track-background-color: color-mix(
+  --ch-slider-track__unselected-background-color: color-mix(
     in srgb,
     currentColor 15%,
     transparent
   );
+  --ch-slider-track-block-size: clamp(3px, 0.25em, 16px);
 
   // Thumb defaults
-  --ch-slider-thumb-size: clamp(8px, 1.5em, 24px);
-
   --ch-slider-thumb-background-color: currentColor;
-
-  --ch-slider-track-block-size: clamp(3px, 0.25em, 16px);
+  --ch-slider-thumb-size: clamp(8px, 1.5em, 24px);
 
   display: inline-grid;
 }
@@ -72,13 +70,13 @@
   pointer-events: none; // Remove pointer-events to allow the hidden input to be interactive
 }
 
-.track--selected {
+.track__selected {
   background-color: var(--ch-slider-selected-track-background-color);
   inline-size: var(--slider-selected-value);
   block-size: 100%;
 }
 
-.track--unselected {
+.track__unselected {
   background-color: var(--ch-slider-unselected-track-background-color);
   inline-size: var(--slider-unselected-value);
   block-size: 100%;

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -17,7 +17,13 @@ const DEFAULT_PERCENTAGE_VALUE_WHEN_MIN_EQUALS_MAX = 0;
 /**
  * The slider control is a input where the user selects a value from within a given range.
  *
- * @part input - ...
+ * @part track - The track of the slider element.
+ * @part thumb - The thumb of the slider element.
+ *
+ * @part track__selected - Represents the portion of the track that is selected, that is, the portion of the track that starts at the min value and goes to the current value.
+ * @part track__unselected - Represents the portion of the track that is not selected, that is, the portion of the track that starts at the current value and goes to the max value.
+ *
+ * @part disabled - Present in all parts when the control is disabled (`disabled` === `true`).
  */
 @Component({
   formAssociated: true,

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -180,15 +180,19 @@ export class ChSlider implements AccessibleNameComponent {
             onInput={this.#handleInput}
           />
 
-          <div class="track" part="track" aria-hidden="true">
+          <div
+            class="track"
+            part={`track${this.disabled ? " disabled" : ""}`}
+            aria-hidden="true"
+          >
             <div
-              class="track--selected"
-              part="track--selected"
+              class="track__selected"
+              part={`track__selected${this.disabled ? " disabled" : ""}`}
               style={{ "--slider-selected-value": `${valueInPercentage}%` }}
             ></div>
             <div
-              class="track--unselected"
-              part="track--unselected"
+              class="track__unselected"
+              part={`track__unselected${this.disabled ? " disabled" : ""}`}
               style={{
                 "--slider-unselected-value": `${100 - valueInPercentage}%`
               }}
@@ -197,7 +201,7 @@ export class ChSlider implements AccessibleNameComponent {
 
           <div
             class="thumb"
-            part="thumb"
+            part={`thumb${this.disabled ? " disabled" : ""}`}
             style={{
               "--slider-thumb-position": `${valueInPercentage}%`,
               "--slider-value": `${valueInPercentage / 100}`

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -26,6 +26,7 @@ const DEFAULT_PERCENTAGE_VALUE_WHEN_MIN_EQUALS_MAX = 0;
   tag: "ch-slider"
 })
 export class ChSlider implements AccessibleNameComponent {
+  #accessibleNameFromExternalLabel: string | undefined;
   #lastModifiedValue = 0;
   #valuePositionRAF = new SyncWithRAF();
 
@@ -139,6 +140,13 @@ export class ChSlider implements AccessibleNameComponent {
   connectedCallback() {
     // Set form value
     this.internals.setFormValue(this.value.toString());
+
+    const labels = this.internals.labels;
+
+    // Get external aria-label
+    if (!this.accessibleName && labels?.length > 0) {
+      this.#accessibleNameFromExternalLabel = labels[0].textContent.trim();
+    }
   }
 
   render() {
@@ -158,7 +166,9 @@ export class ChSlider implements AccessibleNameComponent {
       <Host>
         <div class="position-absolute-wrapper">
           <input
-            aria-label={this.accessibleName || null}
+            aria-label={
+              this.accessibleName ?? this.#accessibleNameFromExternalLabel
+            }
             class="slider"
             disabled={this.disabled}
             type="range"

--- a/src/showcase/pages/slider.html
+++ b/src/showcase/pages/slider.html
@@ -18,8 +18,9 @@
         gap: var(--spacing-un-spacing--l);
       }
 
-      ch-slider .ch-slider__slider::-webkit-slider-thumb {
-        border: 2px solid red;
+      ch-slider::part(thumb) {
+        filter: drop-shadow(0px 3px 14px rgba(0, 0, 0, 0.12))
+          drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.1));
       }
     </style>
   </head>
@@ -32,7 +33,7 @@
       </label>
 
       <label for="slider-2"> Slider test 2 </label>
-      <ch-slider id="slider-2" value="2" step="2" max-value="50"></ch-slider>
+      <ch-slider id="slider-2" value="2" step="0.1" max-value="50"></ch-slider>
     </div>
 
     <div class="card">


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Add support for Shadow DOM in `ch-slider` control.

 - Improve the name of CSS variables and parts.