### PR TITLE
Make the ESLint and TypeScript more strict

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     "plugin:prettier/recommended" // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
   parserOptions: {
-    ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+    ecmaVersion: 2022, // Allows for the parsing of modern ECMAScript features
     project: "./tsconfig.json",
     sourceType: "module" // Allows for the use of imports
   },
@@ -32,12 +32,12 @@ module.exports = {
     "no-debugger": "error", // Error when using debugger;
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements
     "no-empty": "error", // Disallow empty block statements
-    "no-lonely-if": "warn", // Disallow if statements as the only statement in else blocks
+    "no-lonely-if": "error", // Disallow if statements as the only statement in else blocks
     "no-multi-assign": "error", // Disallow use of chained assignment expressions
-    "no-nested-ternary": "warn", // Warns the use of nested ternary expressions
+    "no-nested-ternary": "error", // Errors when using nested ternary expressions
     "no-sequences": "error", // Disallow comma operators
     "no-undef": "off", // Allows defining undefined variables
-    "no-unneeded-ternary": "warn", // Disallow ternary operators when simpler alternatives exist
+    "no-unneeded-ternary": "error", // Disallow ternary operators when simpler alternatives exist
     "no-useless-return": "error", // Disallow redundant return statements
     "spaced-comment": ["error", "always", { exceptions: ["-", "+", "/"] }], // Enforce consistent spacing after the // or /* in a comment
 
@@ -66,8 +66,8 @@ module.exports = {
     // - - - - - - - - - - - -
     // StencilJS
     // - - - - - - - - - - - -
-    "@stencil-community/async-methods": "warn", // This rule catches Stencil public methods that are not async
-    "@stencil-community/decorators-context": "warn", // This rule catches Stencil decorators in bad locations
+    "@stencil-community/async-methods": "error", // This rule catches Stencil public methods that are not async
+    "@stencil-community/decorators-context": "error", // This rule catches Stencil decorators in bad locations
     "@stencil-community/decorators-style": [
       "warn",
       {
@@ -80,18 +80,18 @@ module.exports = {
       }
     ],
     "@stencil-community/ban-exported-const-enums": "warn", // Exported const enums are not allowed
-    "@stencil-community/element-type": "warn", // This rule catches Stencil Element decorator have the correct type
-    "@stencil-community/methods-must-be-public": "warn", // This rule catches Stencil Methods marked as private or protected
-    "@stencil-community/no-unused-watch": "warn", // This rule catches Stencil Watchs with non existing Props or States
+    "@stencil-community/element-type": "error", // This rule catches Stencil Element decorator have the correct type
+    "@stencil-community/methods-must-be-public": "error", // This rule catches Stencil Methods marked as private or protected
+    "@stencil-community/no-unused-watch": "error", // This rule catches Stencil Watchs with non existing Props or States
     "@stencil-community/own-methods-must-be-private": "warn", // This rule catches own class methods marked as public
     "@stencil-community/own-props-must-be-private": "warn", // This rule catches own class properties marked as public
     "@stencil-community/prefer-vdom-listener": "warn", // This rule catches Stencil Listen with vdom events
-    "@stencil-community/props-must-be-public": "warn", // This rule catches Stencil Props marked as private or protected
-    "@stencil-community/props-must-be-readonly": "warn", // This rule catches Stencil Props marked as non readonly, excluding mutable ones
-    "@stencil-community/required-jsdoc": "warn", // This rule catches Stencil Props, Methods and Events to define jsdoc
-    "@stencil-community/required-prefix": ["warn", ["ch-"]], // Ensures that a Component's tag use the "ch-" prefix.
+    "@stencil-community/props-must-be-public": "error", // This rule catches Stencil Props marked as private or protected
+    "@stencil-community/props-must-be-readonly": "error", // This rule catches Stencil Props marked as non readonly, excluding mutable ones
+    "@stencil-community/required-jsdoc": "error", // This rule catches Stencil Props, Methods and Events to define jsdoc
+    "@stencil-community/required-prefix": ["error", ["ch-"]], // Ensures that a Component's tag use the "ch-" prefix.
     "@stencil-community/reserved-member-names": "warn", // Ensures that any of reserved global HTML attribute names are used as @Prop or @Method
-    "@stencil-community/single-export": "warn", // This rule catches modules that expose more than just the Stencil Component itself
+    "@stencil-community/single-export": "error", // This rule catches modules that expose more than just the Stencil Component itself
     "@stencil-community/strict-boolean-conditions": "off",
 
     // WA to fix false positive errors

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     project: "./tsconfig.json",
     sourceType: "module" // Allows for the use of imports
   },
+  ignorePatterns: ["src/deprecated-components/*"],
   rules: {
     // - - - - - - - - - - - -
     // ESLint

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -12,8 +12,10 @@ export function debounce(
     const later = function () {
       timeout = null;
       if (!immediate) {
+        // @ts-expect-error: TODO: This function will be removed when we refactor line-clamp implementation. So we are avoiding this error
         func.apply(this, args);
       }
+      // @ts-expect-error: TODO: This function will be removed when we refactor line-clamp implementation. So we are avoiding this error
     }.bind(this);
 
     const callNow = immediate && !timeout;
@@ -22,6 +24,7 @@ export function debounce(
     timeout = setTimeout(later, wait);
 
     if (callNow) {
+      // @ts-expect-error: TODO: This function will be removed when we refactor line-clamp implementation. So we are avoiding this error
       func.apply(this, args);
     }
   };

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -646,7 +646,7 @@ export namespace Components {
         /**
           * Retrieves the rowId of the next row relative to the currently selected cell.
          */
-        "getNextRow": () => Promise<string>;
+        "getNextRow": () => Promise<string | void>;
         /**
           * Retrieves information about the previous cell relative to the currently selected cell.
          */
@@ -654,7 +654,7 @@ export namespace Components {
         /**
           * Retrieves the rowId of the previous row relative to the currently selected cell.
          */
-        "getPreviousRow": () => Promise<string>;
+        "getPreviousRow": () => Promise<string | void>;
         /**
           * Retrieves information about the currently selected cell.
          */

--- a/src/components/action-group/test/action-group.e2e.ts
+++ b/src/components/action-group/test/action-group.e2e.ts
@@ -35,7 +35,7 @@ describe("ch-action-group", () => {
     expect(dropdownGridColumn).toBe("3");
   });
 
-  //TODO: Find a way to simulate the work that Angular does to locate the item on its correspondent slot and trigger the displayedItemsCountChange event
+  // TODO: Find a way to simulate the work that Angular does to locate the item on its correspondent slot and trigger the displayedItemsCountChange event
   it.skip("Items hide inside more-action-btn when screen size is reduced", async () => {
     const page = await newE2EPage();
 

--- a/src/components/grid/ch-grid-manager-column-resize.ts
+++ b/src/components/grid/ch-grid-manager-column-resize.ts
@@ -107,9 +107,8 @@ export class ChGridManagerColumnResize {
       const number = parseFloat(match[1]);
       const unit = match[2];
       return { number, unit };
-    } else {
-      return null;
     }
+    return null;
   }
 
   private convertUnit(

--- a/src/components/grid/ch-grid-manager-columns.ts
+++ b/src/components/grid/ch-grid-manager-columns.ts
@@ -37,9 +37,8 @@ export class ChGridManagerColumns {
   public getColumns(sorted = false): HTMLChGridColumnElement[] {
     if (sorted) {
       return this.columns.sort(this.fnSortByOrder);
-    } else {
-      return this.columns;
     }
+    return this.columns;
   }
 
   public getColumnsFirstLast(): {
@@ -103,9 +102,7 @@ export class ChGridManagerColumns {
   }
 
   private defineColumnId(column: HTMLChGridColumnElement) {
-    if (!column.columnId) {
-      column.columnId = this.getColumnUniqueId();
-    }
+    column.columnId ||= this.getColumnUniqueId();
   }
 
   private defineColumnIndex(column: HTMLChGridColumnElement) {
@@ -113,15 +110,11 @@ export class ChGridManagerColumns {
   }
 
   private defineColumnOrder(column: HTMLChGridColumnElement) {
-    if (!column.order) {
-      column.order = column.physicalOrder;
-    }
+    column.order ||= column.physicalOrder;
   }
 
   private defineColumnSize(column: HTMLChGridColumnElement) {
-    if (!column.size) {
-      column.size = "auto";
-    }
+    column.size ||= "auto";
   }
 
   private defineColumnDisplayObserver(column: HTMLChGridColumnElement) {

--- a/src/components/grid/ch-grid-manager.ts
+++ b/src/components/grid/ch-grid-manager.ts
@@ -135,23 +135,25 @@ export class ChGridManager {
     }, null);
   }
 
-  getPreviousCell(current: HTMLChGridCellElement): HTMLChGridCellElement {
+  getPreviousCell(
+    current: HTMLChGridCellElement
+  ): HTMLChGridCellElement | void {
     const previousColumn = this.getPreviousColumn(current.column);
 
     if (previousColumn) {
       return current.row.querySelector(
         `:scope > ch-grid-cell:nth-of-type(${previousColumn.physicalOrder})`
-      );
+      ) as HTMLChGridCellElement;
     }
   }
 
-  getNextCell(current: HTMLChGridCellElement): HTMLChGridCellElement {
+  getNextCell(current: HTMLChGridCellElement): HTMLChGridCellElement | void {
     const nextColumn = this.getNextColumn(current.column);
 
     if (nextColumn) {
       return current.row.querySelector(
         `:scope > ch-grid-cell:nth-of-type(${nextColumn.physicalOrder})`
-      );
+      ) as HTMLChGridCellElement;
     }
   }
 
@@ -233,9 +235,11 @@ export class ChGridManager {
     cellId?: string,
     rowId?: string,
     columnId?: string
-  ): HTMLChGridCellElement {
+  ): HTMLChGridCellElement | void {
     if (cellId) {
-      return this.grid.querySelector(`ch-grid-cell[cellid="${cellId}"]`);
+      return this.grid.querySelector(
+        `ch-grid-cell[cellid="${cellId}"]`
+      ) as HTMLChGridCellElement;
     }
     if (rowId && columnId) {
       const row = this.getRow(rowId);

--- a/src/components/grid/ch-grid.tsx
+++ b/src/components/grid/ch-grid.tsx
@@ -263,6 +263,7 @@ export class ChGrid {
     this.manager.componentDidLoad(this.gridLayoutElement);
   }
 
+  // @ts-expect-error: TODO: Fix this error
   componentShouldUpdate(_newValue, _oldValue, name: string) {
     if (
       name === "rowFocused" ||
@@ -898,7 +899,7 @@ export class ChGrid {
    * Retrieves the rowId of the previous row relative to the currently selected cell.
    */
   @Method()
-  async getPreviousRow(): Promise<string> {
+  async getPreviousRow(): Promise<string | void> {
     const currentRow = this.cellSelected?.row;
 
     if (currentRow) {
@@ -910,7 +911,7 @@ export class ChGrid {
    * Retrieves the rowId of the next row relative to the currently selected cell.
    */
   @Method()
-  async getNextRow(): Promise<string> {
+  async getNextRow(): Promise<string | void> {
     const currentRow = this.cellSelected?.row;
 
     if (currentRow) {

--- a/src/components/grid/grid-rowset/ch-grid-rowset.tsx
+++ b/src/components/grid/grid-rowset/ch-grid-rowset.tsx
@@ -118,12 +118,14 @@ export default class HTMLChGridRowsetElement
     return this.parentElement.tagName === "CH-GRID-ROW";
   }
 
-  private getParentRowset(): HTMLChGridRowsetElement {
+  private getParentRowset(): HTMLChGridRowsetElement | undefined {
     const node = this.parentElement.closest("ch-grid-rowset, ch-grid");
 
     if (node.tagName === "CH-GRID-ROWSET") {
       return node as HTMLChGridRowsetElement;
     }
+
+    return undefined;
   }
 }
 

--- a/src/components/grid/readme.md
+++ b/src/components/grid/readme.md
@@ -136,13 +136,13 @@ Type: `Promise<{ cellId: string; rowId: string; columnId: string; }>`
 
 
 
-### `getNextRow() => Promise<string>`
+### `getNextRow() => Promise<string | void>`
 
 Retrieves the rowId of the next row relative to the currently selected cell.
 
 #### Returns
 
-Type: `Promise<string>`
+Type: `Promise<string | void>`
 
 
 
@@ -156,13 +156,13 @@ Type: `Promise<{ cellId: string; rowId: string; columnId: string; }>`
 
 
 
-### `getPreviousRow() => Promise<string>`
+### `getPreviousRow() => Promise<string | void>`
 
 Retrieves the rowId of the previous row relative to the currently selected cell.
 
 #### Returns
 
-Type: `Promise<string>`
+Type: `Promise<string | void>`
 
 
 

--- a/src/components/gx-grid/gx-grid-chameleon.tsx
+++ b/src/components/gx-grid/gx-grid-chameleon.tsx
@@ -34,6 +34,7 @@ declare let gx: Gx;
   styleUrl: "gx-grid-chameleon.scss",
   tag: "gx-grid-chameleon"
 })
+// eslint-disable-next-line @stencil-community/required-prefix
 export class GridChameleon {
   /**
    * The GxGrid instance representing the data to be displayed in the grid.

--- a/src/components/gx-grid/gx-grid-column-filter/gx-grid-chameleon-column-filter.tsx
+++ b/src/components/gx-grid/gx-grid-column-filter/gx-grid-chameleon-column-filter.tsx
@@ -26,6 +26,7 @@ declare let gx: Gx;
   styleUrl: "gx-grid-chameleon-column-filter.scss",
   shadow: true
 })
+// eslint-disable-next-line @stencil-community/required-prefix
 export class GridChameleonColumnFilter {
   private filterEnum: GridChameleonColumnFilterEnum[] = [];
   private inputEqual: HTMLInputElement | HTMLSelectElement;
@@ -163,11 +164,10 @@ export class GridChameleonColumnFilter {
       return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
         date.getDate()
       )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-    } else {
-      return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
-        date.getDate()
-      )}`;
     }
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+      date.getDate()
+    )}`;
   }
 
   private getFilterInputType(dataType: GxControlDataType): string {

--- a/src/components/next/data-modeling-item/next-data-modeling-item.tsx
+++ b/src/components/next/data-modeling-item/next-data-modeling-item.tsx
@@ -838,6 +838,7 @@ export class NextDataModelingSubitem implements ChComponent {
       >
         {
           // Add new field layout (last cell of the collection/entity)
+          // eslint-disable-next-line no-nested-ternary
           this.mode === "add" && this.waitingMode !== "adding" ? (
             this.newFieldMode(captions, errorPart, disabledPart, actions)
           ) : this.level === 0 ? ( // Normal mode. Level === 0

--- a/src/components/paginator/paginator-pages/ch-paginator-pages.tsx
+++ b/src/components/paginator/paginator-pages/ch-paginator-pages.tsx
@@ -138,9 +138,8 @@ export class ChPaginatorPages {
   private fillStart(render: boolean) {
     if (render) {
       return this.renderFirstLastPages ? [1, this.textDots] : [this.textDots];
-    } else {
-      return [];
     }
+    return [];
   }
 
   private fillEnd(render: boolean) {
@@ -148,9 +147,8 @@ export class ChPaginatorPages {
       return this.renderFirstLastPages
         ? [this.textDots, this.totalPages]
         : [this.textDots];
-    } else {
-      return [];
     }
+    return [];
   }
 
   private getRangeItems(start: number, end: number): number[] {
@@ -189,15 +187,14 @@ export class ChPaginatorPages {
                 </button>
               </li>
             );
-          } else {
-            return (
-              <li>
-                <button part="page button dots" disabled>
-                  {item}
-                </button>
-              </li>
-            );
           }
+          return (
+            <li>
+              <button part="page button dots" disabled>
+                {item}
+              </button>
+            </li>
+          );
         })}
       </ol>
     );

--- a/src/components/renders/tree-view/genexus-implementation.ts
+++ b/src/components/renders/tree-view/genexus-implementation.ts
@@ -67,9 +67,9 @@ export const fromGxImageToURL = (
   gxImage: any,
   Settings: any,
   gxImageConstructor: (name: string) => any
-): string => {
+): string | undefined => {
   if (!gxImage) {
-    return;
+    return undefined;
   }
 
   let url = "";

--- a/src/components/shortcuts/ch-shortcuts-manager.ts
+++ b/src/components/shortcuts/ch-shortcuts-manager.ts
@@ -228,9 +228,8 @@ function querySelectorAllPlus(
       .map(selectorItem => {
         if (selector.includes("::part")) {
           return querySelectorPlus(selectorItem, root);
-        } else {
-          return Array.from(root.querySelectorAll(selector)) as HTMLElement[];
         }
+        return Array.from(root.querySelectorAll(selector)) as HTMLElement[];
       })
       .flat() ?? []
   );
@@ -284,9 +283,8 @@ function querySelectorPlus(
     const partName = selectorItems[2];
 
     return querySelectorDeep(root.querySelector(entity), partName);
-  } else {
-    return root.querySelector(selector);
   }
+  return root.querySelector(selector);
 }
 
 interface ShortcutMap {

--- a/src/components/shortcuts/ch-shortcuts.tsx
+++ b/src/components/shortcuts/ch-shortcuts.tsx
@@ -119,11 +119,11 @@ export class ChShortcuts {
     return keyShortcuts.split(/(?<!(?:[+]|^))([+\s])/).map((key, i, items) => {
       if (key === "+" && i > 0 && items[i - 1] !== "+") {
         return <span part="plus">+</span>;
-      } else if (key === " " && i > 0 && items[i - 1] !== "+") {
-        return <span part="slash">/</span>;
-      } else {
-        return <kbd part={`key`}>{KEY_SYMBOL[key] ?? key}</kbd>;
       }
+      if (key === " " && i > 0 && items[i - 1] !== "+") {
+        return <span part="slash">/</span>;
+      }
+      return <kbd part={`key`}>{KEY_SYMBOL[key] ?? key}</kbd>;
     });
   }
 

--- a/src/components/sidebar/expanded-change-obervables.ts
+++ b/src/components/sidebar/expanded-change-obervables.ts
@@ -22,13 +22,13 @@ export const removeObservable = (observableId: string) => {
 export const syncStateWithObservableAncestors = (subscriberId: string) => {
   // There is not any observable
   if (!observables) {
-    return DEFAULT_EXPAND_VALUE;
+    return;
   }
 
   const subscriberInfo = subscribers.get(subscriberId);
 
   if (!subscriberInfo) {
-    return DEFAULT_EXPAND_VALUE;
+    return;
   }
 
   let parentElement: Element = subscriberInfo.getSubscriberRef();

--- a/src/components/suggest/ch-suggest.tsx
+++ b/src/components/suggest/ch-suggest.tsx
@@ -233,6 +233,7 @@ INDEX:
     };
 
     if (!currentFocusedItem) {
+      // @ts-expect-error: TODO: Fix this error
       return;
     }
     let newFocusedItem =

--- a/src/components/suggest/suggest-list-item/ch-suggest-list-item.tsx
+++ b/src/components/suggest/suggest-list-item/ch-suggest-list-item.tsx
@@ -74,6 +74,7 @@ INDEX:
 
   // 9.LOCAL METHODS //
 
+  // @ts-expect-error: TODO: Check if the notation in this function is correct
   private getItemIndexes = (): SuggestItemIndexes => {
     const parentElement = this.el.parentElement;
     if (parentElement.nodeName === "CH-SUGGEST") {

--- a/src/components/suggest/suggest-list-item/ch-suggest-list-item.tsx
+++ b/src/components/suggest/suggest-list-item/ch-suggest-list-item.tsx
@@ -93,7 +93,8 @@ INDEX:
         itemIndex: itemIndex,
         listIndex: undefined // the items does not belongs to a list
       };
-    } else if (parentElement.nodeName === "CH-SUGGEST-LIST") {
+    }
+    if (parentElement.nodeName === "CH-SUGGEST-LIST") {
       const chSuggestList = parentElement;
       const chSuggestListsArray = Array.from(
         chSuggestList.parentElement.querySelectorAll(":scope > ch-suggest-list")

--- a/src/components/suggest/suggest-list-item/test/ch-suggest-list-item.e2e.ts
+++ b/src/components/suggest/suggest-list-item/test/ch-suggest-list-item.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage } from "@stencil/core/testing";
 
-describe('ch-suggest-list-item', () => {
-  it('renders', async () => {
+describe("ch-suggest-list-item", () => {
+  it("renders", async () => {
     const page = await newE2EPage();
-    await page.setContent('<ch-suggest-list-item></ch-suggest-list-item>');
+    await page.setContent("<ch-suggest-list-item></ch-suggest-list-item>");
 
-    const element = await page.find('ch-suggest-list-item');
-    expect(element).toHaveClass('hydrated');
+    const element = await page.find("ch-suggest-list-item");
+    expect(element).toHaveClass("hydrated");
   });
 });

--- a/src/components/suggest/suggest-list/test/ch-suggest-list.e2e.ts
+++ b/src/components/suggest/suggest-list/test/ch-suggest-list.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage } from "@stencil/core/testing";
 
-describe('ch-suggest-list', () => {
-  it('renders', async () => {
+describe("ch-suggest-list", () => {
+  it("renders", async () => {
     const page = await newE2EPage();
-    await page.setContent('<ch-suggest-list></ch-suggest-list>');
+    await page.setContent("<ch-suggest-list></ch-suggest-list>");
 
-    const element = await page.find('ch-suggest-list');
-    expect(element).toHaveClass('hydrated');
+    const element = await page.find("ch-suggest-list");
+    expect(element).toHaveClass("hydrated");
   });
 });

--- a/src/components/suggest/test/ch-suggest.e2e.ts
+++ b/src/components/suggest/test/ch-suggest.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage } from "@stencil/core/testing";
 
-describe('ch-suggest', () => {
-  it('renders', async () => {
+describe("ch-suggest", () => {
+  it("renders", async () => {
     const page = await newE2EPage();
-    await page.setContent('<ch-suggest></ch-suggest>');
+    await page.setContent("<ch-suggest></ch-suggest>");
 
-    const element = await page.find('ch-suggest');
-    expect(element).toHaveClass('hydrated');
+    const element = await page.find("ch-suggest");
+    expect(element).toHaveClass("hydrated");
   });
 });

--- a/src/deprecated-components/form-checkbox/ch-form-checkbox.tsx
+++ b/src/deprecated-components/form-checkbox/ch-form-checkbox.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @stencil-community/required-jsdoc */
 import {
   Component,
   Element,
@@ -16,10 +17,10 @@ import {
 export class ChFormCheckbox {
   @Element() el: HTMLChFormCheckboxElement;
 
-  //A reference to the input
+  // A reference to the input
   checkboxInput!: HTMLInputElement;
 
-  /*********************************
+  /** *******************************
     PROPERTIES & STATE
     *********************************/
 
@@ -60,7 +61,7 @@ export class ChFormCheckbox {
 
   @Event() change: EventEmitter;
 
-  /*********************************
+  /** *******************************
     METHODS
     *********************************/
 
@@ -81,7 +82,7 @@ export class ChFormCheckbox {
 
   handlerOnKeyUp(event) {
     if (event.keyCode == 13) {
-      //Enter key was pressed
+      // Enter key was pressed
       if (!this.checked) {
         this.el.setAttribute("checked", "true");
       } else {
@@ -97,9 +98,8 @@ export class ChFormCheckbox {
   ariaChecked() {
     if (this.checked) {
       return "true";
-    } else {
-      return "false";
     }
+    return "false";
   }
 
   handleInputClick(e) {

--- a/src/deprecated-components/icon/requests.ts
+++ b/src/deprecated-components/icon/requests.ts
@@ -7,6 +7,7 @@ export function getSvgContent(url: string) {
 
   if (!request) {
     // we don't already have a request
+    // @ts-expect-error: This implementation is deprecated, so we are avoiding this error
     request = fetch(url).then(response => {
       if (response.ok) {
         return response.text().then(svgContent => {

--- a/src/deprecated-components/select-item/ch-select-option.tsx
+++ b/src/deprecated-components/select-item/ch-select-option.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @stencil-community/required-jsdoc */
 import {
   Component,
   Host,
@@ -78,20 +79,21 @@ export class ChSelectItem {
 
     for (let i = 0; i < selectItems.length; i++) {
       const item: any = selectItems[i].shadowRoot.lastChild;
-      //remove old item selected class
-      if (item.classList.contains("option-selected"))
+      // remove old item selected class
+      if (item.classList.contains("option-selected")) {
         item.classList.remove("option-selected");
+      }
       selectItems[i].removeAttribute("aria-selected");
-      //remove pre-selection attribute
+      // remove pre-selection attribute
       selectItems[i].removeAttribute("selected");
-      //set active item class
+      // set active item class
       if (selectItems[i].value === targetItem.trim()) {
         item.classList.add("option-selected");
         selectItems[i].setAttribute("aria-selected", "true");
         optionText = selectItems[i].innerHTML;
       }
     }
-    //update selected option text in select
+    // update selected option text in select
     const selectedOptionText: HTMLElement =
       this.el.parentElement.shadowRoot.querySelector("span.text");
     selectedOptionText.innerHTML = optionText;
@@ -100,17 +102,15 @@ export class ChSelectItem {
   resolveLeftIcon() {
     if (this.leftIconSrc !== undefined) {
       return this.leftIconSrc;
-    } else {
-      return "";
     }
+    return "";
   }
 
   resolveRightIcon() {
     if (this.rightIconSrc !== undefined) {
       return this.rightIconSrc;
-    } else {
-      return "";
     }
+    return "";
   }
 
   render() {

--- a/src/deprecated-components/select/ch-select.tsx
+++ b/src/deprecated-components/select/ch-select.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @stencil-community/required-jsdoc */
 import {
   Component,
   Element,
@@ -71,7 +72,7 @@ export class ChSelect {
 
   @Element() el: HTMLChSelectElement;
 
-  //test
+  // test
   private optionsContainerEl?: HTMLDivElement;
   private selectContainerEl?: HTMLDivElement;
   private selectFlexContainerEl?: HTMLDivElement;
@@ -89,7 +90,9 @@ export class ChSelect {
   }
 
   calculateSelectWidth(width) {
-    if (width !== 0) this.selectContainerEl.style.width = width + "px";
+    if (width !== 0) {
+      this.selectContainerEl.style.width = width + "px";
+    }
   }
 
   calculateSelectHeight() {
@@ -105,7 +108,7 @@ export class ChSelect {
         this.toggleComponent();
         break;
       case "ArrowDown" || "ArrowUp":
-        //todo
+        // todo
         break;
       default:
         break;
@@ -114,8 +117,10 @@ export class ChSelect {
 
   @ClickOutside()
   closeSelect() {
-    //close the select when user clicks outside of component area.
-    if (this.toggle) this.toggleComponent();
+    // close the select when user clicks outside of component area.
+    if (this.toggle) {
+      this.toggleComponent();
+    }
   }
 
   @Listen("itemClicked")
@@ -136,17 +141,15 @@ export class ChSelect {
   resolveIcon() {
     if (this.iconSrc !== undefined) {
       return this.iconSrc;
-    } else {
-      return "";
     }
+    return "";
   }
 
   resolveArrowIcon() {
     if (this.arrowIconSrc !== undefined) {
       return this.arrowIconSrc;
-    } else {
-      return this.arrowTop;
     }
+    return this.arrowTop;
   }
 
   render() {

--- a/src/deprecated-components/sidebar-menu-list-item/ch-sidebar-menu-list-item.tsx
+++ b/src/deprecated-components/sidebar-menu-list-item/ch-sidebar-menu-list-item.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @stencil-community/own-methods-must-be-private */
 import {
   Component,
   Element,
@@ -60,6 +61,7 @@ export class ChSidebarMenuListItem {
     this.itemClickedEvent.emit({ "item-id": itemId });
   }
 
+  // @ts-expect-error: This control is deprecated, so we are avoiding this error
   firstListItemIcon() {
     if (this.itemIconSrc !== undefined) {
       return this.itemIconSrc;

--- a/src/deprecated-components/sidebar-menu-list-item/ch-sidebar-menu-list-item.tsx
+++ b/src/deprecated-components/sidebar-menu-list-item/ch-sidebar-menu-list-item.tsx
@@ -41,7 +41,7 @@ export class ChSidebarMenuListItem {
   @State() listTypeItem: string;
 
   componentWillLoad() {
-    //SET THE TPYE OF ITEM
+    // SET THE TPYE OF ITEM
     if (this.el.parentElement.classList.contains("list-one")) {
       this.listTypeItem = "one";
     } else if (this.el.parentElement.classList.contains("list-two")) {
@@ -49,7 +49,7 @@ export class ChSidebarMenuListItem {
     } else {
       this.listTypeItem = "three";
     }
-    //SET COLLAPSABLE OR NOT
+    // SET COLLAPSABLE OR NOT
     if (this.el.querySelector("ch-sidebar-menu-list") !== null) {
       this.collapsable = true;
     }
@@ -67,7 +67,7 @@ export class ChSidebarMenuListItem {
   }
 
   listItemContent() {
-    if (this.listTypeItem === "one")
+    if (this.listTypeItem === "one") {
       return [
         <div class="main-container" onClick={this.itemClicked.bind(this)}>
           <div class="left-container">
@@ -93,7 +93,8 @@ export class ChSidebarMenuListItem {
         </div>,
         <slot name="list"></slot>
       ];
-    if (this.listTypeItem === "two")
+    }
+    if (this.listTypeItem === "two") {
       return [
         <div class="main-container" onClick={this.itemClicked.bind(this)}>
           {this.collapsable ? (
@@ -107,7 +108,8 @@ export class ChSidebarMenuListItem {
         </div>,
         <slot name="list"></slot>
       ];
-    if (this.listTypeItem === "three")
+    }
+    if (this.listTypeItem === "three") {
       return (
         <div class="main-container" onClick={this.itemClicked.bind(this)}>
           <span class="text">
@@ -115,6 +117,7 @@ export class ChSidebarMenuListItem {
           </span>
         </div>
       );
+    }
   }
 
   render() {

--- a/src/deprecated-components/sidebar-menu-list/ch-sidebar-menu-list.tsx
+++ b/src/deprecated-components/sidebar-menu-list/ch-sidebar-menu-list.tsx
@@ -8,7 +8,7 @@ import { Component, Element, Host, h, State } from "@stencil/core";
 export class ChSidebarMenuList {
   @Element() el: HTMLChSidebarMenuListElement;
 
-  /*******************
+  /** *****************
    * STATE
    *******************/
   @State() listType = "list-one";

--- a/src/deprecated-components/sidebar-menu/ch-sidebar-menu.tsx
+++ b/src/deprecated-components/sidebar-menu/ch-sidebar-menu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @stencil-community/required-jsdoc */
 import {
   Component,
   Element,
@@ -27,7 +28,7 @@ export class ChSidebarMenu {
   private topHeightSpeed = 300;
   private speedDivisionValue = 400;
 
-  /*******************
+  /** *****************
    * REFERENCES
    *******************/
   main!: HTMLElement;
@@ -36,7 +37,7 @@ export class ChSidebarMenu {
   footer!: HTMLElement;
   collapseButton!: HTMLElement;
 
-  /*******************
+  /** *****************
    * PROPS
    *******************/
 
@@ -75,13 +76,13 @@ export class ChSidebarMenu {
    */
   @Prop({ reflect: true, mutable: true }) isCollapsed: boolean;
 
-  /*******************
+  /** *****************
    * STATE
    *******************/
   @State() indicator: HTMLElement;
 
   componentDidLoad() {
-    //hide menu in mobile view
+    // hide menu in mobile view
     if (window.matchMedia("(max-width: 767px)").matches) {
       this.menu.classList.add("hidden-xs");
     }
@@ -89,7 +90,7 @@ export class ChSidebarMenu {
       .matchMedia("(max-width: 767px)")
       .addEventListener("change", this.handleMatchMedia.bind(this));
 
-    //get sidebar status from storage
+    // get sidebar status from storage
     this.getSidebarState();
 
     const titleHeight = this.title.offsetHeight;
@@ -97,14 +98,14 @@ export class ChSidebarMenu {
     const titleAndFooterHeight = titleHeight + footerHeight + "px";
     const collapsableItems = this.el.querySelectorAll(".collapsable");
 
-    /*Set menu top position*/
+    /* Set menu top position*/
     const topDistance = this.distanceToTop.toString() + "px";
     this.menu.style.top = topDistance;
 
-    /*Set main height*/
+    /* Set main height*/
     this.main.style.height = `calc(100vh - ${titleAndFooterHeight} - ${topDistance})`;
 
-    //SET INITAL ITEMS MAX HEIGHT
+    // SET INITAL ITEMS MAX HEIGHT
     const items = this.el.querySelectorAll(".item");
     Array.from(items as unknown as HTMLCollectionOf<HTMLElement>).forEach(
       function (item) {
@@ -113,17 +114,17 @@ export class ChSidebarMenu {
           (mainContainer as HTMLElement).offsetHeight + "px";
       }
     );
-    //AFTER INITIAL ITEMS MAX HEIGHT HAS BEEN DEFINED, REDEFINE MAX HEIGHT FOR THE UNCOLLAPSED ITEMS
+    // AFTER INITIAL ITEMS MAX HEIGHT HAS BEEN DEFINED, REDEFINE MAX HEIGHT FOR THE UNCOLLAPSED ITEMS
     const uncollapsedItems = this.el.querySelectorAll(".item.uncollapsed");
     const uncollapsedItemsArr = Array.prototype.slice
       .call(uncollapsedItems)
       .reverse();
 
     uncollapsedItemsArr.forEach(function (item) {
-      //mainContainer height
+      // mainContainer height
       const mainContainerHeight =
         item.shadowRoot.querySelector(".main-container").offsetHeight;
-      //menu list height
+      // menu list height
       const menuList = item.querySelector(":scope > ch-sidebar-menu-list");
       if (menuList) {
         const menuListHeight = (menuList as HTMLElement).offsetHeight;
@@ -131,14 +132,14 @@ export class ChSidebarMenu {
       }
     });
 
-    /**********************************
+    /** ********************************
     LATERAL ACTIVE ITEM INDICATOR LOGIC
     ***********************************/
     this.indicator = document.createElement("DIV");
     this.indicator.setAttribute("id", "indicator");
     this.main.appendChild(this.indicator);
 
-    //when active-item is loaded from session, recalculate indicator position
+    // when active-item is loaded from session, recalculate indicator position
     this.repositionIndicatorAfterMenuUncollapse();
 
     Array.from(items).forEach(
@@ -175,7 +176,7 @@ export class ChSidebarMenu {
       }.bind(this)
     );
 
-    /*********************
+    /** *******************
     SET ACTIVE ITEM LOGIC
     **********************/
     Array.from(items).forEach(
@@ -184,34 +185,34 @@ export class ChSidebarMenu {
           "click",
           function (e) {
             e.stopPropagation();
-            //fede
-            //if (!this.menu.classList.contains("collapsed")) {
-            //remove current active item class
+            // fede
+            // if (!this.menu.classList.contains("collapsed")) {
+            // remove current active item class
             const currentActiveItem = document.querySelector(".item--active");
             if (currentActiveItem !== null) {
               currentActiveItem.classList.remove("item--active");
             }
-            //set current item as active
+            // set current item as active
             item.classList.add("item--active");
 
-            //fede
+            // fede
             this.GetCurrentItemIndicatorPos();
 
-            //store the active item on the sessionStorage
+            // store the active item on the sessionStorage
             this.storeSidebarActiveItem(item);
             this.activeItem = item.id;
-            //}
+            // }
           }.bind(this)
         );
       }.bind(this)
     );
-    //SET ACTIVE CURRENT ACTIVE ITEM IF PRESENT
-    //if (this.activeItemId !== "") {
+    // SET ACTIVE CURRENT ACTIVE ITEM IF PRESENT
+    // if (this.activeItemId !== "") {
     if (this.activeItemId !== "" && !this.activeItem) {
       const activeItem = this.el.querySelector("#" + this.activeItemId);
       activeItem.classList.add("item--active");
 
-      //uncollapse item's parent if exists
+      // uncollapse item's parent if exists
       let parentEl = activeItem.parentElement;
       if (parentEl.hasAttribute("slot")) {
         parentEl = parentEl.parentElement;
@@ -224,8 +225,8 @@ export class ChSidebarMenu {
           grandpaEl.classList.add("uncollapsed");
         }
       }
-      //indicator
-      //let indicator = this.el.shadowRoot.querySelector("#indicator");
+      // indicator
+      // let indicator = this.el.shadowRoot.querySelector("#indicator");
       const activeItemTopPosition = activeItem.getBoundingClientRect().y;
       const activeItemHeight =
         activeItem.shadowRoot.querySelector<HTMLElement>(
@@ -235,7 +236,7 @@ export class ChSidebarMenu {
       this.indicator.style.height = activeItemHeight + "px";
     }
 
-    /****************************
+    /** **************************
     COLLAPSABLE LIST ITEMS LOGIC
     ****************************/
     Array.from(collapsableItems).forEach(
@@ -248,17 +249,17 @@ export class ChSidebarMenu {
               item.classList.contains("list-one__item") &&
               this.menu.classList.contains("collapsed")
             ) {
-              //If item clicked is type 1, and menu is collapsed, just uncollapse the menu.
+              // If item clicked is type 1, and menu is collapsed, just uncollapse the menu.
               this.collapseButton.click();
             } else {
-              this.toggleIcon(item); //This function has to be before  uncollapseList or collapseList.
+              this.toggleIcon(item); // This function has to be before  uncollapseList or collapseList.
               this.setTransitionSpeed(item);
               if (item.classList.contains("uncollapsed")) {
                 this.uncollapseList(item);
               } else {
                 this.collapseList(item);
               }
-              //If this item is type 2, then update list 1 transition speed and maxheight
+              // If this item is type 2, then update list 1 transition speed and maxheight
               if (item.classList.contains("list-two__item")) {
                 const parentItem1 = item.closest(".list-one__item");
                 const heightToTransition =
@@ -267,7 +268,7 @@ export class ChSidebarMenu {
                   parentItem1,
                   heightToTransition
                 );
-                //Update list 1 max. height
+                // Update list 1 max. height
                 this.updateListItem1MaxHeight(parentItem1);
               }
             }
@@ -276,11 +277,11 @@ export class ChSidebarMenu {
       }.bind(this)
     );
 
-    /*******************************
+    /** *****************************
     SINGLE UL1 OPEN AT A TIME LOGIC  
     *******************************/
-    //Only one list of type 1 can be open at the same time.
-    //This is an optional parameter. Applies if 'data-single-ul1-open' attribute is present on #menu
+    // Only one list of type 1 can be open at the same time.
+    // This is an optional parameter. Applies if 'data-single-ul1-open' attribute is present on #menu
     if (this.singleListOpen) {
       const collapsableListOneItems =
         document.querySelectorAll(".list-one__item");
@@ -313,7 +314,7 @@ export class ChSidebarMenu {
       );
     }
 
-    /*******************
+    /** *****************
     COLLAPSE MENU LOGIC
     *******************/
     if (this.collapsible) {
@@ -322,12 +323,12 @@ export class ChSidebarMenu {
         function () {
           let setTimeOutDelay = 0;
           if (this.menu.classList.contains("collapsed")) {
-            //if menu is collapsed, the animation that shows the menu should be quicker
+            // if menu is collapsed, the animation that shows the menu should be quicker
             this.menu.classList.add("collapse-faster");
-            setTimeOutDelay = 300; //This value should be the same as the #menu.collapse-faster transition speed value.
+            setTimeOutDelay = 300; // This value should be the same as the #menu.collapse-faster transition speed value.
           } else {
             this.menu.classList.remove("collapse-faster");
-            setTimeOutDelay = 600; //This value should be the same as the #menu without .collapse-faster transition speed value.
+            setTimeOutDelay = 600; // This value should be the same as the #menu without .collapse-faster transition speed value.
           }
           this.menu.classList.add("collapsing");
           this.hideIndicator();
@@ -376,7 +377,7 @@ export class ChSidebarMenu {
 
     this.getSidebarCollapsedState();
 
-    /******************
+    /** ****************
     ITEMS TOOLTIP LOGIC
     *******************/
     const itemTooltip = document.createElement("DIV");
@@ -409,7 +410,7 @@ export class ChSidebarMenu {
       }.bind(this)
     );
 
-    //REPOSITION INDICATOR ON SCROLL
+    // REPOSITION INDICATOR ON SCROLL
     this.main.addEventListener(
       "scroll",
       function () {
@@ -417,7 +418,7 @@ export class ChSidebarMenu {
       }.bind(this)
     );
 
-    //Calculation of menu top value and height on scroll
+    // Calculation of menu top value and height on scroll
     let lastTop: number;
     document.addEventListener(
       "scroll",
@@ -428,33 +429,31 @@ export class ChSidebarMenu {
         if (lastTop === undefined) {
           lastTop = 0;
         }
-        //make menu.top a number
+        // make menu.top a number
         const menuTop = Number(this.menu.style.top.split("px")[0]);
         if (menuTop > 0) {
           if (menuTop - (top - lastTop) > 0) {
             const scrollTopValue: number = top - lastTop;
             this.menu.style.top = menuTop - scrollTopValue + "px";
             lastTop = top;
-            /*Set main height*/
+            /* Set main height*/
             const mainTop = this.distanceToTop - top;
             const topStr = mainTop + "px";
             this.main.style.height = `calc(100vh - ${titleAndFooterHeight} - ${topStr})`;
-            //reposition of active item indicator
+            // reposition of active item indicator
             this.GetCurrentItemIndicatorPos();
           } else {
             this.menu.style.top = "0px";
-            //reposition of active item indicator
+            // reposition of active item indicator
             this.GetCurrentItemIndicatorPos();
           }
-        } else {
-          if (menuTop == 0) {
-            if (top <= this.distanceToTop) {
-              this.menu.style.top = this.distanceToTop - top + "px";
-              lastTop = top;
-              this.main.style.height = `calc(100vh - ${titleAndFooterHeight} - ${top})`;
-              //reposition of active item indicator
-              this.GetCurrentItemIndicatorPos();
-            }
+        } else if (menuTop == 0) {
+          if (top <= this.distanceToTop) {
+            this.menu.style.top = this.distanceToTop - top + "px";
+            lastTop = top;
+            this.main.style.height = `calc(100vh - ${titleAndFooterHeight} - ${top})`;
+            // reposition of active item indicator
+            this.GetCurrentItemIndicatorPos();
           }
         }
       }.bind(this)
@@ -471,7 +470,7 @@ export class ChSidebarMenu {
 
   @ClickOutside({ exclude: ".sidebar__toggle-ico" })
   closeSidebar() {
-    //close the sidebar when user clicks outside of component area (only in mobile view - xs media screens).
+    // close the sidebar when user clicks outside of component area (only in mobile view - xs media screens).
     const screenSize = window.matchMedia("(max-width: 767px)");
     if (screenSize.matches) {
       // Viewport is less or equal to 767 pixels wide
@@ -480,7 +479,7 @@ export class ChSidebarMenu {
     }
   }
 
-  //get position of current active item
+  // get position of current active item
   GetCurrentItemIndicatorPos() {
     let timer = null;
     const currentActiveItem = document.querySelector(".item--active");
@@ -489,7 +488,7 @@ export class ChSidebarMenu {
         currentActiveItem.getBoundingClientRect().y;
       this.indicator.classList.add("speed-zero");
       this.indicator.style.top = currentActiveItemTopPosition + "px";
-      //detect when scrolling has stopped
+      // detect when scrolling has stopped
       if (timer !== null) {
         clearTimeout(timer);
       }
@@ -502,7 +501,7 @@ export class ChSidebarMenu {
     }
   }
 
-  //REPOSITION INDICATOR AFTER MENU COLLAPSE
+  // REPOSITION INDICATOR AFTER MENU COLLAPSE
   repositionIndicatorAfterMenuCollapse() {
     const activeItem = this.el.querySelector(".item--active");
     if (activeItem !== null) {
@@ -515,7 +514,7 @@ export class ChSidebarMenu {
         this.indicator.style.top = topPosition + "px";
         this.indicator.style.height = height + "px";
       } else {
-        //else, the active item has no parent l ist. just reposition indicator
+        // else, the active item has no parent l ist. just reposition indicator
         const topPosition = activeItem.getBoundingClientRect().y;
         const height = (activeItem as HTMLElement).offsetHeight;
         this.indicator.style.top = topPosition + "px";
@@ -523,7 +522,7 @@ export class ChSidebarMenu {
       }
     }
   }
-  //REPOSITION INDICATOR AFTER MENU UNCOLLAPSE
+  // REPOSITION INDICATOR AFTER MENU UNCOLLAPSE
   repositionIndicatorAfterMenuUncollapse() {
     const activeItem = this.el.querySelector(".item--active");
     if (activeItem !== null) {
@@ -539,11 +538,11 @@ export class ChSidebarMenu {
     }
   }
 
-  //HIDE INDICATOR
+  // HIDE INDICATOR
   hideIndicator() {
     this.indicator.classList.add("hide");
   }
-  //SHOW INDICATOR
+  // SHOW INDICATOR
   showIndicator() {
     this.indicator.classList.remove("hide");
   }
@@ -595,7 +594,7 @@ export class ChSidebarMenu {
     });
   }
 
-  /*UPDATE LIST ITEM 1 TRANSITION SPEED*/
+  /* UPDATE LIST ITEM 1 TRANSITION SPEED*/
   updateListItem1TransitionSpeed(item, height) {
     if (height > this.topHeightSpeed) {
       height = this.topHeightSpeed;
@@ -603,7 +602,7 @@ export class ChSidebarMenu {
     item.style.transitionDuration = height / this.speedDivisionValue + "s";
   }
 
-  /*UPDATE LIST ITEM 1 MAX HEIGHT*/
+  /* UPDATE LIST ITEM 1 MAX HEIGHT*/
   updateListItem1MaxHeight(item) {
     const mainContainerHeight =
       item.shadowRoot.querySelector(".main-container").clientHeight;
@@ -619,7 +618,7 @@ export class ChSidebarMenu {
     item.style.maxHeight = totalMaxHeight + "px";
   }
 
-  /*TOGGLE ITEM ICON*/
+  /* TOGGLE ITEM ICON*/
   toggleIcon(item) {
     if (item.classList.contains("uncollapsed")) {
       item.classList.remove("uncollapsed");
@@ -628,7 +627,7 @@ export class ChSidebarMenu {
     }
   }
 
-  /*SET ITEM TRANSITION SPEED*/
+  /* SET ITEM TRANSITION SPEED*/
   setTransitionSpeed(item) {
     let transitionSpeed = 0;
     const childListHeight = item.querySelector(
@@ -643,16 +642,16 @@ export class ChSidebarMenu {
       transitionSpeed / this.speedDivisionValue + "s";
   }
 
-  /*COLLAPSE LIST*/
+  /* COLLAPSE LIST*/
   collapseList(item) {
     const mainContainerHeight =
       item.shadowRoot.querySelector(".main-container").offsetHeight;
     item.style.maxHeight = mainContainerHeight + "px";
 
-    //store the item's collapsed state
+    // store the item's collapsed state
     this.storeSidebarCollapsedItem(item);
   }
-  /*UNCOLLAPSE LIST*/
+  /* UNCOLLAPSE LIST*/
   uncollapseList(item) {
     const mainContainerHeight =
       item.shadowRoot.querySelector(".main-container").clientHeight;
@@ -661,7 +660,7 @@ export class ChSidebarMenu {
     ).clientHeight;
     item.style.maxHeight = mainContainerHeight + childListHeight + "px";
 
-    //store the item's uncollapsed state
+    // store the item's uncollapsed state
     this.storeSidebarUncollapsedItem(item);
   }
 
@@ -697,7 +696,7 @@ export class ChSidebarMenu {
     }
   }
 
-  /*GET SIDEBAR STATE*/
+  /* GET SIDEBAR STATE*/
   getSidebarState() {
     const storageHelper = new StorageHelper.SessionStorageWorker();
     const storageItems = storageHelper.getAllItems();
@@ -709,8 +708,8 @@ export class ChSidebarMenu {
           if (item) {
             item.classList.add("item--active");
             this.activeItem = item.id;
-            //fede
-            //const itemPos = item.offsetTop;
+            // fede
+            // const itemPos = item.offsetTop;
             /*
             this.main.scroll({
               top: 100, 
@@ -759,7 +758,7 @@ export class ChSidebarMenu {
     }
   }
 
-  //collapse menu button handler
+  // collapse menu button handler
   collapseMenuHandler() {
     this.collapseBtnClicked.emit({ isCollapsed: this.isCollapsed });
   }

--- a/src/deprecated-components/sidebar-menu/ch-sidebar-menu.tsx
+++ b/src/deprecated-components/sidebar-menu/ch-sidebar-menu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @stencil-community/own-methods-must-be-private */
 /* eslint-disable @stencil-community/required-jsdoc */
 import {
   Component,
@@ -148,12 +149,14 @@ export class ChSidebarMenu {
           "click",
           function (e) {
             e.stopPropagation();
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             if (!this.menu.classList.contains("collapsed")) {
               const itemTopPosition = item.getBoundingClientRect().y;
               const itemHeight =
                 item.shadowRoot.querySelector(".main-container").offsetHeight;
 
               if (
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.singleListOpen &&
                 item.classList.contains("list-one__item")
               ) {
@@ -164,13 +167,18 @@ export class ChSidebarMenu {
                     itemCopy.shadowRoot.querySelector(".main-container");
                   totalHeight += itemCopyMainContainer.offsetHeight;
                 }
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.indicator.style.top = totalHeight + "px";
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.indicator.style.height = itemHeight + "px";
               } else {
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.indicator.style.top = itemTopPosition + "px";
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.indicator.style.height = itemHeight + "px";
               }
             }
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
           }.bind(this)
         );
       }.bind(this)
@@ -196,12 +204,16 @@ export class ChSidebarMenu {
             item.classList.add("item--active");
 
             // fede
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.GetCurrentItemIndicatorPos();
 
             // store the active item on the sessionStorage
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.storeSidebarActiveItem(item);
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.activeItem = item.id;
             // }
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
           }.bind(this)
         );
       }.bind(this)
@@ -247,16 +259,22 @@ export class ChSidebarMenu {
           function () {
             if (
               item.classList.contains("list-one__item") &&
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
               this.menu.classList.contains("collapsed")
             ) {
               // If item clicked is type 1, and menu is collapsed, just uncollapse the menu.
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
               this.collapseButton.click();
             } else {
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
               this.toggleIcon(item); // This function has to be before  uncollapseList or collapseList.
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
               this.setTransitionSpeed(item);
               if (item.classList.contains("uncollapsed")) {
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.uncollapseList(item);
               } else {
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.collapseList(item);
               }
               // If this item is type 2, then update list 1 transition speed and maxheight
@@ -264,14 +282,17 @@ export class ChSidebarMenu {
                 const parentItem1 = item.closest(".list-one__item");
                 const heightToTransition =
                   item.querySelector(".list-three").offsetHeight;
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.updateListItem1TransitionSpeed(
                   parentItem1,
                   heightToTransition
                 );
                 // Update list 1 max. height
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.updateListItem1MaxHeight(parentItem1);
               }
             }
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
           }.bind(this)
         );
       }.bind(this)
@@ -292,6 +313,7 @@ export class ChSidebarMenu {
           mainContainer.addEventListener(
             "click",
             function () {
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
               if (!this.menu.classList.contains("collapsed")) {
                 const lastUl1Opened = document.querySelector(".lastUl1Opened");
                 if (
@@ -308,6 +330,7 @@ export class ChSidebarMenu {
                   item.classList.remove("lastUl1Opened");
                 }
               }
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
             }.bind(this)
           );
         }.bind(this)
@@ -322,52 +345,78 @@ export class ChSidebarMenu {
         "click",
         function () {
           let setTimeOutDelay = 0;
+          // @ts-expect-error: This control is deprecated, so we are avoiding this error
           if (this.menu.classList.contains("collapsed")) {
             // if menu is collapsed, the animation that shows the menu should be quicker
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.menu.classList.add("collapse-faster");
             setTimeOutDelay = 300; // This value should be the same as the #menu.collapse-faster transition speed value.
           } else {
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.menu.classList.remove("collapse-faster");
             setTimeOutDelay = 600; // This value should be the same as the #menu without .collapse-faster transition speed value.
           }
+          // @ts-expect-error: This control is deprecated, so we are avoiding this error
           this.menu.classList.add("collapsing");
+          // @ts-expect-error: This control is deprecated, so we are avoiding this error
           this.hideIndicator();
           setTimeout(
             function () {
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
               if (this.menu.classList.contains("collapsed")) {
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.uncollapseCollapsedLists();
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.undoSwitchListOneOrder();
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.menu.classList.remove("collapsed");
                 setTimeout(
                   function () {
+                    // @ts-expect-error: This control is deprecated, so we are avoiding this error
                     this.repositionIndicatorAfterMenuUncollapse();
+                    // @ts-expect-error: This control is deprecated, so we are avoiding this error
                   }.bind(this),
                   50
                 );
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.isCollapsed = false;
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.collapseMenuHandler();
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.storeSidebarState();
               } else {
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.collapseUncollapsedLists1();
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.switchListOneOrder();
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.menu.classList.add("collapsed");
                 setTimeout(
                   function () {
+                    // @ts-expect-error: This control is deprecated, so we are avoiding this error
                     this.repositionIndicatorAfterMenuCollapse();
+                    // @ts-expect-error: This control is deprecated, so we are avoiding this error
                   }.bind(this),
                   50
                 );
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.isCollapsed = true;
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.collapseMenuHandler();
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.storeSidebarState();
               }
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
               this.menu.classList.remove("collapsing");
               setTimeout(
                 function () {
+                  // @ts-expect-error: This control is deprecated, so we are avoiding this error
                   this.showIndicator();
+                  // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 }.bind(this),
                 400
               );
+              // @ts-expect-error: This control is deprecated, so we are avoiding this error
             }.bind(this),
             setTimeOutDelay
           );
@@ -391,20 +440,24 @@ export class ChSidebarMenu {
         mainContainer.addEventListener(
           "mouseenter",
           function () {
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             if (this.menu.classList.contains("collapsed")) {
               itemTooltip.classList.add("visible");
               itemTooltip.innerHTML = item.childNodes[0].nodeValue;
               const itemTopPosition = item.getBoundingClientRect().y;
               itemTooltip.style.top = itemTopPosition + "px";
             }
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
           }.bind(this)
         );
         mainContainer.addEventListener(
           "mouseleave",
           function () {
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             if (this.menu.classList.contains("collapsed")) {
               itemTooltip.classList.remove("visible");
             }
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
           }.bind(this)
         );
       }.bind(this)
@@ -414,6 +467,7 @@ export class ChSidebarMenu {
     this.main.addEventListener(
       "scroll",
       function () {
+        // @ts-expect-error: This control is deprecated, so we are avoiding this error
         this.GetCurrentItemIndicatorPos();
       }.bind(this)
     );
@@ -430,29 +484,40 @@ export class ChSidebarMenu {
           lastTop = 0;
         }
         // make menu.top a number
+        // @ts-expect-error: This control is deprecated, so we are avoiding this error
         const menuTop = Number(this.menu.style.top.split("px")[0]);
         if (menuTop > 0) {
           if (menuTop - (top - lastTop) > 0) {
             const scrollTopValue: number = top - lastTop;
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.menu.style.top = menuTop - scrollTopValue + "px";
             lastTop = top;
             /* Set main height*/
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             const mainTop = this.distanceToTop - top;
             const topStr = mainTop + "px";
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.main.style.height = `calc(100vh - ${titleAndFooterHeight} - ${topStr})`;
             // reposition of active item indicator
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.GetCurrentItemIndicatorPos();
           } else {
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.menu.style.top = "0px";
             // reposition of active item indicator
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.GetCurrentItemIndicatorPos();
           }
         } else if (menuTop == 0) {
+          // @ts-expect-error: This control is deprecated, so we are avoiding this error
           if (top <= this.distanceToTop) {
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.menu.style.top = this.distanceToTop - top + "px";
             lastTop = top;
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.main.style.height = `calc(100vh - ${titleAndFooterHeight} - ${top})`;
             // reposition of active item indicator
+            // @ts-expect-error: This control is deprecated, so we are avoiding this error
             this.GetCurrentItemIndicatorPos();
           }
         }
@@ -494,6 +559,7 @@ export class ChSidebarMenu {
       }
       timer = setTimeout(
         function () {
+          // @ts-expect-error: This control is deprecated, so we are avoiding this error
           this.indicator.classList.remove("speed-zero");
         }.bind(this),
         50
@@ -744,6 +810,7 @@ export class ChSidebarMenu {
             this.menu.classList.add("collapsed");
             setTimeout(
               function () {
+                // @ts-expect-error: This control is deprecated, so we are avoiding this error
                 this.repositionIndicatorAfterMenuCollapse();
               }.bind(this),
               50

--- a/src/deprecated-components/step-list-item/ch-step-list-item.tsx
+++ b/src/deprecated-components/step-list-item/ch-step-list-item.tsx
@@ -42,10 +42,11 @@ export class ChStepListItem {
     for (let i = 0; i < stepItems.length; i++) {
       const item: any = stepItems[i].shadowRoot.lastChild.childNodes[0];
 
-      //remove old item selected class
-      if (item.classList.contains("li-item--active"))
+      // remove old item selected class
+      if (item.classList.contains("li-item--active")) {
         item.classList.remove("li-item--active");
-      //set active item class
+      }
+      // set active item class
       if (stepItems[i].innerText === targetItem) {
         item.classList.add("li-item--active");
       }
@@ -55,9 +56,8 @@ export class ChStepListItem {
   resolveIcon() {
     if (this.iconSrc !== undefined) {
       return this.iconSrc;
-    } else {
-      return getAssetPath("step-list-item-assets/dot.svg");
     }
+    return getAssetPath("step-list-item-assets/dot.svg");
   }
 
   render() {
@@ -66,15 +66,15 @@ export class ChStepListItem {
         <li
           class={
             {
-              //"tree-open": this.opened,
-              //disabled: this.disabled,
+              // "tree-open": this.opened,
+              // disabled: this.disabled,
             }
           }
         >
           <div
             class={{
               "li-item": true
-              //"li-text--selected": this.selected,
+              // "li-text--selected": this.selected,
             }}
           >
             <span class="text" onClick={() => this.itemClickedHandler(this)}>

--- a/src/deprecated-components/tree-item/ch-tree-item.tsx
+++ b/src/deprecated-components/tree-item/ch-tree-item.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-lonely-if */
+/* eslint-disable @stencil-community/required-jsdoc */
 import {
   Component,
   Event,

--- a/src/deprecated-components/tree/ch-tree.tsx
+++ b/src/deprecated-components/tree/ch-tree.tsx
@@ -18,7 +18,7 @@ export class ChTree {
   @Element() el: HTMLChTreeElement;
   ulTree!: HTMLElement;
 
-  //PROPS
+  // PROPS
   /**
    * Set this attribute if you want all this tree tree-items to have a checkbox
    */
@@ -34,17 +34,17 @@ export class ChTree {
    */
   @Prop({ mutable: true }) toggleCheckboxes = false;
 
-  //STATE
+  // STATE
   @State() nestedTree = false;
   @State() mainTree = false;
 
   componentWillLoad() {
-    //Check if this tree is nested
+    // Check if this tree is nested
     const parentElementTagName = this.el.parentElement.tagName;
     if (parentElementTagName === "CH-TREE-ITEM") {
       this.nestedTree = true;
     }
-    //if this is the main tree...
+    // if this is the main tree...
     const parentTreeTagName = this.el.parentElement.tagName;
     if (parentTreeTagName !== "CH-TREE-ITEM") {
       this.mainTree = true;
@@ -53,7 +53,7 @@ export class ChTree {
 
   @Listen("liItemClicked")
   liItemClickedHandler() {
-    //Remove 'selected' state from previous selected item
+    // Remove 'selected' state from previous selected item
     const chTreeItems = this.el.querySelectorAll("ch-tree-item");
     chTreeItems.forEach(chTreeItem => {
       (chTreeItem as unknown as ChTreeItem).selected = false;
@@ -62,7 +62,7 @@ export class ChTree {
 
   @Listen("toggleIconClicked")
   toggleIconClickedHandler() {
-    //Update not leaf tree items vertical line height
+    // Update not leaf tree items vertical line height
     const treeItems = this.el.querySelectorAll("ch-tree-item.not-leaf");
     treeItems.forEach(treeItem => {
       (treeItem as unknown as ChTreeItem).updateTreeVerticalLineHeight();

--- a/src/helpers/storage-helper.ts
+++ b/src/helpers/storage-helper.ts
@@ -19,7 +19,7 @@ export class SessionStorageWorker {
 
   constructor() {
     this.sessionStorageSupported =
-      typeof window.sessionStorage != "undefined" &&
+      typeof window.sessionStorage !== "undefined" &&
       window.sessionStorage != null;
   }
 
@@ -64,9 +64,8 @@ export class SessionStorageWorker {
     if (this.sessionStorageSupported) {
       const item = sessionStorage.getItem(key);
       return item;
-    } else {
-      return null;
     }
+    return null;
   }
 
   // remove value from storage

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,26 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "allowUnreachableCode": false,
     "declaration": false,
+    "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["DOM", "ES2022", "DOM.Iterable"],
-    "moduleResolution": "node",
     "module": "esnext",
     "target": "ES2022",
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "moduleResolution": "node",
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+
+    // Linting
+    "allowUnreachableCode": false,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    // "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+    // "strict": true
   },
   "include": ["src", "stencil.config.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Breaking changes
 - ch-grid's interface types has been updated to improve the type safety.
   - Before: `getNextRow: () => Promise<string>`
     NOW: `getNextRow: () => Promise<string | void>`

   - Before: `getPreviousRow: () => Promise<string>`
      NOW: `getPreviousRow: () => Promise<string | void>`