### PR TITLE
Add `ch-radio-group-render` control

### DIFF
--- a/src/common/reserverd-names.ts
+++ b/src/common/reserverd-names.ts
@@ -57,6 +57,23 @@ export const DROPDOWN_PARTS_DICTIONARY = {
 export const DROPDOWN_EXPORT_PARTS = joinParts(DROPDOWN_PARTS_DICTIONARY);
 
 // - - - - - - - - - - - - - - - - - - - -
+//            Radio item Parts
+// - - - - - - - - - - - - - - - - - - - -
+export const RADIO_ITEM_PARTS_DICTIONARY = {
+  RADIO_ITEM: "radio-item",
+  CONTAINER: "radio__container",
+  INPUT: "radio__input",
+  OPTION: "radio__option",
+  LABEL: "radio__label",
+
+  CHECKED: "checked",
+  DISABLED: "disabled",
+  UNCHECKED: "unchecked"
+} as const;
+
+export const RADIO_ITEM_EXPORT_PARTS = joinParts(RADIO_ITEM_PARTS_DICTIONARY);
+
+// - - - - - - - - - - - - - - - - - - - -
 //         Segmented control Parts
 // - - - - - - - - - - - - - - - - - - - -
 export const SEGMENTED_CONTROL_PARTS_DICTIONARY = {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -29,6 +29,7 @@ import { ChPaginatorNavigateClickedEvent, ChPaginatorNavigateType } from "./comp
 import { ChPaginatorPagesPageChangedEvent } from "./components/paginator/paginator-pages/ch-paginator-pages";
 import { ChPopoverAlign, PopoverActionElement } from "./components/popover/types";
 import { ecLevel } from "./components/qr/ch-qr";
+import { RadioItem } from "./components/renders/radio-group/types";
 import { SegmentedControlItem } from "./components/renders/segmented-control/types";
 import { SuggestItemSelectedEvent } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
 import { FocusChangeAttempt, SuggestItemSelectedEvent as SuggestItemSelectedEvent1 } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
@@ -68,6 +69,7 @@ export { ChPaginatorNavigateClickedEvent, ChPaginatorNavigateType } from "./comp
 export { ChPaginatorPagesPageChangedEvent } from "./components/paginator/paginator-pages/ch-paginator-pages";
 export { ChPopoverAlign, PopoverActionElement } from "./components/popover/types";
 export { ecLevel } from "./components/qr/ch-qr";
+export { RadioItem } from "./components/renders/radio-group/types";
 export { SegmentedControlItem } from "./components/renders/segmented-control/types";
 export { SuggestItemSelectedEvent } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
 export { FocusChangeAttempt, SuggestItemSelectedEvent as SuggestItemSelectedEvent1 } from "./components/suggest/suggest-list-item/ch-suggest-list-item";
@@ -1504,6 +1506,24 @@ export namespace Components {
         "text": string | undefined;
     }
     /**
+     * The radio group control is used to render a short list of mutually exclusive options.
+     * It contains radio items to allow users to select one option from the list of options.
+     */
+    interface ChRadioGroupRender {
+        /**
+          * This attribute lets you specify if the radio-group is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+         */
+        "disabled": boolean;
+        /**
+          * This property lets you define the items of the ch-radio-group-render control.
+         */
+        "items"?: RadioItem[];
+        /**
+          * The value of the control.
+         */
+        "value": string;
+    }
+    /**
      * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
      * This control represents and item of the ch-segmented-control-render
      */
@@ -2572,6 +2592,10 @@ export interface ChPopoverCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChPopoverElement;
 }
+export interface ChRadioGroupRenderCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLChRadioGroupRenderElement;
+}
 export interface ChSegmentedControlItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChSegmentedControlItemElement;
@@ -3367,6 +3391,27 @@ declare global {
         prototype: HTMLChQrElement;
         new (): HTMLChQrElement;
     };
