### PR TITLE
Add `ch-switch` control

### DIFF
--- a/src/common/reserverd-names.ts
+++ b/src/common/reserverd-names.ts
@@ -109,6 +109,22 @@ export const SEGMENTED_CONTROL_EXPORT_PARTS = joinParts(
 );
 
 // - - - - - - - - - - - - - - - - - - - -
+//              Switch Parts
+// - - - - - - - - - - - - - - - - - - - -
+export const SWITCH_PARTS_DICTIONARY = {
+  TRACK: "track",
+  THUMB: "thumb",
+  CAPTION: "caption",
+
+  // - - - - - - - - States - - - - - - - -
+  CHECKED: "checked",
+  DISABLED: "disabled",
+  UNCHECKED: "unchecked"
+} as const;
+
+export const SWITCH_EXPORT_PARTS = joinParts(SWITCH_PARTS_DICTIONARY);
+
+// - - - - - - - - - - - - - - - - - - - -
 //             Tree view Parts
 // - - - - - - - - - - - - - - - - - - - -
 const TREE_VIEW_ITEM_CHECKBOX_TRANSFORMED_PARTS_DICTIONARY = {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1858,6 +1858,44 @@ export namespace Components {
          */
         "value": any;
     }
+    /**
+     * @status experimental
+     * A switch/toggle control that enables you to select between options.
+     */
+    interface ChSwitch {
+        /**
+          * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
+         */
+        "accessibleName"?: string;
+        /**
+          * Caption displayed when the switch is 'on'
+         */
+        "checkedCaption": string;
+        /**
+          * The value when the switch is 'on'
+         */
+        "checkedValue": string;
+        /**
+          * This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).
+         */
+        "disabled": boolean;
+        /**
+          * This property specifies the `name` of the control when used in a form.
+         */
+        "name"?: string;
+        /**
+          * Caption displayed when the switch is 'off'
+         */
+        "unCheckedCaption": string;
+        /**
+          * The value when the switch is 'off'. If you want to not add the value when the control is used in a form and it's unchecked, just let this property with the default `undefined` value.
+         */
+        "unCheckedValue": string;
+        /**
+          * The value of the control.
+         */
+        "value": string;
+    }
     interface ChTabRender {
         /**
           * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
@@ -2732,6 +2770,10 @@ export interface ChSuggestCustomEvent<T> extends CustomEvent<T> {
 export interface ChSuggestListItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChSuggestListItemElement;
+}
+export interface ChSwitchCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLChSwitchElement;
 }
 export interface ChTabRenderCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -3737,6 +3779,27 @@ declare global {
         prototype: HTMLChSuggestListItemElement;
         new (): HTMLChSuggestListItemElement;
     };
+    interface HTMLChSwitchElementEventMap {
+        "input": any;
+    }
+    /**
+     * @status experimental
+     * A switch/toggle control that enables you to select between options.
+     */
+    interface HTMLChSwitchElement extends Components.ChSwitch, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLChSwitchElementEventMap>(type: K, listener: (this: HTMLChSwitchElement, ev: ChSwitchCustomEvent<HTMLChSwitchElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLChSwitchElementEventMap>(type: K, listener: (this: HTMLChSwitchElement, ev: ChSwitchCustomEvent<HTMLChSwitchElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLChSwitchElement: {
+        prototype: HTMLChSwitchElement;
+        new (): HTMLChSwitchElement;
+    };
     interface HTMLChTabRenderElementEventMap {
         "expandMainGroup": string;
         "itemClose": TabItemCloseInfo;
@@ -4039,6 +4102,7 @@ declare global {
         "ch-suggest": HTMLChSuggestElement;
         "ch-suggest-list": HTMLChSuggestListElement;
         "ch-suggest-list-item": HTMLChSuggestListItemElement;
+        "ch-switch": HTMLChSwitchElement;
         "ch-tab-render": HTMLChTabRenderElement;
         "ch-test-flexible-layout": HTMLChTestFlexibleLayoutElement;
         "ch-test-suggest": HTMLChTestSuggestElement;
@@ -5933,6 +5997,48 @@ declare namespace LocalJSX {
          */
         "value"?: any;
     }
+    /**
+     * @status experimental
+     * A switch/toggle control that enables you to select between options.
+     */
+    interface ChSwitch {
+        /**
+          * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
+         */
+        "accessibleName"?: string;
+        /**
+          * Caption displayed when the switch is 'on'
+         */
+        "checkedCaption"?: string;
+        /**
+          * The value when the switch is 'on'
+         */
+        "checkedValue": string;
+        /**
+          * This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).
+         */
+        "disabled"?: boolean;
+        /**
+          * This property specifies the `name` of the control when used in a form.
+         */
+        "name"?: string;
+        /**
+          * The 'input' event is emitted when a change to the element's value is committed by the user.
+         */
+        "onInput"?: (event: ChSwitchCustomEvent<any>) => void;
+        /**
+          * Caption displayed when the switch is 'off'
+         */
+        "unCheckedCaption"?: string;
+        /**
+          * The value when the switch is 'off'. If you want to not add the value when the control is used in a form and it's unchecked, just let this property with the default `undefined` value.
+         */
+        "unCheckedValue"?: string;
+        /**
+          * The value of the control.
+         */
+        "value"?: string;
+    }
     interface ChTabRender {
         /**
           * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
@@ -6717,6 +6823,7 @@ declare namespace LocalJSX {
         "ch-suggest": ChSuggest;
         "ch-suggest-list": ChSuggestList;
         "ch-suggest-list-item": ChSuggestListItem;
+        "ch-switch": ChSwitch;
         "ch-tab-render": ChTabRender;
         "ch-test-flexible-layout": ChTestFlexibleLayout;
         "ch-test-suggest": ChTestSuggest;
@@ -6910,6 +7017,11 @@ declare module "@stencil/core" {
             "ch-suggest": LocalJSX.ChSuggest & JSXBase.HTMLAttributes<HTMLChSuggestElement>;
             "ch-suggest-list": LocalJSX.ChSuggestList & JSXBase.HTMLAttributes<HTMLChSuggestListElement>;
             "ch-suggest-list-item": LocalJSX.ChSuggestListItem & JSXBase.HTMLAttributes<HTMLChSuggestListItemElement>;
+            /**
+             * @status experimental
+             * A switch/toggle control that enables you to select between options.
+             */
+            "ch-switch": LocalJSX.ChSwitch & JSXBase.HTMLAttributes<HTMLChSwitchElement>;
             "ch-tab-render": LocalJSX.ChTabRender & JSXBase.HTMLAttributes<HTMLChTabRenderElement>;
             "ch-test-flexible-layout": LocalJSX.ChTestFlexibleLayout & JSXBase.HTMLAttributes<HTMLChTestFlexibleLayoutElement>;
             "ch-test-suggest": LocalJSX.ChTestSuggest & JSXBase.HTMLAttributes<HTMLChTestSuggestElement>;

--- a/src/components/switch/readme.md
+++ b/src/components/switch/readme.md
@@ -1,0 +1,70 @@
+# ch-switch
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property                    | Attribute            | Description                                                                                                                                                                            | Type      | Default     |
+| --------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `accessibleName`            | `accessible-name`    | Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.                      | `string`  | `undefined` |
+| `checkedCaption`            | `checked-caption`    | Caption displayed when the switch is 'on'                                                                                                                                              | `string`  | `undefined` |
+| `checkedValue` _(required)_ | `checked-value`      | The value when the switch is 'on'                                                                                                                                                      | `string`  | `undefined` |
+| `disabled`                  | `disabled`           | This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).                          | `boolean` | `false`     |
+| `name`                      | `name`               | This property specifies the `name` of the control when used in a form.                                                                                                                 | `string`  | `undefined` |
+| `unCheckedCaption`          | `un-checked-caption` | Caption displayed when the switch is 'off'                                                                                                                                             | `string`  | `undefined` |
+| `unCheckedValue`            | `un-checked-value`   | The value when the switch is 'off'. If you want to not add the value when the control is used in a form and it's unchecked, just let this property with the default `undefined` value. | `string`  | `undefined` |
+| `value`                     | `value`              | The value of the control.                                                                                                                                                              | `string`  | `null`      |
+
+
+## Events
+
+| Event   | Description                                                                                 | Type               |
+| ------- | ------------------------------------------------------------------------------------------- | ------------------ |
+| `input` | The 'input' event is emitted when a change to the element's value is committed by the user. | `CustomEvent<any>` |
+
+
+## Shadow Parts
+
+| Part          | Description                                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `"caption"`   | The caption (checked or unchecked) of the switch element.                                                         |
+| `"checked"`   | Present in the `track`, `thumb` and `caption` parts when the control is checked (`value` === `checkedValue`).     |
+| `"disabled"`  | Present in the `track`, `thumb` and `caption` parts when the control is disabled (`disabled` === `true`).         |
+| `"thumb"`     | The thumb of the switch element.                                                                                  |
+| `"track"`     | The track of the switch element.                                                                                  |
+| `"unchecked"` | Present in the `track`, `thumb` and `caption` parts when the control is unchecked (`value` === `unCheckedValue`). |
+
+
+## CSS Custom Properties
+
+| Name                                            | Description                                                                                                                       |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `--ch-switch-thumb-size`                        | Specifies the size of the thumb. @default clamp(8px, 1em, 24px)                                                                   |
+| `--ch-switch-thumb__checked-background-color`   | Specifies the background color of the thumb when the control is unchecked. @default currentColor                                  |
+| `--ch-switch-thumb__state-transition-duration`  | Specifies the transition duration of the thumb when switching between states. @default 0ms                                        |
+| `--ch-switch-thumb__unchecked-background-color` | Specifies the background color of the thumb when the control is unchecked. @default #b2b2b2                                       |
+| `--ch-switch-track-block-size`                  | Specifies the block size of the track. @default clamp(3px, 0.5em, 16px)                                                           |
+| `--ch-switch-track-inline-size`                 | Specifies the inline size of the track. @default clamp(3px, 0.5em, 16px)                                                          |
+| `--ch-switch-track__checked-background-color`   | Specifies the background color of the track when the control is checked. @default color-mix(in srgb, currentColor 35%, #b2b2b2)   |
+| `--ch-switch-track__unchecked-background-color` | Specifies the background color of the track when the control is unchecked. @default color-mix(in srgb, currentColor 35%, #b2b2b2) |
+
+
+## Dependencies
+
+### Used by
+
+ - [ch-showcase](../../showcase/assets/components)
+
+### Graph
+```mermaid
+graph TD;
+  ch-showcase --> ch-switch
+  style ch-switch fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -1,0 +1,152 @@
+@import "../../common/_base";
+
+@include box-sizing();
+
+$slider-border-radius: min(0.25em, 5px);
+
+:host {
+  /**
+   * @prop --ch-switch-thumb-size:
+   * Specifies the size of the thumb. 
+   * @default clamp(8px, 1em, 24px)
+   */
+  --ch-switch-thumb-size: clamp(8px, 1em, 24px);
+
+  /**
+   * @prop --ch-switch-track-block-size:
+   * Specifies the block size of the track. 
+   * @default clamp(3px, 0.5em, 16px)
+   */
+  --ch-switch-track-block-size: clamp(3px, 0.5em, 16px);
+
+  /**
+   * @prop --ch-switch-track-inline-size:
+   * Specifies the inline size of the track. 
+   * @default clamp(3px, 0.5em, 16px)
+   */
+  --ch-switch-track-inline-size: clamp(3px, 2em, 40px);
+
+  --ch-switch-track__on-background-color: color-mix(
+    in srgb,
+    currentColor 35%,
+    #b2b2b2
+  );
+  --ch-switch-track__off-background-color: color-mix(
+    in srgb,
+    currentColor 35%,
+    #b2b2b2
+  );
+
+  --ch-switch-thumb__on-background-color: currentColor;
+  --ch-switch-thumb__off-background-color: #b2b2b2;
+
+  --ch-switch-thumb__state-transition-duration: 0ms;
+
+  display: inline-grid;
+
+  // Remove outline of the focus state. This selector must not have higher
+  // specificity, since it should be overridden by the class applied to the control
+  // outline: unset;
+
+  // Avoid zooming on double tap
+  touch-action: manipulation;
+
+  // Remove text selection on double click
+  user-select: none;
+
+  pointer-events: none;
+}
+
+// Necessary to implement to focus delegation to the input when clicking on
+// external labels
+:host(:not(.ch-disabled)) .wrapper-for-click-event {
+  pointer-events: all;
+}
+
+.wrapper-for-click-event {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  align-items: center;
+  max-inline-size: max-content;
+  cursor: pointer;
+}
+
+// - - - - - - - - - - - - - - - -
+//              Track
+// - - - - - - - - - - - - - - - -
+.track {
+  display: inline-grid;
+  position: relative;
+  align-items: center;
+  inline-size: var(--ch-switch-track-inline-size);
+  block-size: var(--ch-switch-track-block-size);
+
+  background-color: var(--ch-switch-track__off-background-color);
+  border-radius: $slider-border-radius;
+
+  // Switch slider has more priority to display in the width if there is
+  // not enough space to display switch and label at the same time
+  min-inline-size: var(--ch-switch-track-inline-size);
+  pointer-events: none;
+
+  &--checked {
+    background-color: var(--ch-switch-track__on-background-color);
+  }
+}
+
+// - - - - - - - - - - - - - - - -
+//              Thumb
+// - - - - - - - - - - - - - - - -
+.thumb {
+  display: flex;
+  position: absolute;
+  background-color: var(--ch-switch-thumb__off-background-color);
+  border-radius: 50%;
+  inline-size: var(--ch-switch-thumb-size);
+  block-size: var(--ch-switch-thumb-size);
+  inset-inline-start: 0px;
+
+  pointer-events: none;
+  transition: inset linear var(--ch-switch-thumb__state-transition-duration);
+
+  &--checked {
+    background-color: var(--ch-switch-thumb__on-background-color);
+
+    // We move the circle using margin-inline-start to support RTL
+    inset-inline-start: calc(100% - var(--ch-switch-thumb-size));
+  }
+}
+
+// We "hide" the input, but not its area to help accessibility readers
+input {
+  // Reset browser defaults
+  appearance: none;
+  margin: 0;
+  outline: unset;
+  font: unset; // Necessary to inherit the font-size and place the correct inline-size
+
+  display: flex;
+  position: absolute;
+  background-color: var(--ch-switch-thumb__off-background-color);
+  border-radius: 50%;
+  inline-size: var(--ch-switch-thumb-size);
+  block-size: var(--ch-switch-thumb-size);
+  inset-inline-start: 0px;
+  pointer-events: none;
+  transition: inset linear var(--ch-switch-thumb__state-transition-duration);
+
+  &--checked {
+    background-color: var(--ch-switch-thumb__on-background-color);
+
+    // We move the circle using margin-inline-start to support RTL
+    inset-inline-start: calc(100% - var(--ch-switch-thumb-size));
+  }
+}
+
+// - - - - - - - - - - - - - - - -
+//             Caption
+// - - - - - - - - - - - - - - - -
+.caption {
+  cursor: pointer;
+}

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -92,6 +92,7 @@
   grid-auto-flow: column;
   grid-auto-columns: max-content;
   align-items: center;
+  min-block-size: var(--ch-switch-thumb-size);
   max-inline-size: max-content;
   cursor: pointer;
 }

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -2,15 +2,35 @@
 
 @include box-sizing();
 
-$slider-border-radius: min(0.25em, 5px);
-
 :host {
+  /**
+   * @prop --ch-switch-thumb__checked-background-color:
+   * Specifies the background color of the thumb when the control is unchecked. 
+   * @default currentColor
+   */
+  --ch-switch-thumb__checked-background-color: currentColor;
+
+  /**
+    * @prop --ch-switch-thumb__unchecked-background-color:
+    * Specifies the background color of the thumb when the control is unchecked. 
+    * @default #b2b2b2
+    */
+  --ch-switch-thumb__unchecked-background-color: #b2b2b2;
+
   /**
    * @prop --ch-switch-thumb-size:
    * Specifies the size of the thumb. 
    * @default clamp(8px, 1em, 24px)
    */
   --ch-switch-thumb-size: clamp(8px, 1em, 24px);
+
+  /**
+    * @prop --ch-switch-thumb__state-transition-duration:
+    * Specifies the transition duration of the thumb when switching between
+    * states.
+    * @default 0ms
+    */
+  --ch-switch-thumb__state-transition-duration: 0ms;
 
   /**
    * @prop --ch-switch-track-block-size:
@@ -26,27 +46,29 @@ $slider-border-radius: min(0.25em, 5px);
    */
   --ch-switch-track-inline-size: clamp(3px, 2em, 40px);
 
-  --ch-switch-track__on-background-color: color-mix(
-    in srgb,
-    currentColor 35%,
-    #b2b2b2
-  );
-  --ch-switch-track__off-background-color: color-mix(
+  /**
+   * @prop --ch-switch-track__checked-background-color:
+   * Specifies the background color of the track when the control is checked. 
+   * @default color-mix(in srgb, currentColor 35%, #b2b2b2)
+   */
+  --ch-switch-track__checked-background-color: color-mix(
     in srgb,
     currentColor 35%,
     #b2b2b2
   );
 
-  --ch-switch-thumb__on-background-color: currentColor;
-  --ch-switch-thumb__off-background-color: #b2b2b2;
-
-  --ch-switch-thumb__state-transition-duration: 0ms;
+  /**
+   * @prop --ch-switch-track__unchecked-background-color:
+   * Specifies the background color of the track when the control is unchecked. 
+   * @default color-mix(in srgb, currentColor 35%, #b2b2b2)
+   */
+  --ch-switch-track__unchecked-background-color: color-mix(
+    in srgb,
+    currentColor 35%,
+    #b2b2b2
+  );
 
   display: inline-grid;
-
-  // Remove outline of the focus state. This selector must not have higher
-  // specificity, since it should be overridden by the class applied to the control
-  // outline: unset;
 
   // Avoid zooming on double tap
   touch-action: manipulation;
@@ -54,6 +76,8 @@ $slider-border-radius: min(0.25em, 5px);
   // Remove text selection on double click
   user-select: none;
 
+  // Necessary to implement to focus delegation to the input when clicking on
+  // external labels
   pointer-events: none;
 }
 
@@ -82,8 +106,8 @@ $slider-border-radius: min(0.25em, 5px);
   inline-size: var(--ch-switch-track-inline-size);
   block-size: var(--ch-switch-track-block-size);
 
-  background-color: var(--ch-switch-track__off-background-color);
-  border-radius: $slider-border-radius;
+  background-color: var(--ch-switch-track__unchecked-background-color);
+  border-radius: calc(var(--ch-switch-track-block-size) / 2);
 
   // Switch slider has more priority to display in the width if there is
   // not enough space to display switch and label at the same time
@@ -91,7 +115,7 @@ $slider-border-radius: min(0.25em, 5px);
   pointer-events: none;
 
   &--checked {
-    background-color: var(--ch-switch-track__on-background-color);
+    background-color: var(--ch-switch-track__checked-background-color);
   }
 }
 
@@ -101,7 +125,7 @@ $slider-border-radius: min(0.25em, 5px);
 .thumb {
   display: flex;
   position: absolute;
-  background-color: var(--ch-switch-thumb__off-background-color);
+  background-color: var(--ch-switch-thumb__unchecked-background-color);
   border-radius: 50%;
   inline-size: var(--ch-switch-thumb-size);
   block-size: var(--ch-switch-thumb-size);
@@ -111,7 +135,7 @@ $slider-border-radius: min(0.25em, 5px);
   transition: inset linear var(--ch-switch-thumb__state-transition-duration);
 
   &--checked {
-    background-color: var(--ch-switch-thumb__on-background-color);
+    background-color: var(--ch-switch-thumb__checked-background-color);
 
     // We move the circle using margin-inline-start to support RTL
     inset-inline-start: calc(100% - var(--ch-switch-thumb-size));
@@ -128,7 +152,7 @@ input {
 
   display: flex;
   position: absolute;
-  background-color: var(--ch-switch-thumb__off-background-color);
+  background-color: var(--ch-switch-thumb__unchecked-background-color);
   border-radius: 50%;
   inline-size: var(--ch-switch-thumb-size);
   block-size: var(--ch-switch-thumb-size);
@@ -137,7 +161,7 @@ input {
   transition: inset linear var(--ch-switch-thumb__state-transition-duration);
 
   &--checked {
-    background-color: var(--ch-switch-thumb__on-background-color);
+    background-color: var(--ch-switch-thumb__checked-background-color);
 
     // We move the circle using margin-inline-start to support RTL
     inset-inline-start: calc(100% - var(--ch-switch-thumb-size));

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -10,13 +10,24 @@ import {
   h
 } from "@stencil/core";
 import { AccessibleNameComponent } from "../../common/interfaces";
-import { DISABLED_CLASS } from "../../common/reserverd-names";
+import {
+  DISABLED_CLASS,
+  SWITCH_PARTS_DICTIONARY
+} from "../../common/reserverd-names";
 import { tokenMap } from "../../common/utils";
 
 /**
  * @status experimental
  *
  * A switch/toggle control that enables you to select between options.
+ *
+ * @part track - The track of the switch element.
+ * @part thumb - The thumb of the switch element.
+ * @part caption - The caption (checked or unchecked) of the switch element.
+ *
+ * @part checked - Present in the `track`, `thumb` and `caption` parts when the control is checked (`value` === `checkedValue`).
+ * @part disabled - Present in the `track`, `thumb` and `caption` parts when the control is disabled (`disabled` === `true`).
+ * @part unchecked - Present in the `track`, `thumb` and `caption` parts when the control is unchecked (`value` === `unCheckedValue`).
  */
 @Component({
   formAssociated: true,
@@ -136,10 +147,10 @@ export class ChSwitch implements AccessibleNameComponent {
           <div
             class={{ track: true, "track--checked": checked }}
             part={tokenMap({
-              track: true,
-              disabled: this.disabled,
-              checked: checked,
-              unchecked: !checked
+              [SWITCH_PARTS_DICTIONARY.TRACK]: true,
+              [SWITCH_PARTS_DICTIONARY.DISABLED]: this.disabled,
+              [SWITCH_PARTS_DICTIONARY.CHECKED]: checked,
+              [SWITCH_PARTS_DICTIONARY.UNCHECKED]: !checked
             })}
           >
             <input
@@ -150,10 +161,10 @@ export class ChSwitch implements AccessibleNameComponent {
               }
               class={{ thumb: true, "thumb--checked": checked }}
               part={tokenMap({
-                thumb: true,
-                disabled: this.disabled,
-                checked: checked,
-                unchecked: !checked
+                [SWITCH_PARTS_DICTIONARY.THUMB]: true,
+                [SWITCH_PARTS_DICTIONARY.DISABLED]: this.disabled,
+                [SWITCH_PARTS_DICTIONARY.CHECKED]: checked,
+                [SWITCH_PARTS_DICTIONARY.UNCHECKED]: !checked
               })}
               checked={checked}
               disabled={this.disabled}
@@ -169,7 +180,12 @@ export class ChSwitch implements AccessibleNameComponent {
             // switch has the aria-valuetext attribute
             aria-hidden="true"
             class="caption"
-            part="caption"
+            part={tokenMap({
+              [SWITCH_PARTS_DICTIONARY.CAPTION]: true,
+              [SWITCH_PARTS_DICTIONARY.DISABLED]: this.disabled,
+              [SWITCH_PARTS_DICTIONARY.CHECKED]: checked,
+              [SWITCH_PARTS_DICTIONARY.UNCHECKED]: !checked
+            })}
           >
             {checked ? this.checkedCaption : this.unCheckedCaption}
           </span>

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -1,0 +1,180 @@
+import {
+  AttachInternals,
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Host,
+  Prop,
+  Watch,
+  h
+} from "@stencil/core";
+import { AccessibleNameComponent } from "../../common/interfaces";
+import { DISABLED_CLASS } from "../../common/reserverd-names";
+import { tokenMap } from "../../common/utils";
+
+/**
+ * @status experimental
+ *
+ * A switch/toggle control that enables you to select between options.
+ */
+@Component({
+  formAssociated: true,
+  shadow: { delegatesFocus: true },
+  styleUrl: "switch.scss",
+  tag: "ch-switch"
+})
+export class ChSwitch implements AccessibleNameComponent {
+  #accessibleNameFromExternalLabel: string | undefined;
+  #inputRef: HTMLInputElement;
+
+  @AttachInternals() internals: ElementInternals;
+
+  @Element() el: HTMLChSwitchElement;
+
+  /**
+   * Specifies a short string, typically 1 to 3 words, that authors associate
+   * with an element to provide users of assistive technologies with a label
+   * for the element.
+   */
+  @Prop() readonly accessibleName?: string;
+
+  /**
+   * Caption displayed when the switch is 'on'
+   */
+  @Prop() readonly checkedCaption: string;
+
+  /**
+   * The value when the switch is 'on'
+   */
+  @Prop() readonly checkedValue!: string;
+
+  /**
+   * This attribute allows you specify if the element is disabled.
+   * If disabled, it will not trigger any user interaction related event
+   * (for example, click event).
+   */
+  @Prop() readonly disabled: boolean = false;
+
+  /**
+   * This property specifies the `name` of the control when used in a form.
+   */
+  @Prop({ reflect: true }) readonly name?: string;
+
+  /**
+   * Caption displayed when the switch is 'off'
+   */
+  @Prop() readonly unCheckedCaption: string;
+
+  /**
+   * The value when the switch is 'off'. If you want to not add the value when
+   * the control is used in a form and it's unchecked, just let this property
+   * with the default `undefined` value.
+   */
+  @Prop() readonly unCheckedValue: string = undefined;
+
+  /**
+   * The value of the control.
+   */
+  @Prop({ mutable: true }) value: string = null;
+  @Watch("value")
+  handleValueChange(newValue: number) {
+    // Update form value
+    this.internals.setFormValue(newValue?.toString());
+  }
+
+  /**
+   * The 'input' event is emitted when a change to the element's value is committed by the user.
+   */
+  @Event() input: EventEmitter;
+
+  #handleInput = (event: UIEvent) => {
+    event.stopPropagation();
+    const checked = (event.target as HTMLInputElement).checked;
+
+    // Toggle the value property
+    this.value = checked ? this.checkedValue : this.unCheckedValue;
+
+    this.input.emit(event);
+  };
+
+  #handleClickChange = () => {
+    this.#inputRef.click();
+  };
+
+  #stopClickPropagation = (event: MouseEvent) => {
+    event.stopPropagation();
+  };
+
+  connectedCallback() {
+    // Set initial value to unchecked if empty
+    this.value ||= this.unCheckedValue;
+
+    // Set form value
+    this.internals.setFormValue(this.value?.toString());
+
+    const labels = this.internals.labels;
+
+    // Get external aria-label
+    if (!this.accessibleName && labels?.length > 0) {
+      this.#accessibleNameFromExternalLabel = labels[0].textContent.trim();
+    }
+  }
+
+  render() {
+    const checked = this.value === this.checkedValue;
+
+    return (
+      <Host
+        class={this.disabled ? DISABLED_CLASS : null}
+        onClick={!this.disabled ? this.#handleClickChange : null}
+      >
+        <label
+          class="wrapper-for-click-event"
+          onClick={!this.disabled ? this.#stopClickPropagation : null}
+        >
+          <div
+            class={{ track: true, "track--checked": checked }}
+            part={tokenMap({
+              track: true,
+              disabled: this.disabled,
+              checked: checked,
+              unchecked: !checked
+            })}
+          >
+            <input
+              role="switch"
+              aria-checked={checked ? "true" : "false"}
+              aria-label={
+                this.accessibleName ?? this.#accessibleNameFromExternalLabel
+              }
+              class={{ thumb: true, "thumb--checked": checked }}
+              part={tokenMap({
+                thumb: true,
+                disabled: this.disabled,
+                checked: checked,
+                unchecked: !checked
+              })}
+              checked={checked}
+              disabled={this.disabled}
+              type="checkbox"
+              value={checked ? this.checkedValue : this.unCheckedValue}
+              onInput={!this.disabled ? this.#handleInput : null}
+              ref={el => (this.#inputRef = el)}
+            />
+          </div>
+
+          <span
+            // The values are hidden from the accessibility tree, because the
+            // switch has the aria-valuetext attribute
+            aria-hidden="true"
+            class="caption"
+            part="caption"
+          >
+            {checked ? this.checkedCaption : this.unCheckedCaption}
+          </span>
+        </label>
+      </Host>
+    );
+  }
+}

--- a/src/components/switch/test/switch.e2e.ts
+++ b/src/components/switch/test/switch.e2e.ts
@@ -1,0 +1,32 @@
+// import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+
+describe.skip("[ch-switch]", () => {
+  // let element: E2EElement;
+  // let page: E2EPage;
+  // beforeEach(async () => {
+  //   page = await newE2EPage();
+  //   await page.setContent("<ch-switch id='id0'>TEST TEXT</ch-switch>");
+  //   element = await page.find("ch-switch");
+  // });
+  // it("should work without parameters", () => {
+  //   expect(element.textContent.trim()).toEqual("TEST TEXT");
+  // });
+  // it("should set label caption", async () => {
+  //   await element.setProperty("caption", "TEST TEXT0");
+  //   await page.waitForChanges();
+  //   const label = await page.find("label");
+  //   expect(label.textContent.trim()).toEqual("TEST TEXT0");
+  // });
+  // it("should detect if it's checked", async () => {
+  //   await element.setProperty("checked", true);
+  //   await page.waitForChanges();
+  //   const input = await page.find("input");
+  //   expect(await input.getProperty("checked")).toEqual(true);
+  // });
+  // it("should detect if it's disabled", async () => {
+  //   await element.setProperty("disabled", true);
+  //   await page.waitForChanges();
+  //   const input = await page.find("input");
+  //   expect(await input.getProperty("disabled")).toEqual(true);
+  // });
+});

--- a/src/showcase/assets/components/readme.md
+++ b/src/showcase/assets/components/readme.md
@@ -29,6 +29,7 @@
 - [ch-layout-splitter](../../../components/layout-splitter)
 - [ch-qr](../../../components/qr)
 - [ch-slider](../../../components/slider)
+- [ch-switch](../../../components/switch)
 - [ch-tab-render](../../../components/tab)
 - [ch-tree-view-render](../../../components/tree-view)
 
@@ -43,6 +44,7 @@ graph TD;
   ch-showcase --> ch-layout-splitter
   ch-showcase --> ch-qr
   ch-showcase --> ch-slider
+  ch-showcase --> ch-switch
   ch-showcase --> ch-tab-render
   ch-showcase --> ch-tree-view-render
   ch-flexible-layout-render --> ch-flexible-layout

--- a/src/showcase/assets/components/showcase-stories.ts
+++ b/src/showcase/assets/components/showcase-stories.ts
@@ -4,6 +4,7 @@ import { dropdownShowcaseStory } from "./dropdown/dropdown.showcase";
 import { layoutSplitterShowcaseStory } from "./layout-splitter/layout-splitter.showcase";
 import { qrShowcaseStory } from "./qr/qr.showcase";
 import { sliderShowcaseStory } from "./slider/slider.showcase";
+import { switchShowcaseStory } from "./switch/switch.showcase";
 import { tabShowcaseStory } from "./tab/tab.showcase";
 import { treeViewShowcaseStory } from "./tree-view/tree-view.showcase";
 
@@ -14,6 +15,7 @@ export const showcaseStories = {
   "layout-splitter": layoutSplitterShowcaseStory,
   qr: qrShowcaseStory,
   slider: sliderShowcaseStory,
+  switch: switchShowcaseStory,
   tab: tabShowcaseStory,
   "tree-view-in-development": treeViewShowcaseStory
 } as const;

--- a/src/showcase/assets/components/showcase.tsx
+++ b/src/showcase/assets/components/showcase.tsx
@@ -572,7 +572,7 @@ export class ChShowcase {
           aria-label={property.accessibleName ?? null}
           class="form-input"
           type="text"
-          value={property.value.toString()}
+          value={property.value?.toString()}
           onInput={this.#showcaseStoryInput.get(propertyGroupId)}
         />
       ]);
@@ -601,7 +601,7 @@ export class ChShowcase {
           aria-label={property.accessibleName ?? null}
           class="form-input"
           type="number"
-          value={property.value.toString()}
+          value={property.value?.toString()}
           onInput={this.#showcaseStoryInputNumber.get(propertyGroupId)}
         />
       ]);

--- a/src/showcase/assets/components/switch/switch.showcase.tsx
+++ b/src/showcase/assets/components/switch/switch.showcase.tsx
@@ -1,0 +1,159 @@
+import { forceUpdate, h } from "@stencil/core";
+import { ChSwitch } from "../../../../components/switch/switch";
+import { ShowcaseRenderProperties, ShowcaseStory } from "../types";
+import { Mutable } from "../../../../common/types";
+
+const state: Partial<Mutable<ChSwitch>> = {};
+const formRefs: {
+  [key in "form-switch-1" | "form-switch-2" | "form-switch-3"]:
+    | HTMLFormElement
+    | undefined;
+} = {
+  "form-switch-1": undefined,
+  "form-switch-2": undefined,
+  "form-switch-3": undefined
+};
+
+const formValues = {
+  "switch-1": "",
+  "switch-2": "",
+  "switch-3": ""
+};
+
+const handleValueInput =
+  (formId: keyof typeof formRefs, switchId: keyof typeof formValues) => () => {
+    formValues[switchId] = Object.fromEntries(new FormData(formRefs[formId]))[
+      switchId
+    ] as string;
+
+    // TODO: Until we support external slots in the ch-flexible-layout-render,
+    // this is a hack to update the render of the widget and thus re-render the
+    // combo-box updating the displayed items
+    const showcaseRef = formRefs[formId].closest("ch-showcase");
+
+    if (showcaseRef) {
+      forceUpdate(showcaseRef);
+    }
+  };
+
+const render = () => (
+  <div class="checkbox-test-main-wrapper">
+    <fieldset>
+      <legend class="heading-4 field-legend-test">No label</legend>
+      <form id="form-switch-1" ref={el => (formRefs["form-switch-1"] = el)}>
+        <ch-switch
+          name="switch-1"
+          accessibleName={state.accessibleName}
+          class="switch"
+          checkedValue={state.checkedValue}
+          unCheckedValue={state.unCheckedValue}
+          checkedCaption={state.checkedCaption}
+          unCheckedCaption={state.unCheckedCaption}
+          disabled={state.disabled}
+          value={state.value}
+          onInput={handleValueInput("form-switch-1", "switch-1")}
+        ></ch-switch>
+      </form>
+      Form value: {formValues["switch-1"]}
+    </fieldset>
+
+    <fieldset>
+      <legend class="heading-4 field-legend-test">Label with HTML for</legend>
+      <form id="form-switch-2" ref={el => (formRefs["form-switch-2"] = el)}>
+        <label class="form-input__label" htmlFor="switch-2">
+          Label for switch 2
+        </label>
+
+        <ch-switch
+          id="switch-2"
+          name="switch-2"
+          accessibleName={state.accessibleName}
+          class="switch"
+          checkedValue={state.checkedValue}
+          unCheckedValue={state.unCheckedValue}
+          checkedCaption={state.checkedCaption}
+          unCheckedCaption={state.unCheckedCaption}
+          disabled={state.disabled}
+          value={state.value}
+          onInput={handleValueInput("form-switch-2", "switch-2")}
+        ></ch-switch>
+      </form>
+      Form value: {formValues["switch-2"]}
+    </fieldset>
+
+    <fieldset>
+      <legend class="heading-4 field-legend-test">
+        Component inside label
+      </legend>
+      <form id="form-switch-3" ref={el => (formRefs["form-switch-3"] = el)}>
+        <label class="form-input__label" htmlFor="switch-3">
+          Label for switch 3
+          <ch-switch
+            id="switch-3"
+            name="switch-3"
+            accessibleName={state.accessibleName}
+            class="switch"
+            checkedValue={state.checkedValue}
+            unCheckedValue={state.unCheckedValue}
+            checkedCaption={state.checkedCaption}
+            unCheckedCaption={state.unCheckedCaption}
+            disabled={state.disabled}
+            value={state.value}
+            onInput={handleValueInput("form-switch-3", "switch-3")}
+          ></ch-switch>
+        </label>
+      </form>
+      Form value: {formValues["switch-3"]}
+    </fieldset>
+  </div>
+);
+
+const showcaseRenderProperties: ShowcaseRenderProperties<Mutable<ChSwitch>> = [
+  {
+    caption: "Properties",
+    properties: [
+      {
+        id: "accessibleName",
+        caption: "Accessible Name",
+        value: undefined,
+        type: "string"
+      },
+      {
+        id: "checkedValue",
+        caption: "Checked Value",
+        value: "true",
+        type: "string"
+      },
+      {
+        id: "unCheckedValue",
+        caption: "Unchecked Value",
+        value: undefined,
+        type: "string"
+      },
+      {
+        id: "checkedCaption",
+        caption: "Checked Caption",
+        value: "Checked caption",
+        type: "string"
+      },
+      {
+        id: "unCheckedCaption",
+        caption: "Unchecked Caption",
+        value: "Unchecked caption",
+        type: "string"
+      },
+      {
+        id: "disabled",
+        caption: "Disabled",
+        value: false,
+        type: "boolean"
+      }
+    ]
+  }
+];
+
+export const switchShowcaseStory: ShowcaseStory<Mutable<ChSwitch>> = {
+  properties: showcaseRenderProperties,
+  render: render,
+  state: state
+};

--- a/src/showcase/assets/components/types.ts
+++ b/src/showcase/assets/components/types.ts
@@ -5,6 +5,7 @@ import { ChDropdownRender } from "../../../components/dropdown/dropdown-render";
 import { ChLayoutSplitter } from "../../../components/layout-splitter/layout-splitter";
 import { ChQr } from "../../../components/qr/qr";
 import { ChSlider } from "../../../components/slider/slider";
+import { ChSwitch } from "../../../components/switch/switch";
 import { ChTabRender } from "../../../components/tab/tab";
 import { ChTreeViewRender } from "../../../components/tree-view/tree-view-render";
 
@@ -64,7 +65,7 @@ export type ShowcaseRenderPropertyString<
   T,
   D extends keyof T
 > = ShowcaseRenderPropertyBase<T, D> & {
-  value: string;
+  value: string | undefined;
   render?: "input" | "textarea";
   type: "string";
 };
@@ -96,5 +97,6 @@ export type ShowcaseAvailableStories =
   | Mutable<ChLayoutSplitter>
   | Mutable<ChQr>
   | Mutable<ChSlider>
+  | Mutable<ChSwitch>
   | Mutable<ChTabRender>
   | Mutable<ChTreeViewRender>;

--- a/src/showcase/models/components.js
+++ b/src/showcase/models/components.js
@@ -25,6 +25,7 @@ const components = [
   ["shortcuts", "Shortcuts", EXPERIMENTAL],
   ["sidebar", "Sidebar", EXPERIMENTAL],
   ["slider", "Slider", DEVELOPER_PREVIEW],
+  ["switch", "Switch", EXPERIMENTAL],
   ["suggest", "Suggest", EXPERIMENTAL],
   ["tab", "Tab", EXPERIMENTAL],
   ["textblock", "Textblock", EXPERIMENTAL],


### PR DESCRIPTION
A switch/toggle control that enables you to select between options. It has:
 - Shadow DOM.
 - RTL support.
 - Accessibility.
 - Compatible with web forms.