### PR TITLE
Fixes and improvements for `rawHTML` implementation in `ch-markdown`

### DIFF
--- a/src/components/markdown/parsers/raw-html-to-jsx.tsx
+++ b/src/components/markdown/parsers/raw-html-to-jsx.tsx
@@ -19,6 +19,31 @@ const tagsToSanitize = new Set([
   "title"
 ]);
 
+const LAST_SEMICOLON_AND_SPACES_IN_INLINE_STYLE = /\s*;\s*$/;
+const SEMICOLON_AND_SPACES = /\s*;\s*/;
+const COLON_AND_SPACES = /\s*:\s*/;
+
+const getStyleObjectFromString = (
+  inlineStyle: string
+): { [key in string]: string } => {
+  // Remove last " ;   "
+  const formattedStyle = inlineStyle.replace(
+    LAST_SEMICOLON_AND_SPACES_IN_INLINE_STYLE,
+    ""
+  );
+
+  // ["background-color: red", "color: black", ...]
+  const propertiesWithValues = formattedStyle.split(SEMICOLON_AND_SPACES);
+  const styleObject = {};
+
+  propertiesWithValues.forEach(propertyAndValue => {
+    const separatedPropertyAndValue = propertyAndValue.split(COLON_AND_SPACES);
+    styleObject[separatedPropertyAndValue[0]] = separatedPropertyAndValue[1];
+  });
+
+  return styleObject;
+};
+
 const renderDictionary: {
   [key in keyof RootContentMap]: (element: RootContentMap[key]) => any;
 } = {
@@ -33,6 +58,13 @@ const renderDictionary: {
         (properties.href as string)?.includes("javascript:"))
     ) {
       return;
+    }
+
+    // Parse style to an object
+    if (properties.style !== undefined) {
+      properties.style = getStyleObjectFromString(
+        properties.style as string
+      ) as any;
     }
 
     if (properties.className !== undefined) {

--- a/src/components/markdown/parsers/raw-html-to-jsx.tsx
+++ b/src/components/markdown/parsers/raw-html-to-jsx.tsx
@@ -60,6 +60,13 @@ const renderDictionary: {
       return;
     }
 
+    // Remove native attr listeners
+    for (const key in properties) {
+      if (key.startsWith("on")) {
+        delete properties[key];
+      }
+    }
+
     // Parse style to an object
     if (properties.style !== undefined) {
       properties.style = getStyleObjectFromString(


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Add support to render style attrs when using `rawHTML`.

 - Remove attributes that start with "on" to not attach listeners when using `rawHTML`.