### PR TITLE
Add support for undefined images in `getImagePathCallback` of the Tree View control

### DIFF
--- a/src/components/tree-view/internal/tree-view-item/tree-view-item.tsx
+++ b/src/components/tree-view/internal/tree-view-item/tree-view-item.tsx
@@ -631,9 +631,15 @@ export class ChTreeViewItem {
     const imageIsString = typeof img === "string";
     const parsedImg: GxImageMultiState = imageIsString
       ? { base: img }
-      : img.default;
+      : img?.default;
 
     if (direction === "start") {
+      if (!img) {
+        this.#startImage = null;
+        this.#startImageExpanded = null;
+        return;
+      }
+
       // Add url("") wrapper for the image path as it is going to be used in a
       // background or mask
       if (imageIsString && this.startImgType !== "img") {
@@ -658,6 +664,12 @@ export class ChTreeViewItem {
     }
     // End image
     else {
+      if (!img) {
+        this.#endImage = null;
+        this.#endImageExpanded = null;
+        return;
+      }
+
       // Add url("") wrapper for the image path as it is going to be used in a
       // background or mask
       if (imageIsString && this.endImgType !== "img") {
@@ -1110,7 +1122,7 @@ export class ChTreeViewItem {
             [this.parts]: hasParts
           })}
           style={
-            pseudoStartImage
+            pseudoStartImage && (this.#startImage || this.#startImageExpanded)
               ? this.#getImageExpandedOrDefault(
                   this.#startImage,
                   this.#startImageExpanded
@@ -1194,7 +1206,7 @@ export class ChTreeViewItem {
                   [this.parts]: hasParts
                 })}
                 style={
-                  pseudoEndImage
+                  pseudoEndImage && (this.#endImage || this.#endImageExpanded)
                     ? this.#getImageExpandedOrDefault(
                         this.#endImage,
                         this.#endImageExpanded
@@ -1204,6 +1216,7 @@ export class ChTreeViewItem {
                 onDblClick={!this.editing ? this.#handleActionDblClick : null}
               >
                 {this.startImgSrc &&
+                  this.#startImage &&
                   this.#renderImg(
                     hasParts
                       ? `${START_IMAGE_PARTS} ${this.parts}`
@@ -1233,6 +1246,7 @@ export class ChTreeViewItem {
                 )}
 
                 {this.endImgSrc &&
+                  this.#endImage &&
                   this.#renderImg(
                     hasParts
                       ? `${END_IMAGE_PARTS} ${this.parts}`

--- a/src/components/tree-view/internal/tree-view-item/tree-view-item.tsx
+++ b/src/components/tree-view/internal/tree-view-item/tree-view-item.tsx
@@ -69,8 +69,10 @@ const LAST_SUB_ITEM = `:scope>${TREE_ITEM_TAG_NAME}:last-child`;
 const DENY_DROP_CLASS = `item-deny-drop`;
 
 // Custom parts
-const START_IMAGE_PARTS = `${TREE_VIEW_ITEM_PARTS_DICTIONARY.IMAGE} ${TREE_VIEW_ITEM_PARTS_DICTIONARY.START_IMAGE}`;
-const END_IMAGE_PARTS = `${TREE_VIEW_ITEM_PARTS_DICTIONARY.IMAGE} ${TREE_VIEW_ITEM_PARTS_DICTIONARY.END_IMAGE}`;
+const START_IMAGE_PARTS =
+  `${TREE_VIEW_ITEM_PARTS_DICTIONARY.IMAGE} ${TREE_VIEW_ITEM_PARTS_DICTIONARY.START_IMAGE}` as const;
+const END_IMAGE_PARTS =
+  `${TREE_VIEW_ITEM_PARTS_DICTIONARY.IMAGE} ${TREE_VIEW_ITEM_PARTS_DICTIONARY.END_IMAGE}` as const;
 
 // Keys
 const EXPANDABLE_ID = "expandable";
@@ -970,7 +972,7 @@ export class ChTreeViewItem {
     imageType === "img" && (
       <img
         aria-hidden="true"
-        class={cssClass}
+        class={`img ${cssClass}`}
         part={cssClass}
         alt=""
         src={src}

--- a/src/components/tree-view/types.ts
+++ b/src/components/tree-view/types.ts
@@ -127,7 +127,7 @@ export type LazyLoadTreeItemsCallback = (
 export type TreeViewImagePathCallback = (
   item: TreeViewItemModel,
   iconDirection: "start" | "end"
-) => string | TreeViewItemImageMultiState;
+) => string | TreeViewItemImageMultiState | undefined;
 
 export type TreeViewItemImageMultiState = {
   default: GxImageMultiState;

--- a/src/showcase/assets/components/tree-view/models.ts
+++ b/src/showcase/assets/components/tree-view/models.ts
@@ -5,7 +5,8 @@ import {
 import {
   LazyLoadTreeItemsCallback,
   TreeViewItemModel,
-  TreeViewImagePathCallback
+  TreeViewImagePathCallback,
+  TreeViewModel
 } from "../../../../components/tree-view/types";
 
 const KB_EXPLORER_ORDER = {
@@ -317,7 +318,7 @@ const kbExplorer_root: TreeViewItemModel[] = [
   }
 ];
 
-export const kbExplorerModel = [
+export const kbExplorerModel: TreeViewModel = [
   {
     id: "root",
     caption: "GeneXusNext Develop",
@@ -325,6 +326,7 @@ export const kbExplorerModel = [
     expanded: true,
     leaf: false,
     startImgSrc: `${ASSETS_PREFIX}version.svg`,
+    startImgType: "img",
     dragDisabled: true,
     dropDisabled: true,
     items: kbExplorer_root
@@ -337,6 +339,7 @@ const kbExplorerModel_MainPrograms: TreeViewItemModel[] = [
     caption: "Prompt",
     dragDisabled: true,
     dropDisabled: true,
+    startImgType: "img",
     leaf: true,
     startImgSrc: `${ASSETS_PREFIX}panel-for-sd.svg`,
     metadata: "Panel",


### PR DESCRIPTION
Also fix empty images when using "img" as the render of the images.