### PR TITLE
Add the `selectedId` in the rendered pages on initial load for `ch-list`

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -482,6 +482,12 @@ export class ChList implements DraggableView {
         this.#renderedPages.add(item.id);
       }
     });
+
+    // The selected id must be added to the rendered pages, even if it was not
+    // marked as "wasRendered" in the UI Model
+    if (this.selectedId) {
+      this.#renderedPages.add(this.selectedId);
+    }
   };
 
   // #handleItemDblClick = (event: MouseEvent) => {


### PR DESCRIPTION
This fixes the initial page not being displayed on the initial load.