### PR TITLE
Fix Flexible Layout control not working correctly with ch-tab-render as content

### DIFF
--- a/src/components/flexible-layout/internal/flexible-layout/flexible-layout.tsx
+++ b/src/components/flexible-layout/internal/flexible-layout/flexible-layout.tsx
@@ -238,6 +238,13 @@ export class ChFlexibleLayout {
   private handleItemChange =
     (viewId: string) =>
     (event: ChTabRenderCustomEvent<TabSelectedItemInfo>) => {
+      // Check if the selected item change event comes from a tab of the
+      // shadowroot, instead of a tab of the light DOM (case where a view has a
+      // "nested" ch-tab-render control)
+      if ((event.target as HTMLElement).getRootNode() !== this.el.shadowRoot) {
+        return;
+      }
+
       event.stopPropagation();
 
       // Add the view id to properly update the render


### PR DESCRIPTION
When the ch-tab-render control was used as a widget of the Flexible Layout control, the selectedItemChange event of the ch-tab-render triggered the selection of the Flexible Layout items.