### PR TITLE
Add methods and callbacks in the Action List control

### DIFF
--- a/src/components/action-list/action-list-render.tsx
+++ b/src/components/action-list/action-list-render.tsx
@@ -166,8 +166,6 @@ const defaultSortItemsCallback = (subModel: ActionListItemModel[]): void => {
   });
 };
 
-// type ImmediateFilter = "immediate" | "debounced" | undefined;
-
 @Component({
   tag: "ch-action-list-render",
   styleUrl: "action-list-render.scss",
@@ -412,7 +410,7 @@ export class ChActionListRender {
     }
 
     if (groupParentId) {
-      const parentGroup = this.#flattenedModel.get(itemInfo.id);
+      const parentGroup = this.#flattenedModel.get(groupParentId);
 
       // The parent group does not exists or it isn't a group
       if (

--- a/src/components/action-list/action-list-render.tsx
+++ b/src/components/action-list/action-list-render.tsx
@@ -711,9 +711,13 @@ export class ChActionListRender {
       el => el.id === itemToRemoveId
     );
 
-    // Remove the UI model from the previous parent. The equality function
-    // must be by index, not by object reference
-    removeElement(parentArray, itemToRemoveIndex);
+    // In some situations, the user could remove the item before the
+    // "removeItemCallback" promise is resolved
+    if (itemToRemoveIndex > -1) {
+      // Remove the UI model from the previous parent. The equality function
+      // must be by index, not by object reference
+      removeElement(parentArray, itemToRemoveIndex);
+    }
 
     this.#flattenedModel.delete(itemToRemoveId);
 

--- a/src/components/action-list/action-list-render.tsx
+++ b/src/components/action-list/action-list-render.tsx
@@ -387,6 +387,8 @@ export class ChActionListRender {
 
   /**
    * Fired when an item is clicked and `selection === "none"`.
+   * Applies for items that have `type === "actionable"` or
+   * (`type === "group"` and `expandable === true`)
    */
   @Event() itemClick: EventEmitter<ActionListItemModelExtended>;
 
@@ -597,6 +599,9 @@ export class ChActionListRender {
     const itemInfo = this.#getItemOrGroupInfo(actionListItemOrGroup.id);
     this.#checkIfMustExpandCollapseGroup(itemInfo);
 
+    if (itemInfo.type === "group" && !itemInfo.expandable) {
+      return;
+    }
     this.itemClick.emit(this.#flattenedModel.get(itemInfo.id));
   };
 

--- a/src/components/action-list/internal/action-list-item/action-list-item.scss
+++ b/src/components/action-list/internal/action-list-item/action-list-item.scss
@@ -86,7 +86,7 @@
 // - - - - - - - - - - - - - - - - - - - -
 //            Additional items
 // - - - - - - - - - - - - - - - - - - - -
-:host(:not(:hover)) .show-on-mouse-hover {
+:host(:not(:hover):not(:focus-within)) .show-on-mouse-hover {
   display: none;
 }
 


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fixes:
   - Don't fire `itemClick` event if the group's caption is not interactable.

   - Show additional actions on item focus.

   - Check if the item still exists before applying removeElement.

 - Features:
   - Add support to `removeItem` method in the Action List control.

   - Add `fixItemCallback` Prop in the Action List control.

   - Add support to `addItem` method in the Action List control