+    interface HTMLChRadioGroupRenderElementEventMap {
+        "change": string;
+    }
+    /**
+     * The radio group control is used to render a short list of mutually exclusive options.
+     * It contains radio items to allow users to select one option from the list of options.
+     */
+    interface HTMLChRadioGroupRenderElement extends Components.ChRadioGroupRender, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLChRadioGroupRenderElementEventMap>(type: K, listener: (this: HTMLChRadioGroupRenderElement, ev: ChRadioGroupRenderCustomEvent<HTMLChRadioGroupRenderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLChRadioGroupRenderElementEventMap>(type: K, listener: (this: HTMLChRadioGroupRenderElement, ev: ChRadioGroupRenderCustomEvent<HTMLChRadioGroupRenderElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLChRadioGroupRenderElement: {
+        prototype: HTMLChRadioGroupRenderElement;
+        new (): HTMLChRadioGroupRenderElement;
+    };
     interface HTMLChSegmentedControlItemElementEventMap {
         "selectedChange": string;
     }
@@ -3876,6 +3921,7 @@ declare global {
         "ch-paginator-pages": HTMLChPaginatorPagesElement;
         "ch-popover": HTMLChPopoverElement;
         "ch-qr": HTMLChQrElement;
+        "ch-radio-group-render": HTMLChRadioGroupRenderElement;
         "ch-segmented-control-item": HTMLChSegmentedControlItemElement;
         "ch-segmented-control-render": HTMLChSegmentedControlRenderElement;
         "ch-select": HTMLChSelectElement;
@@ -5372,6 +5418,28 @@ declare namespace LocalJSX {
         "text"?: string | undefined;
     }
     /**
+     * The radio group control is used to render a short list of mutually exclusive options.
+     * It contains radio items to allow users to select one option from the list of options.
+     */
+    interface ChRadioGroupRender {
+        /**
+          * This attribute lets you specify if the radio-group is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+         */
+        "disabled"?: boolean;
+        /**
+          * This property lets you define the items of the ch-radio-group-render control.
+         */
+        "items"?: RadioItem[];
+        /**
+          * Fired when the selected item change. It contains the information about the new selected value.
+         */
+        "onChange"?: (event: ChRadioGroupRenderCustomEvent<string>) => void;
+        /**
+          * The value of the control.
+         */
+        "value"?: string;
+    }
+    /**
      * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
      * This control represents and item of the ch-segmented-control-render
      */
@@ -6430,6 +6498,7 @@ declare namespace LocalJSX {
         "ch-paginator-pages": ChPaginatorPages;
         "ch-popover": ChPopover;
         "ch-qr": ChQr;
+        "ch-radio-group-render": ChRadioGroupRender;
         "ch-segmented-control-item": ChSegmentedControlItem;
         "ch-segmented-control-render": ChSegmentedControlRender;
         "ch-select": ChSelect;
@@ -6599,6 +6668,11 @@ declare module "@stencil/core" {
              */
             "ch-popover": LocalJSX.ChPopover & JSXBase.HTMLAttributes<HTMLChPopoverElement>;
             "ch-qr": LocalJSX.ChQr & JSXBase.HTMLAttributes<HTMLChQrElement>;
+            /**
+             * The radio group control is used to render a short list of mutually exclusive options.
+             * It contains radio items to allow users to select one option from the list of options.
+             */
+            "ch-radio-group-render": LocalJSX.ChRadioGroupRender & JSXBase.HTMLAttributes<HTMLChRadioGroupRenderElement>;
             /**
              * Segmented control is used to pick one choice from a linear set of closely related choices, and immediately apply that selection.
              * This control represents and item of the ch-segmented-control-render

--- a/src/components/renders/radio-group/radio-group-render.scss
+++ b/src/components/renders/radio-group/radio-group-render.scss
@@ -1,0 +1,84 @@
+@import "../../../common/_base";
+
+@include box-sizing();
+
+$option-checked-background-color: transparent;
+$option-checked-border-color: currentColor;
+$option-checked-color: currentColor;
+$option-checked-box-shadow: currentColor;
+
+:host {
+  display: inline-grid;
+  grid-auto-rows: max-content;
+
+  // This property is necessary to ensure the focus is not delegated to the
+  // checked radio when clicking the background of the control, but not an item
+  pointer-events: none;
+}
+
+.radio-item {
+  /**
+   * @prop --ch-radio-item__radio-container-size:
+   * Specifies the size for the container of the `radio__input` and `radio__option` elements.
+   * @default min(1em, 20px)
+   */
+  --ch-radio-item__radio-container-size: min(1em, 20px);
+
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+
+  // Avoid zooming on double tap
+  touch-action: manipulation;
+}
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  inline-size: var(--ch-radio-item__radio-container-size);
+  block-size: var(--ch-radio-item__radio-container-size);
+  border: 1px solid $option-checked-border-color;
+  border-radius: 50%;
+
+  &--checked {
+    background-color: $option-checked-background-color;
+  }
+}
+
+.input {
+  display: flex;
+  inline-size: 100%;
+  block-size: 100%;
+  opacity: 0;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+
+  &--enabled {
+    pointer-events: all;
+  }
+}
+
+.option {
+  position: absolute;
+  inline-size: 50%;
+  block-size: 50%;
+  background-color: $option-checked-color;
+  border-radius: 50%;
+  pointer-events: none;
+
+  &--unchecked {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+
+.label {
+  cursor: pointer;
+
+  &--enabled {
+    pointer-events: all;
+  }
+}

--- a/src/components/renders/radio-group/radio-group-render.scss
+++ b/src/components/renders/radio-group/radio-group-render.scss
@@ -5,9 +5,22 @@
 $option-checked-background-color: transparent;
 $option-checked-border-color: currentColor;
 $option-checked-color: currentColor;
-$option-checked-box-shadow: currentColor;
 
 :host {
+  /**
+   * @prop --ch-radio-group__radio-container-size:
+   * Specifies the size for the container of the `radio__input` and `radio__option` elements.
+   * @default min(1em, 20px)
+   */
+  --ch-radio-group__radio-container-size: min(1em, 20px);
+
+  /**
+   * @prop --ch-radio-group__radio-option-size:
+   * Specifies the size for the `radio__option` element.
+   * @default 50%
+   */
+  --ch-radio-group__radio-option-size: 50%;
+
   display: inline-grid;
   grid-auto-rows: max-content;
 
@@ -17,13 +30,6 @@ $option-checked-box-shadow: currentColor;
 }
 
 .radio-item {
-  /**
-   * @prop --ch-radio-item__radio-container-size:
-   * Specifies the size for the container of the `radio__input` and `radio__option` elements.
-   * @default min(1em, 20px)
-   */
-  --ch-radio-item__radio-container-size: min(1em, 20px);
-
   display: flex;
   align-items: center;
   align-self: stretch;
@@ -37,8 +43,8 @@ $option-checked-box-shadow: currentColor;
   align-items: center;
   justify-content: center;
   position: relative;
-  inline-size: var(--ch-radio-item__radio-container-size);
-  block-size: var(--ch-radio-item__radio-container-size);
+  inline-size: var(--ch-radio-group__radio-container-size);
+  block-size: var(--ch-radio-group__radio-container-size);
   border: 1px solid $option-checked-border-color;
   border-radius: 50%;
 
@@ -63,8 +69,8 @@ $option-checked-box-shadow: currentColor;
 
 .option {
   position: absolute;
-  inline-size: 50%;
-  block-size: 50%;
+  inline-size: var(--ch-radio-group__radio-option-size);
+  block-size: var(--ch-radio-group__radio-option-size);
   background-color: $option-checked-color;
   border-radius: 50%;
   pointer-events: none;

--- a/src/components/renders/radio-group/radio-group-render.tsx
+++ b/src/components/renders/radio-group/radio-group-render.tsx
@@ -1,0 +1,144 @@
+import {
+  AttachInternals,
+  Component,
+  Event,
+  EventEmitter,
+  Host,
+  Prop,
+  Watch,
+  h
+} from "@stencil/core";
+import { RadioItem } from "./types";
+import { RADIO_ITEM_PARTS_DICTIONARY } from "../../../common/reserverd-names";
+
+const PARTS = (checked: boolean, disabled: boolean) => {
+  const checkedValue = checked
+    ? RADIO_ITEM_PARTS_DICTIONARY.CHECKED
+    : RADIO_ITEM_PARTS_DICTIONARY.UNCHECKED;
+
+  return disabled
+    ? `${RADIO_ITEM_PARTS_DICTIONARY.DISABLED} ${checkedValue}`
+    : checkedValue;
+};
+
+/**
+ * The radio group control is used to render a short list of mutually exclusive options.
+ *
+ * It contains radio items to allow users to select one option from the list of options.
+ *
+ * @part radio__item - The radio item element.
+ * @part radio__container - The container that serves as a wrapper for the `input` and the `option` parts.
+ * @part radio__input - The invisible input element that implements the interactions for the component. This part must be kept "invisible".
+ * @part radio__option - The actual "input" that is rendered above the `input` part. This part has `position: absolute` and `pointer-events: none`.
+ * @part radio__label - The label that is rendered when the `caption` property is not empty.
+ *
+ * @part checked - Present in the `radio__item`, `radio__option`, `radio__label` and `radio__container` parts when the control is checked (`checked` === `true`).
+ * @part disabled - Present in the `radio__item`, `radio__option`, `radio__label` and `radio__container` parts when the control is disabled (`disabled` === `true`).
+ * @part unchecked - Present in the `radio__item`, `radio__option`, `radio__label` and `radio__container` parts when the control is not checked (`checked` !== `true`).
+ */
+@Component({
+  formAssociated: true,
+  shadow: { delegatesFocus: true },
+  styleUrl: "radio-group-render.scss",
+  tag: "ch-radio-group-render"
+})
+export class ChRadioGroupRender {
+  @AttachInternals() internals: ElementInternals;
+
+  /**
+   * This attribute lets you specify if the radio-group is disabled.
+   * If disabled, it will not fire any user interaction related event
+   * (for example, click event).
+   */
+  @Prop() readonly disabled: boolean = false;
+
+  /**
+   * This property lets you define the items of the ch-radio-group-render control.
+   */
+  @Prop() readonly items?: RadioItem[];
+
+  /**
+   * The value of the control.
+   */
+  @Prop({ mutable: true }) value: string;
+  @Watch("value")
+  handleValueChange(newValue: string) {
+    // Update form value
+    this.internals.setFormValue(newValue);
+  }
+
+  /**
+   * Fired when the selected item change. It contains the information about the
+   * new selected value.
+   */
+  @Event() change: EventEmitter<string>;
+
+  #handleCheckedInputChange = (value: string) => (event: InputEvent) => {
+    event.stopPropagation();
+    this.value = value;
+
+    this.change.emit(value);
+  };
+
+  #itemRender = (item: RadioItem, index: number) => {
+    const checked = this.value === item.value;
+    const disabled = item.disabled || this.disabled;
+
+    const additionalParts = PARTS(checked, disabled);
+
+    return (
+      <div
+        class="radio-item"
+        part={`${RADIO_ITEM_PARTS_DICTIONARY.RADIO_ITEM} ${additionalParts}`}
+      >
+        <div
+          class={{
+            container: true,
+            "container--checked": checked
+          }}
+          part={`${RADIO_ITEM_PARTS_DICTIONARY.CONTAINER} ${additionalParts}`}
+        >
+          <input
+            id={item.caption ? `radio-item-${index}` : null}
+            name="radio-group"
+            aria-label={!item.caption ? item.accessibleName : null}
+            class={{ input: true, "input--enabled": !disabled }}
+            part={RADIO_ITEM_PARTS_DICTIONARY.INPUT}
+            type="radio"
+            checked={checked}
+            disabled={disabled}
+            value={item.value}
+            onInput={this.#handleCheckedInputChange(item.value)}
+          />
+          <div
+            class={{
+              option: true,
+              "option--unchecked": !checked
+            }}
+            part={`${RADIO_ITEM_PARTS_DICTIONARY.OPTION} ${additionalParts}`}
+            aria-hidden="true"
+          ></div>
+        </div>
+
+        {item.caption && (
+          <label
+            class={{ label: true, "label--enabled": !disabled }}
+            part={`${RADIO_ITEM_PARTS_DICTIONARY.LABEL} ${additionalParts}`}
+            htmlFor={`radio-item-${index}`}
+          >
+            {item.caption}
+          </label>
+        )}
+      </div>
+    );
+  };
+
+  connectedCallback() {
+    // Set form value
+    this.internals.setFormValue(this.value);
+  }
+
+  render() {
+    return <Host role="radiogroup">{this.items?.map(this.#itemRender)}</Host>;
+  }
+}

--- a/src/components/renders/radio-group/readme.md
+++ b/src/components/renders/radio-group/readme.md
@@ -1,0 +1,54 @@
+# ch-radio-group-render
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+The radio group control is used to render a short list of mutually exclusive options.
+
+It contains radio items to allow users to select one option from the list of options.
+
+## Properties
+
+| Property   | Attribute  | Description                                                                                                                                                  | Type          | Default     |
+| ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- | ----------- |
+| `disabled` | `disabled` | This attribute lets you specify if the radio-group is disabled. If disabled, it will not fire any user interaction related event (for example, click event). | `boolean`     | `false`     |
+| `items`    | --         | This property lets you define the items of the ch-radio-group-render control.                                                                                | `RadioItem[]` | `undefined` |
+| `value`    | `value`    | The value of the control.                                                                                                                                    | `string`      | `undefined` |
+
+
+## Events
+
+| Event    | Description                                                                                    | Type                  |
+| -------- | ---------------------------------------------------------------------------------------------- | --------------------- |
+| `change` | Fired when the selected item change. It contains the information about the new selected value. | `CustomEvent<string>` |
+
+
+## Shadow Parts
+
+| Part                 | Description                                                                                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"checked"`          | Present in the `radio__item`, `radio__option`, `radio__label` and `radio__container` parts when the control is checked (`checked` === `true`).     |
+| `"disabled"`         | Present in the `radio__item`, `radio__option`, `radio__label` and `radio__container` parts when the control is disabled (`disabled` === `true`).   |
+| `"radio__container"` | The container that serves as a wrapper for the `input` and the `option` parts.                                                                     |
+| `"radio__input"`     | The invisible input element that implements the interactions for the component. This part must be kept "invisible".                                |
+| `"radio__item"`      | The radio item element.                                                                                                                            |
+| `"radio__label"`     | The label that is rendered when the `caption` property is not empty.                                                                               |
+| `"radio__option"`    | The actual "input" that is rendered above the `input` part. This part has `position: absolute` and `pointer-events: none`.                         |
+| `"unchecked"`        | Present in the `radio__item`, `radio__option`, `radio__label` and `radio__container` parts when the control is not checked (`checked` !== `true`). |
+
+
+## CSS Custom Properties
+
+| Name                                     | Description                                                                                                      |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `--ch-radio-group__radio-container-size` | Specifies the size for the container of the `radio__input` and `radio__option` elements. @default min(1em, 20px) |
+| `--ch-radio-group__radio-option-size`    | Specifies the size for the `radio__option` element. @default 50%                                                 |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/renders/radio-group/types.ts
+++ b/src/components/renders/radio-group/types.ts
@@ -1,0 +1,7 @@
+export type RadioItem = {
+  accessibleName?: string;
+  caption?: string;
+  class?: string;
+  disabled?: boolean;
+  value: string;
+};

--- a/src/showcase/models/components.js
+++ b/src/showcase/models/components.js
@@ -23,6 +23,7 @@ const components = [
   "paginator",
   "popover",
   ["qr", "QR"],
+  "radio-group",
   "segmented-control",
   "select",
   "shortcuts",

--- a/src/showcase/pages/radio-group.html
+++ b/src/showcase/pages/radio-group.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Radio Group</title>
+    <script type="module" src="/build/chameleon.esm.js"></script>
+    <script nomodule src="/build/chameleon.js"></script>
+    <link href="/build/chameleon.css" rel="stylesheet" />
+
+    <style>
+      body {
+        display: grid;
+        grid-template-columns: 1fr 260px;
+        gap: var(--spacing-un-spacing--l);
+      }
+
+      ch-radio-group-render::part(disabled) {
+        opacity: 0.625;
+      }
+
+      ch-radio-group-render::part(radio__container):focus-within {
+        color: var(--icons-un-icon__primary);
+      }
+    </style>
+  </head>
+  <body class="white-label">
+    <div class="card">
+      <form id="myForm">
+        <div style="display: flex; flex-direction: column">
+          <label for="radio-group-1">Label for radio-group-1</label>
+          <ch-radio-group-render
+            name="radio-group-1"
+            id="radio-group-1"
+            placeholder="Choose a value..."
+            value="Value 1"
+          ></ch-radio-group-render>
+        </div>
+
+        <div>
+          <label>
+            Label for radio-group-2
+            <ch-radio-group-render
+              id="radio-group-2"
+              value="Value 3"
+            ></ch-radio-group-render>
+          </label>
+        </div>
+
+        <div>
+          <label for="radio-group-3">Label for radio-group-3</label>
+          <ch-radio-group-render
+            accessible-name="Custom label 3"
+            id="radio-group-3"
+            value="Value 3"
+          ></ch-radio-group-render>
+        </div>
+
+        <label>
+          Label for radio-group-4
+          <ch-radio-group-render
+            name="checkboxxxxx"
+            accessible-name="Custom label 4"
+            value="Value 4"
+          ></ch-radio-group-render>
+        </label>
+
+        <div>
+          <label>
+            "Native" Web Component
+            <ch-native></ch-native>
+          </label>
+        </div>
+
+        <label for="lname">Last name:</label>
+        <input type="text" id="lname" name="lname" value="Doe" />
+
+        <div>
+          <label style="display: grid">
+            Last name 2:
+            <input type="checkbox" name="lname" value="Doe" />
+          </label>
+        </div>
+      </form>
+    </div>
+
+    <div class="card">
+      <div><ch-checkbox caption="Disabled"></ch-checkbox></div>
+    </div>
+
+    <script>
+      const radioGroup1 = document.getElementById("radio-group-1");
+      const radioGroup2 = document.getElementById("radio-group-2");
+
+      radioGroup1.addEventListener("change", () => {
+        console.log("RadioGroup 1 change... - - - Value:", radioGroup1.value);
+      });
+
+      radioGroup2.addEventListener("change", () => {
+        console.log("RadioGroup 2 change... - - - Value:", radioGroup2.value);
+      });
+
+      const radioGroup1Items = [
+        { value: "Value 1", caption: "Label for the value 1" },
+        {
+          value: "Value 2",
+          caption: "Label for the value 2"
+        },
+        {
+          value: "Value 3",
+          caption: "Label for the value 3",
+          disabled: true
+        },
+        { value: "Value 4", caption: "Label for the value 4" },
+        {
+          value: "Value 5",
+          caption: "Label for the value 5",
+          disabled: true
+        },
+        {
+          value: "Value 6",
+          caption: "Label for the value 6"
+        },
+        {
+          value: "Value 7",
+          caption: "Label for the value 7",
+          disabled: true
+        },
+        { value: "Value 8", caption: "Label for the value 8" }
+      ];
+
+      radioGroup1.items = radioGroup1Items;
+      radioGroup2.items = radioGroup1Items;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
The radio group control is used to render a short list of mutually exclusive options.

It contains radio items to allow users to select one option from the list of options.