### PR TITLE
Improve accessibility in the `ch-checkbox` control and improve control customization

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -48,21 +48,21 @@ $option-checked-box-shadow: var(--option-highlight-color, currentColor);
   position: relative;
   inline-size: var(--ch-checkbox__container-size);
   block-size: var(--ch-checkbox__container-size);
-  border: 1px solid $option-checked-border-color;
-  border-radius: 18.75%;
-
-  &--checked {
-    background-color: $option-checked-background-color;
-  }
 }
 
 .input {
   display: flex;
   inline-size: 100%;
   block-size: 100%;
-  opacity: 0;
+
+  // Reset browser defaults
+  appearance: none;
   margin: 0;
   padding: 0;
+  outline: unset;
+
+  border: 1px solid $option-checked-border-color;
+  border-radius: 18.75%;
 }
 
 .option {

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -43,9 +43,9 @@ $option-checked-box-shadow: var(--option-highlight-color, currentColor);
    */
   --ch-checkbox__option-image-size: 100%;
 
-  display: flex;
+  display: inline-grid;
+  grid-template-columns: max-content 1fr;
   align-items: center;
-  align-self: stretch;
 
   // Remove outline of the focus state. This selector must not have higher
   // specificity, since it should be overridden by the class applied to the control

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -1,9 +1,7 @@
 @import "../../common/_base";
 
-$option-checked-background-color: var(--option-checked-color, #ffffff00);
-$option-checked-border-color: var(--option-border-color, currentColor);
+$option-checked-border-color: currentColor;
 $option-checked-color: currentColor;
-$option-checked-box-shadow: var(--option-highlight-color, currentColor);
 
 @include box-sizing();
 

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -16,11 +16,32 @@ $option-checked-box-shadow: var(--option-highlight-color, currentColor);
   --ch-checkbox__container-size: min(1em, 20px);
 
   /**
+   * @prop --ch-checkbox__checked-image:
+   * Specifies the image of the checkbox when is checked.
+   * @default url("data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='currentColor' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/></svg>")
+   */
+  --ch-checkbox__option-checked-image: url("data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='currentColor' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/></svg>");
+
+  /**
+   * @prop --ch-checkbox__option-indeterminate-image:
+   * Specifies the image of the checkbox when is indeterminate.
+   * @default url("data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='currentColor' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/></svg>")
+   */
+  --ch-checkbox__option-indeterminate-image: url("data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><rect width='8' height='8'/></svg>");
+
+  /**
    * @prop --ch-checkbox__option-size:
-   * Specifies the size for the `radio__option` element.
+   * Specifies the size for the `option` element.
    * @default 50%
    */
   --ch-checkbox__option-size: 50%;
+
+  /**
+   * @prop --ch-checkbox__option-image-size:
+   * Specifies the image size of the `option` element.
+   * @default 100%
+   */
+  --ch-checkbox__option-image-size: 100%;
 
   display: flex;
   align-items: center;
@@ -73,7 +94,13 @@ $option-checked-box-shadow: var(--option-highlight-color, currentColor);
   pointer-events: none;
 
   &--checked {
-    -webkit-mask: url("data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='currentColor' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/></svg>");
+    -webkit-mask: no-repeat center / var(--ch-checkbox__option-image-size)
+      var(--ch-checkbox__option-checked-image);
+  }
+
+  &--indeterminate {
+    -webkit-mask: no-repeat center / var(--ch-checkbox__option-image-size)
+      var(--ch-checkbox__option-indeterminate-image);
   }
 
   &--not-displayed {

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -38,7 +38,7 @@ const PARTS = (checked: boolean, indeterminate: boolean, disabled: boolean) => {
 
 /**
  * @part container - The container that serves as a wrapper for the `input` and the `option` parts.
- * @part input - The invisible input element that implements the interactions for the component. This part must be kept "invisible".
+ * @part input - The input element that implements the interactions for the component.
  * @part option - The actual "input" that is rendered above the `input` part. This part has `position: absolute` and `pointer-events: none`.
  * @part label - The label that is rendered when the `caption` property is not empty.
  *

--- a/src/components/checkbox/readme.md
+++ b/src/components/checkbox/readme.md
@@ -30,24 +30,27 @@
 
 ## Shadow Parts
 
-| Part              | Description                                                                                                                                                             |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"checked"`       | Present in the `option`, `label` and `container` parts when the control is checked and not indeterminate (`value` === `checkedValue` and `indeterminate !== true`).     |
-| `"container"`     | The container that serves as a wrapper for the `input` and the `option` parts.                                                                                          |
-| `"disabled"`      | Present in the `option`, `label` and `container` parts when the control is disabled (`disabled` === `true`).                                                            |
-| `"indeterminate"` | Present in the `option`, `label` and `container` parts when the control is indeterminate (`indeterminate` === `true`).                                                  |
-| `"input"`         | The invisible input element that implements the interactions for the component. This part must be kept "invisible".                                                     |
-| `"label"`         | The label that is rendered when the `caption` property is not empty.                                                                                                    |
-| `"option"`        | The actual "input" that is rendered above the `input` part. This part has `position: absolute` and `pointer-events: none`.                                              |
-| `"unchecked"`     | Present in the `option`, `label` and `container` parts when the control is unchecked and not indeterminate (`value` === `unCheckedValue` and `indeterminate !== true`). |
+| Part              | Description                                                                                                                                                                      |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"checked"`       | Present in the `input`, `option`, `label` and `container` parts when the control is checked and not indeterminate (`value` === `checkedValue` and `indeterminate !== true`).     |
+| `"container"`     | The container that serves as a wrapper for the `input` and the `option` parts.                                                                                                   |
+| `"disabled"`      | Present in the `input`, `option`, `label` and `container` parts when the control is disabled (`disabled` === `true`).                                                            |
+| `"indeterminate"` | Present in the `input`, `option`, `label` and `container` parts when the control is indeterminate (`indeterminate` === `true`).                                                  |
+| `"input"`         | The input element that implements the interactions for the component.                                                                                                            |
+| `"label"`         | The label that is rendered when the `caption` property is not empty.                                                                                                             |
+| `"option"`        | The actual "input" that is rendered above the `input` part. This part has `position: absolute` and `pointer-events: none`.                                                       |
+| `"unchecked"`     | Present in the `input`, `option`, `label` and `container` parts when the control is unchecked and not indeterminate (`value` === `unCheckedValue` and `indeterminate !== true`). |
 
 
 ## CSS Custom Properties
 
-| Name                            | Description                                                                                        |
-| ------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--ch-checkbox__container-size` | Specifies the size for the container of the `input` and `option` elements. @default min(1em, 20px) |
-| `--ch-checkbox__option-size`    | Specifies the size for the `radio__option` element. @default 50%                                   |
+| Name                                        | Description                                                                                                                                                                                                                                                |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--ch-checkbox__checked-image`              | Specifies the image of the checkbox when is checked. @default url("data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='currentColor' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/></svg>")       |
+| `--ch-checkbox__container-size`             | Specifies the size for the container of the `input` and `option` elements. @default min(1em, 20px)                                                                                                                                                         |
+| `--ch-checkbox__option-image-size`          | Specifies the image size of the `option` element. @default 100%                                                                                                                                                                                            |
+| `--ch-checkbox__option-indeterminate-image` | Specifies the image of the checkbox when is indeterminate. @default url("data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='currentColor' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/></svg>") |
+| `--ch-checkbox__option-size`                | Specifies the size for the `option` element. @default 50%                                                                                                                                                                                                  |
 
 
 ## Dependencies


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Enable more surface area to interact with the checkbox.

 - Add support to customize the checked and indeterminate images and their sizes with custom vars.

 - Fix option size not working properly in some cases.

 - Make more white-label the default colors.