### PR TITLE
In the `ch-combo-box`, use as the `min-inline-size` the size of the largest value and improve responsiveness

### DIFF
--- a/src/components/combobox/combo-box.scss
+++ b/src/components/combobox/combo-box.scss
@@ -101,6 +101,7 @@
   --ch-combo-box-mask-block-end-width: 0px;
 
   display: inline-grid;
+  grid-template-columns: 1fr max-content;
   align-items: center;
   position: relative;
 
@@ -125,6 +126,11 @@
 }
 
 :host(.ch-disabled) {
+  pointer-events: none;
+}
+
+.invisible-text {
+  visibility: hidden;
   pointer-events: none;
 }
 

--- a/src/showcase/assets/components/combo-box/combo-box.showcase.tsx
+++ b/src/showcase/assets/components/combo-box/combo-box.showcase.tsx
@@ -84,6 +84,10 @@ const render = () => (
         class="combo-box"
         disabled={state.disabled}
         destroyItemsOnClose={state.destroyItemsOnClose}
+        filter={state.filter}
+        filterDebounce={state.filterDebounce}
+        filterOptions={state.filterOptions}
+        filterType={state.filterType}
         model={
           state.filterOptions.alreadyProcessed === true &&
           state.filterType !== "none"
@@ -92,6 +96,7 @@ const render = () => (
         }
         readonly={state.readonly}
         value={state.value}
+        onFilterChange={handleFilterChange}
       ></ch-combo-box>
     </fieldset>
 
@@ -109,6 +114,10 @@ const render = () => (
           class="combo-box"
           disabled={state.disabled}
           destroyItemsOnClose={state.destroyItemsOnClose}
+          filter={state.filter}
+          filterDebounce={state.filterDebounce}
+          filterOptions={state.filterOptions}
+          filterType={state.filterType}
           model={
             state.filterOptions.alreadyProcessed === true &&
             state.filterType !== "none"
@@ -117,6 +126,7 @@ const render = () => (
           }
           readonly={state.readonly}
           value={state.value}
+          onFilterChange={handleFilterChange}
         ></ch-combo-box>
       </label>
     </fieldset>


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Use as the `min-inline-size` the size of the largest value

 - Find the best position alignment when using positionTry and content overflows the window