### PR TITLE
Add support to render HTML in `ch-markdown` and improve DOM sanitizer

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1217,10 +1217,6 @@ export namespace Components {
      */
     interface ChMarkdown {
         /**
-          * `true` to render potentially dangerous user content when rendering HTML with the option `rawHtml === true`
-         */
-        "allowDangerousHtml": boolean;
-        /**
           * `true` to render raw HTML with sanitization.
          */
         "rawHtml": boolean;
@@ -5185,10 +5181,6 @@ declare namespace LocalJSX {
      * - When the code highlighting is needed at runtime, the control will load on demand the code parser and the programming language needed to parse the code.
      */
     interface ChMarkdown {
-        /**
-          * `true` to render potentially dangerous user content when rendering HTML with the option `rawHtml === true`
-         */
-        "allowDangerousHtml"?: boolean;
         /**
           * `true` to render raw HTML with sanitization.
          */

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -28,16 +28,16 @@ export class ChMarkdown {
 
   @Element() el: HTMLChMarkdownElement;
 
-  /**
-   * `true` to render potentially dangerous user content when rendering HTML
-   * with the option `rawHtml === true`
-   */
-  @Prop() readonly allowDangerousHtml: boolean = false;
+  // /**
+  //  * `true` to render potentially dangerous user content when rendering HTML
+  //  * with the option `rawHtml === true`
+  //  */
+  // @Prop() readonly allowDangerousHtml: boolean = false;
 
   /**
    * `true` to render raw HTML with sanitization.
    */
-  @Prop() readonly rawHtml: boolean = false;
+  @Prop() readonly rawHtml: boolean = true;
 
   /**
    * This property allows us to implement custom rendering for the code blocks.
@@ -56,7 +56,7 @@ export class ChMarkdown {
 
     this.#JSXTree = await markdownToJSX(this.value, {
       rawHTML: this.rawHtml,
-      allowDangerousHtml: this.allowDangerousHtml,
+      allowDangerousHtml: true, // Allow dangerous in this version
       renderCode: this.renderCode
     });
   }

--- a/src/components/markdown/parsers/markdown-to-jsx.tsx
+++ b/src/components/markdown/parsers/markdown-to-jsx.tsx
@@ -246,6 +246,11 @@ export const renderDictionary: {
   inlineCode: element => <code class="hljs">{element.value}</code>,
 
   link: async (element, metadata) => {
+    // Sanitize scripts
+    if (element.url.includes("javascript:")) {
+      return;
+    }
+
     const content = await mdASTtoJSX(element, metadata);
 
     return (
@@ -271,6 +276,11 @@ export const renderDictionary: {
 
     // TODO: It's unnecessary to set aria-label when referenceType === "shortcut"
     // TODO: The title is not supported well. See "An Example Putting the Parts Together" section in markdown.html
+
+    // Sanitize scripts
+    if (url.includes("javascript:")) {
+      return;
+    }
 
     return (
       <a

--- a/src/components/markdown/parsers/markdown-to-jsx.tsx
+++ b/src/components/markdown/parsers/markdown-to-jsx.tsx
@@ -227,12 +227,9 @@ export const renderDictionary: {
       HTMLToJSX = (await import("./raw-html-to-jsx")).rawHTMLToJSX;
     }
 
-    // // TESTTTTT
-    // if (metadata.rawHTML) {
-    //   console.log(HTMLToJSX(element.value, metadata.allowDangerousHtml));
-    // }
-
-    return metadata.rawHTML ? element.value : element.value;
+    return metadata.rawHTML
+      ? HTMLToJSX(element.value, metadata.allowDangerousHtml)
+      : element.value;
   },
 
   image: element => (

--- a/src/components/markdown/parsers/raw-html-to-jsx.tsx
+++ b/src/components/markdown/parsers/raw-html-to-jsx.tsx
@@ -3,6 +3,21 @@ import { fromHTMLStringToHast } from "@genexus/markdown-parser/dist/parse-html.j
 // import { Root, RootContent, RootContentMap } from "hast";
 import { Element as HElement, Root, RootContentMap } from "hast";
 
+const tagsToSanitize = new Set([
+  "base",
+  "embed",
+  "head",
+  "html",
+  "iframe",
+  "link",
+  "meta",
+  "object",
+  "script",
+  "style",
+  "svg",
+  "title"
+]);
+
 const renderDictionary: {
   [key in keyof RootContentMap]: (element: RootContentMap[key]) => any;
 } = {
@@ -12,8 +27,7 @@ const renderDictionary: {
 
     // Minimal sanitization
     if (
-      element.tagName === "script" ||
-      element.tagName === "iframe" ||
+      tagsToSanitize.has(element.tagName) ||
       (element.tagName === "a" &&
         (properties.href as string)?.includes("javascript:"))
     ) {

--- a/src/components/markdown/parsers/raw-html-to-jsx.tsx
+++ b/src/components/markdown/parsers/raw-html-to-jsx.tsx
@@ -5,6 +5,7 @@ import { Element as HElement, Root, RootContentMap } from "hast";
 
 const tagsToSanitize = new Set([
   "base",
+  "body",
   "embed",
   "head",
   "html",

--- a/src/components/markdown/parsers/raw-html-to-jsx.tsx
+++ b/src/components/markdown/parsers/raw-html-to-jsx.tsx
@@ -1,11 +1,56 @@
+import { h } from "@stencil/core";
 import { fromHTMLStringToHast } from "@genexus/markdown-parser/dist/parse-html.js";
+// import { Root, RootContent, RootContentMap } from "hast";
+import { Element as HElement, Root, RootContentMap } from "hast";
+
+const renderDictionary: {
+  [key in keyof RootContentMap]: (element: RootContentMap[key]) => any;
+} = {
+  comment: () => "",
+  element: element => {
+    const properties = element.properties;
+
+    // Minimal sanitization
+    if (
+      element.tagName === "script" ||
+      (element.tagName === "a" &&
+        (properties.href as string)?.includes("javascript:"))
+    ) {
+      return;
+    }
+
+    if (properties.className !== undefined) {
+      properties.class = (properties.className as string[]).join(" ");
+      delete properties.className;
+    }
+
+    if (properties.htmlFor) {
+      properties.for = properties.htmlFor;
+      delete properties.htmlFor;
+    }
+
+    return (
+      <element.tagName {...properties}>
+        {renderChildren(element)}
+      </element.tagName>
+    );
+  },
+  text: element => element.value,
+  doctype: () => ""
+};
+
+function renderChildren(element: Root | HElement) {
+  return element.children.map(child => renderDictionary[child.type](child));
+}
 
 export const rawHTMLToJSX = (
   htmlString: string,
   allowDangerousHtml: boolean
 ) => {
-  // eslint-disable-next-line no-console
-  console.log(
-    fromHTMLStringToHast(htmlString, allowDangerousHtml, { fragment: true })
-  );
+  const hast: Root = fromHTMLStringToHast(htmlString, allowDangerousHtml, {
+    fragment: true
+  });
+
+  // Render the hast as JSX
+  return renderChildren(hast);
 };

--- a/src/components/markdown/parsers/raw-html-to-jsx.tsx
+++ b/src/components/markdown/parsers/raw-html-to-jsx.tsx
@@ -13,6 +13,7 @@ const renderDictionary: {
     // Minimal sanitization
     if (
       element.tagName === "script" ||
+      element.tagName === "iframe" ||
       (element.tagName === "a" &&
         (properties.href as string)?.includes("javascript:"))
     ) {

--- a/src/components/markdown/readme.md
+++ b/src/components/markdown/readme.md
@@ -23,12 +23,11 @@ A control to render markdown syntax. It supports GitHub Flavored Markdown
 
 ## Properties
 
-| Property             | Attribute              | Description                                                                                                | Type                                          | Default             |
-| -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ------------------- |
-| `allowDangerousHtml` | `allow-dangerous-html` | `true` to render potentially dangerous user content when rendering HTML with the option `rawHtml === true` | `boolean`                                     | `false`             |
-| `rawHtml`            | `raw-html`             | `true` to render raw HTML with sanitization.                                                               | `boolean`                                     | `false`             |
-| `renderCode`         | --                     | This property allows us to implement custom rendering for the code blocks.                                 | `(options: MarkdownCodeRenderOptions) => any` | `defaultCodeRender` |
-| `value`              | `value`                | Specifies the markdown string to parse.                                                                    | `string`                                      | `undefined`         |
+| Property     | Attribute  | Description                                                                | Type                                          | Default             |
+| ------------ | ---------- | -------------------------------------------------------------------------- | --------------------------------------------- | ------------------- |
+| `rawHtml`    | `raw-html` | `true` to render raw HTML with sanitization.                               | `boolean`                                     | `true`              |
+| `renderCode` | --         | This property allows us to implement custom rendering for the code blocks. | `(options: MarkdownCodeRenderOptions) => any` | `defaultCodeRender` |
+| `value`      | `value`    | Specifies the markdown string to parse.                                    | `string`                                      | `undefined`         |
 
 
 ----------------------------------------------

--- a/src/showcase/pages/markdown.html
+++ b/src/showcase/pages/markdown.html
@@ -27,9 +27,7 @@
       }
 
       body {
-        display: grid;
-        grid-template-columns: 1fr;
-        gap: var(--spacing-un-spacing--l);
+        grid-template-rows: 1fr;
       }
 
       .card-markdown {
@@ -155,7 +153,7 @@
       }
     </style>
   </head>
-  <body class="white-label">
+  <body class="white-label unanimo">
     <div class="card card-markdown">
       <textarea class="form-input">
 Chameleon Markdown Parser


### PR DESCRIPTION
The following tags are not rendered when using HTML in the control (and having `rawHTML = true`):
  - `base`
  - `body`
  - `embed`
  - `head`
  - `html`
  - `iframe`
  - `link`
  - `meta`
  - `object`
  - `script`
  - `style`
  - `svg`
  - `title`
  - `a` tag with `"javascript:"` in its `href`