### PR TITLE
Fixes and improvements for `ch-checkbox` control

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -4,19 +4,23 @@ $option-checked-background-color: var(--option-checked-color, #ffffff00);
 $option-checked-border-color: var(--option-border-color, currentColor);
 $option-checked-color: currentColor;
 $option-checked-box-shadow: var(--option-highlight-color, currentColor);
-$option-checked-box-shadow-size: min(0.15em, 2px);
-
-$space-between-container-and-label: min(0.35em, 7px);
 
 @include box-sizing();
 
 :host {
   /**
-   * @prop --ch-checkbox-container-size:
+   * @prop --ch-checkbox__container-size:
    * Specifies the size for the container of the `input` and `option` elements.
    * @default min(1em, 20px)
    */
-  --ch-checkbox-container-size: min(1em, 20px);
+  --ch-checkbox__container-size: min(1em, 20px);
+
+  /**
+   * @prop --ch-checkbox__option-size:
+   * Specifies the size for the `radio__option` element.
+   * @default 50%
+   */
+  --ch-checkbox__option-size: 50%;
 
   display: flex;
   align-items: center;
@@ -38,18 +42,17 @@ $space-between-container-and-label: min(0.35em, 7px);
 }
 
 .container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: relative;
-  inline-size: var(--ch-checkbox-container-size);
-  block-size: var(--ch-checkbox-container-size);
+  inline-size: var(--ch-checkbox__container-size);
+  block-size: var(--ch-checkbox__container-size);
   border: 1px solid $option-checked-border-color;
   border-radius: 18.75%;
 
   &--checked {
     background-color: $option-checked-background-color;
-  }
-
-  &:focus-within {
-    box-shadow: 0 0 1px 1px color-mix(in srgb, currentColor 25%, transparent);
   }
 }
 
@@ -64,25 +67,17 @@ $space-between-container-and-label: min(0.35em, 7px);
 
 .option {
   position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  inline-size: 50%;
-  block-size: 50%;
+  inline-size: var(--ch-checkbox__option-size);
+  block-size: var(--ch-checkbox__option-size);
   background-color: $option-checked-color;
-  opacity: 0;
   pointer-events: none;
 
   &--checked {
-    opacity: 1;
     -webkit-mask: url("data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='currentColor' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/></svg>");
   }
 
-  &--indeterminate {
-    opacity: 1;
+  &--not-displayed {
+    opacity: 0;
+    visibility: hidden;
   }
-}
-
-.label {
-  margin-inline-start: $space-between-container-and-label;
 }

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -216,6 +216,7 @@ export class CheckBox implements AccessibleNameComponent, DisableableComponent {
           <div
             class={{
               option: true,
+              "option--not-displayed": !this.checked && !this.indeterminate,
               "option--checked": this.checked && !this.indeterminate,
               "option--indeterminate": this.indeterminate
             }}

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -46,10 +46,10 @@ const PARTS = (checked: boolean, indeterminate: boolean, disabled: boolean) => {
  * @part option - The actual "input" that is rendered above the `input` part. This part has `position: absolute` and `pointer-events: none`.
  * @part label - The label that is rendered when the `caption` property is not empty.
  *
- * @part checked - Present in the `option` and `container` parts when the control is checked and not indeterminate (`value` === `checkedValue` and `indeterminate !== true`).
- * @part disabled - Present in the `option` and `container` parts when the control is disabled (`disabled` === `true`).
- * @part indeterminate - Present in the `option` and `container` parts when the control is indeterminate (`indeterminate` === `true`).
- * @part unchecked - Present in the `option` and `container` parts when the control is unchecked and not indeterminate (`value` === `unCheckedValue` and `indeterminate !== true`).
+ * @part checked - Present in the `option`, `label` and `container` parts when the control is checked and not indeterminate (`value` === `checkedValue` and `indeterminate !== true`).
+ * @part disabled - Present in the `option`, `label` and `container` parts when the control is disabled (`disabled` === `true`).
+ * @part indeterminate - Present in the `option`, `label` and `container` parts when the control is indeterminate (`indeterminate` === `true`).
+ * @part unchecked - Present in the `option`, `label` and `container` parts when the control is unchecked and not indeterminate (`value` === `unCheckedValue` and `indeterminate !== true`).
  */
 @Component({
   shadow: true,
@@ -227,7 +227,7 @@ export class CheckBox implements AccessibleNameComponent, DisableableComponent {
         {this.caption && (
           <label
             class="label"
-            part={LABEL_PART}
+            part={`${LABEL_PART} ${additionalParts}`}
             htmlFor={CHECKBOX_ID}
             onClick={this.#handleClick}
           >

--- a/src/components/checkbox/readme.md
+++ b/src/components/checkbox/readme.md
@@ -30,23 +30,24 @@
 
 ## Shadow Parts
 
-| Part              | Description                                                                                                                                                    |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"checked"`       | Present in the `option` and `container` parts when the control is checked and not indeterminate (`value` === `checkedValue` and `indeterminate !== true`).     |
-| `"container"`     | The container that serves as a wrapper for the `input` and the `option` parts.                                                                                 |
-| `"disabled"`      | Present in the `option` and `container` parts when the control is disabled (`disabled` === `true`).                                                            |
-| `"indeterminate"` | Present in the `option` and `container` parts when the control is indeterminate (`indeterminate` === `true`).                                                  |
-| `"input"`         | The invisible input element that implements the interactions for the component. This part must be kept "invisible".                                            |
-| `"label"`         | The label that is rendered when the `caption` property is not empty.                                                                                           |
-| `"option"`        | The actual "input" that is rendered above the `input` part. This part has `position: absolute` and `pointer-events: none`.                                     |
-| `"unchecked"`     | Present in the `option` and `container` parts when the control is unchecked and not indeterminate (`value` === `unCheckedValue` and `indeterminate !== true`). |
+| Part              | Description                                                                                                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"checked"`       | Present in the `option`, `label` and `container` parts when the control is checked and not indeterminate (`value` === `checkedValue` and `indeterminate !== true`).     |
+| `"container"`     | The container that serves as a wrapper for the `input` and the `option` parts.                                                                                          |
+| `"disabled"`      | Present in the `option`, `label` and `container` parts when the control is disabled (`disabled` === `true`).                                                            |
+| `"indeterminate"` | Present in the `option`, `label` and `container` parts when the control is indeterminate (`indeterminate` === `true`).                                                  |
+| `"input"`         | The invisible input element that implements the interactions for the component. This part must be kept "invisible".                                                     |
+| `"label"`         | The label that is rendered when the `caption` property is not empty.                                                                                                    |
+| `"option"`        | The actual "input" that is rendered above the `input` part. This part has `position: absolute` and `pointer-events: none`.                                              |
+| `"unchecked"`     | Present in the `option`, `label` and `container` parts when the control is unchecked and not indeterminate (`value` === `unCheckedValue` and `indeterminate !== true`). |
 
 
 ## CSS Custom Properties
 
-| Name                           | Description                                                                                        |
-| ------------------------------ | -------------------------------------------------------------------------------------------------- |
-| `--ch-checkbox-container-size` | Specifies the size for the container of the `input` and `option` elements. @default min(1em, 20px) |
+| Name                            | Description                                                                                        |
+| ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `--ch-checkbox__container-size` | Specifies the size for the container of the `input` and `option` elements. @default min(1em, 20px) |
+| `--ch-checkbox__option-size`    | Specifies the size for the `radio__option` element. @default 50%                                   |
 
 
 ## Dependencies


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fixes:
   - (white-label) The container part won't show a `box-shadow` by default when the input is focused.

   - (white-label) The container and label elements won't have a separation by default.

   - Opacity styles applied outside the checkbox won't display the option if the checkbox is not checked.

   - Rename `--ch-checkbox-container-size` part to `--ch-checkbox__container-size`

 - Features:
   - Expose `disabled`, `checked`, `unchecked` and `indeterminate` states in "label" part.

   - The size of the option part can now be configured using the `--ch-checkbox__option-size` custom var.

   