### PR TITLE
Add `ch-image` control 

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -15,7 +15,7 @@ import { CodeDiffEditorOptions } from "./components/code-diff-editor/code-diff-e
 import { CodeEditorOptions } from "./components/code-editor/code-editor-types.js";
 import { ComboBoxFilterOptions, ComboBoxFilterType, ComboBoxModel } from "./components/combobox/types";
 import { ChPopoverAlign, ChPopoverSizeMatch, PopoverActionElement } from "./components/popover/types";
-import { GxDataTransferInfo, ImageRender, LabelPosition } from "./common/types";
+import { GxDataTransferInfo, GxImageMultiState, ImageRender, LabelPosition } from "./common/types";
 import { DropdownModel } from "./components/dropdown/types";
 import { DraggableViewInfo, FlexibleLayoutGroupModel, FlexibleLayoutItemExtended, FlexibleLayoutItemModel, FlexibleLayoutLeafModel, FlexibleLayoutLeafType, FlexibleLayoutModel, FlexibleLayoutRenders, FlexibleLayoutViewRemoveResult, FlexibleLayoutWidget, FlexibleLayoutWidgetCloseInfo, ViewItemCloseInfo, ViewSelectedItemInfo, WidgetReorderInfo } from "./components/flexible-layout/internal/flexible-layout/types";
 import { GridLocalization } from "./deprecated-components/grid/ch-grid";
@@ -64,7 +64,7 @@ export { CodeDiffEditorOptions } from "./components/code-diff-editor/code-diff-e
 export { CodeEditorOptions } from "./components/code-editor/code-editor-types.js";
 export { ComboBoxFilterOptions, ComboBoxFilterType, ComboBoxModel } from "./components/combobox/types";
 export { ChPopoverAlign, ChPopoverSizeMatch, PopoverActionElement } from "./components/popover/types";
-export { GxDataTransferInfo, ImageRender, LabelPosition } from "./common/types";
+export { GxDataTransferInfo, GxImageMultiState, ImageRender, LabelPosition } from "./common/types";
 export { DropdownModel } from "./components/dropdown/types";
 export { DraggableViewInfo, FlexibleLayoutGroupModel, FlexibleLayoutItemExtended, FlexibleLayoutItemModel, FlexibleLayoutLeafModel, FlexibleLayoutLeafType, FlexibleLayoutModel, FlexibleLayoutRenders, FlexibleLayoutViewRemoveResult, FlexibleLayoutWidget, FlexibleLayoutWidgetCloseInfo, ViewItemCloseInfo, ViewSelectedItemInfo, WidgetReorderInfo } from "./components/flexible-layout/internal/flexible-layout/types";
 export { GridLocalization } from "./deprecated-components/grid/ch-grid";
@@ -1367,6 +1367,34 @@ export namespace Components {
           * The URL of the icon.
          */
         "src": string;
+    }
+    /**
+     * A control to display multiple images, depending on the state (focus, hover,
+     * active or disabled) of a parent element.
+     */
+    interface ChImage {
+        /**
+          * Specifies a reference for the container, in order to update the state of the icon. The reference must be an ancestor of the control. If not specified, the direct parent reference will be used.
+         */
+        "containerRef": HTMLElement | undefined;
+        /**
+          * Specifies if the icon is disabled.
+         */
+        "disabled": boolean;
+        /**
+          * This property specifies a callback that is executed when the path the image needs to be resolved.
+         */
+        "getImagePathCallback": (
+    imageSrc: string
+  ) => GxImageMultiState;
+        /**
+          * Specifies the src for the image.
+         */
+        "src": string | undefined;
+        /**
+          * Specifies how the image will be rendered.
+         */
+        "type": Exclude<ImageRender, "img">;
     }
     interface ChIntersectionObserver {
         /**
@@ -4170,6 +4198,16 @@ declare global {
         prototype: HTMLChIconElement;
         new (): HTMLChIconElement;
     };
+    /**
+     * A control to display multiple images, depending on the state (focus, hover,
+     * active or disabled) of a parent element.
+     */
+    interface HTMLChImageElement extends Components.ChImage, HTMLStencilElement {
+    }
+    var HTMLChImageElement: {
+        prototype: HTMLChImageElement;
+        new (): HTMLChImageElement;
+    };
     interface HTMLChIntersectionObserverElementEventMap {
         "intersectionUpdate": IntersectionObserverEntry;
     }
@@ -5213,6 +5251,7 @@ declare global {
         "ch-grid-settings-columns": HTMLChGridSettingsColumnsElement;
         "ch-grid-virtual-scroller": HTMLChGridVirtualScrollerElement;
         "ch-icon": HTMLChIconElement;
+        "ch-image": HTMLChImageElement;
         "ch-intersection-observer": HTMLChIntersectionObserverElement;
         "ch-layout-splitter": HTMLChLayoutSplitterElement;
         "ch-markdown": HTMLChMarkdownElement;
@@ -6549,6 +6588,34 @@ declare namespace LocalJSX {
           * The URL of the icon.
          */
         "src"?: string;
+    }
+    /**
+     * A control to display multiple images, depending on the state (focus, hover,
+     * active or disabled) of a parent element.
+     */
+    interface ChImage {
+        /**
+          * Specifies a reference for the container, in order to update the state of the icon. The reference must be an ancestor of the control. If not specified, the direct parent reference will be used.
+         */
+        "containerRef"?: HTMLElement | undefined;
+        /**
+          * Specifies if the icon is disabled.
+         */
+        "disabled"?: boolean;
+        /**
+          * This property specifies a callback that is executed when the path the image needs to be resolved.
+         */
+        "getImagePathCallback": (
+    imageSrc: string
+  ) => GxImageMultiState;
+        /**
+          * Specifies the src for the image.
+         */
+        "src"?: string | undefined;
+        /**
+          * Specifies how the image will be rendered.
+         */
+        "type"?: Exclude<ImageRender, "img">;
     }
     interface ChIntersectionObserver {
         /**
@@ -8630,6 +8697,7 @@ declare namespace LocalJSX {
         "ch-grid-settings-columns": ChGridSettingsColumns;
         "ch-grid-virtual-scroller": ChGridVirtualScroller;
         "ch-icon": ChIcon;
+        "ch-image": ChImage;
         "ch-intersection-observer": ChIntersectionObserver;
         "ch-layout-splitter": ChLayoutSplitter;
         "ch-markdown": ChMarkdown;
@@ -8824,6 +8892,11 @@ declare module "@stencil/core" {
              */
             "ch-grid-virtual-scroller": LocalJSX.ChGridVirtualScroller & JSXBase.HTMLAttributes<HTMLChGridVirtualScrollerElement>;
             "ch-icon": LocalJSX.ChIcon & JSXBase.HTMLAttributes<HTMLChIconElement>;
+            /**
+             * A control to display multiple images, depending on the state (focus, hover,
+             * active or disabled) of a parent element.
+             */
+            "ch-image": LocalJSX.ChImage & JSXBase.HTMLAttributes<HTMLChImageElement>;
             "ch-intersection-observer": LocalJSX.ChIntersectionObserver & JSXBase.HTMLAttributes<HTMLChIntersectionObserverElement>;
             "ch-layout-splitter": LocalJSX.ChLayoutSplitter & JSXBase.HTMLAttributes<HTMLChLayoutSplitterElement>;
             /**

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -1,0 +1,54 @@
+ch-image {
+  /**
+   * @prop --ch-image-size:
+   * Specifies the box size that contains the image.
+   * @default 0.875em
+   */
+  --ch-image-size: 0.875em;
+
+  /**
+    * @prop --ch-image-background-size:
+    * Specifies the size of the image.
+    * @default 100%
+    */
+  --ch-image-background-size: 100%;
+
+  display: inline-grid;
+  inline-size: var(--ch-image-size);
+  block-size: var(--ch-image-size);
+  pointer-events: none;
+
+  --ch-image-src: var(--ch-start-img--base);
+}
+
+[data-ch-image] {
+  &:hover .ch-image--enabled {
+    --ch-image-src: var(--ch-start-img--hover, var(--ch-start-img--base));
+  }
+
+  &:active .ch-image--enabled {
+    --ch-image-src: var(--ch-start-img--active, var(--ch-start-img--base));
+  }
+
+  &:focus .ch-image--enabled {
+    --ch-image-src: var(
+      --ch-start-img--focus,
+      var(--ch-start-img--active, var(--ch-start-img--base))
+    );
+  }
+}
+
+.ch-image--disabled {
+  --ch-image-src: var(--ch-start-img--disabled, var(--ch-start-img--base));
+}
+
+.ch-image--background {
+  background: no-repeat center / var(--ch-image-background-size)
+    var(--ch-image-src);
+}
+
+.ch-image--mask {
+  -webkit-mask: no-repeat center / var(--ch-image-background-size)
+    var(--ch-image-src);
+  background-color: currentColor;
+}

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -1,0 +1,104 @@
+import { Component, Host, h, Prop, Element, Watch } from "@stencil/core";
+import {
+  GxImageMultiState,
+  GxImageMultiStateStart,
+  ImageRender
+} from "../../common/types";
+import { updateDirectionInImageCustomVar } from "../../common/utils";
+
+const DATA_IMAGE = "data-ch-image";
+
+/**
+ * A control to display multiple images, depending on the state (focus, hover,
+ * active or disabled) of a parent element.
+ */
+@Component({
+  tag: "ch-image",
+  styleUrl: "image.scss"
+})
+export class ChImage {
+  #currentContainerRef!: HTMLElement;
+  #image: GxImageMultiStateStart | undefined;
+
+  @Element() el!: HTMLChImageElement;
+
+  /**
+   * Specifies a reference for the container, in order to update the state of
+   * the icon. The reference must be an ancestor of the control.
+   * If not specified, the direct parent reference will be used.
+   */
+  @Prop() readonly containerRef: HTMLElement | undefined;
+  @Watch("containerRef")
+  containerRefChanged(newContainer: HTMLElement | undefined) {
+    // Remove previous data in the current parent
+    this.#currentContainerRef?.removeAttribute(DATA_IMAGE);
+
+    this.#currentContainerRef = newContainer ?? this.el.parentElement;
+
+    // Add data in the new parent
+    this.#currentContainerRef?.setAttribute(DATA_IMAGE, "");
+  }
+
+  /**
+   * Specifies if the icon is disabled.
+   */
+  @Prop() readonly disabled: boolean = false;
+
+  /**
+   * This property specifies a callback that is executed when the path the
+   * image needs to be resolved.
+   */
+  @Prop() readonly getImagePathCallback!: (
+    imageSrc: string
+  ) => GxImageMultiState;
+
+  /**
+   * Specifies the src for the image.
+   */
+  @Prop() readonly src: string | undefined;
+  @Watch("src")
+  srcChanged(newSrc: string | undefined) {
+    this.#image = newSrc
+      ? (updateDirectionInImageCustomVar(
+          this.getImagePathCallback(newSrc),
+          "start"
+        ) as GxImageMultiStateStart)
+      : undefined;
+  }
+
+  /**
+   * Specifies how the image will be rendered.
+   */
+  @Prop() readonly type: Exclude<ImageRender, "img"> = "background";
+
+  connectedCallback() {
+    this.#currentContainerRef = this.containerRef ?? this.el.parentElement;
+
+    this.#currentContainerRef?.setAttribute(DATA_IMAGE, "");
+
+    if (this.src) {
+      this.#image = updateDirectionInImageCustomVar(
+        this.getImagePathCallback(this.src),
+        "start"
+      ) as GxImageMultiStateStart;
+    }
+  }
+
+  disconnectedCallback() {
+    this.#currentContainerRef?.removeAttribute(DATA_IMAGE);
+  }
+
+  render() {
+    return (
+      <Host
+        aria-hidden="true"
+        class={{
+          "ch-image--disabled": this.disabled,
+          "ch-image--enabled": !this.disabled,
+          [`ch-image--${this.type}`]: true
+        }}
+        style={this.#image ?? undefined}
+      ></Host>
+    );
+  }
+}

--- a/src/components/image/readme.md
+++ b/src/components/image/readme.md
@@ -1,0 +1,45 @@
+# ch-image
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+A control to display multiple images, depending on the state (focus, hover,
+active or disabled) of a parent element.
+
+## Properties
+
+| Property                            | Attribute  | Description                                                                                                                                                                                      | Type                                      | Default        |
+| ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- | -------------- |
+| `containerRef`                      | --         | Specifies a reference for the container, in order to update the state of the icon. The reference must be an ancestor of the control. If not specified, the direct parent reference will be used. | `HTMLElement`                             | `undefined`    |
+| `disabled`                          | `disabled` | Specifies if the icon is disabled.                                                                                                                                                               | `boolean`                                 | `false`        |
+| `getImagePathCallback` _(required)_ | --         | This property specifies a callback that is executed when the path the image needs to be resolved.                                                                                                | `(imageSrc: string) => GxImageMultiState` | `undefined`    |
+| `src`                               | `src`      | Specifies the src for the image.                                                                                                                                                                 | `string`                                  | `undefined`    |
+| `type`                              | `type`     | Specifies how the image will be rendered.                                                                                                                                                        | `"background" \| "mask"`                  | `"background"` |
+
+
+## CSS Custom Properties
+
+| Name                         | Description                                                      |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `--ch-image-background-size` | Specifies the size of the image. @default 100%                   |
+| `--ch-image-size`            | Specifies the box size that contains the image. @default 0.875em |
+
+
+## Dependencies
+
+### Used by
+
+ - [ch-showcase](../../showcase/assets/components)
+
+### Graph
+```mermaid
+graph TD;
+  ch-showcase --> ch-image
+  style ch-image fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/showcase/assets/components/image/image.showcase.tsx
+++ b/src/showcase/assets/components/image/image.showcase.tsx
@@ -1,0 +1,113 @@
+import { h } from "@stencil/core";
+import { ShowcaseRenderProperties, ShowcaseStory } from "../types";
+import { Mutable } from "../../../../common/types";
+import { ChImage } from "../../../../components/image/image";
+import { getImagePathCallback } from "./models";
+
+const state: Partial<Mutable<ChImage>> = {};
+let button2Ref: HTMLButtonElement;
+
+const render = () => (
+  <div class="image-test-main-wrapper">
+    <button
+      class="button-tertiary button-icon"
+      disabled={state.disabled}
+      type="button"
+    >
+      <ch-image
+        disabled={state.disabled}
+        getImagePathCallback={getImagePathCallback}
+        src={state.src}
+        type={state.type}
+      ></ch-image>
+      Some text
+    </button>
+
+    <button
+      class="button-tertiary button-icon"
+      disabled={state.disabled}
+      type="button"
+      ref={el => (button2Ref = el)}
+    >
+      <div>
+        <ch-image
+          containerRef={button2Ref}
+          disabled={state.disabled}
+          getImagePathCallback={getImagePathCallback}
+          src={state.src}
+          type={state.type}
+        ></ch-image>
+      </div>
+      Some text
+    </button>
+  </div>
+);
+
+const showcaseRenderProperties: ShowcaseRenderProperties<Mutable<ChImage>> = [
+  {
+    caption: "Properties",
+    properties: [
+      {
+        id: "src",
+        caption: "Src",
+        value: "folder",
+        render: "input",
+        type: "string"
+      },
+      {
+        id: "type",
+        caption: "Type",
+        value: "background",
+        values: [
+          { caption: "Background", value: "background" },
+          { caption: "Mask", value: "mask" }
+        ],
+        render: "radio-group",
+        type: "enum"
+      },
+      {
+        id: "disabled",
+        caption: "Disabled",
+        value: false,
+        type: "boolean"
+      }
+    ]
+  }
+];
+
+export const imageShowcaseStory: ShowcaseStory<Mutable<ChImage>> = {
+  properties: showcaseRenderProperties,
+  markupWithoutUIModel: `<button
+          class="button-tertiary button-icon"
+          disabled={<disabled value>}
+          type="button"
+        >
+          <ch-image
+            disabled={<disabled value>}
+            getImagePathCallback={getImagePathCallback}
+            src={<src value>}
+            type={<type value>}
+          ></ch-image>
+          Some text
+        </button>
+
+        <button
+          class="button-tertiary button-icon"
+          disabled={<disabled value>}
+          type="button"
+          ref={el => (this.#buttonRef = el)}
+        >
+          <div>
+            <ch-image
+              containerRef={this.#buttonRef}
+              disabled={<disabled value>}
+              getImagePathCallback={getImagePathCallback}
+              src={<src value>}
+              type={<type value>}
+            ></ch-image>
+          </div>
+          Some text
+        </button>`,
+  render: render,
+  state: state
+};

--- a/src/showcase/assets/components/image/models.ts
+++ b/src/showcase/assets/components/image/models.ts
@@ -1,0 +1,34 @@
+import { GxImageMultiState } from "../../../../common/types";
+
+const FOLDER_ICON = "folder";
+const MODULE_ICON = "module";
+
+export const getImagePathCallback = (
+  imgSrc: string
+  // iconDirection: "start" | "end"
+): GxImageMultiState => {
+  if (imgSrc === MODULE_ICON) {
+    return {
+      base: "var(--icon-module-base)",
+      active: "var(--icon-module-active)",
+      hover: "var(--icon-module-hover)",
+      disabled: "var(--icon-module-disabled)"
+    };
+  }
+
+  if (imgSrc === FOLDER_ICON) {
+    return {
+      base: "var(--icon-folder-base)",
+      active: "var(--icon-folder-active)",
+      hover: "var(--icon-folder-hover)",
+      disabled: "var(--icon-folder-disabled)"
+    };
+  }
+
+  return {
+    base: "var(--icon-stencil-base)",
+    active: "var(--icon-stencil-active)",
+    hover: "var(--icon-stencil-hover)",
+    disabled: "var(--icon-stencil-disabled)"
+  };
+};

--- a/src/showcase/assets/components/readme.md
+++ b/src/showcase/assets/components/readme.md
@@ -30,6 +30,7 @@
 - [ch-dialog](../../../components/dialog)
 - [ch-dropdown-render](../../../components/dropdown)
 - [ch-test-flexible-layout](../../../components/test/test-flexible-layout)
+- [ch-image](../../../components/image)
 - [ch-layout-splitter](../../../components/layout-splitter)
 - [ch-markdown](../../../components/markdown)
 - [ch-popover](../../../components/popover)
@@ -54,6 +55,7 @@ graph TD;
   ch-showcase --> ch-dialog
   ch-showcase --> ch-dropdown-render
   ch-showcase --> ch-test-flexible-layout
+  ch-showcase --> ch-image
   ch-showcase --> ch-layout-splitter
   ch-showcase --> ch-markdown
   ch-showcase --> ch-popover

--- a/src/showcase/assets/components/showcase-stories.ts
+++ b/src/showcase/assets/components/showcase-stories.ts
@@ -7,6 +7,7 @@ import { comboBoxShowcaseStory } from "./combo-box/combo-box.showcase";
 import { dialogShowcaseStory } from "./dialog/dialog.showcase";
 import { dropdownShowcaseStory } from "./dropdown/dropdown.showcase";
 import { flexibleLayoutShowcaseStory } from "./flexible-layout/flexible-layout.showcase";
+import { imageShowcaseStory } from "./image/image.showcase";
 import { layoutSplitterShowcaseStory } from "./layout-splitter/layout-splitter.showcase";
 import { markdownShowcaseStory } from "./markdown/markdown.showcase";
 import { popoverShowcaseStory } from "./popover/popover.showcase";
@@ -27,6 +28,7 @@ export const showcaseStories = {
   "combo-box": comboBoxShowcaseStory,
   dialog: dialogShowcaseStory,
   dropdown: dropdownShowcaseStory,
+  image: imageShowcaseStory,
   "layout-splitter": layoutSplitterShowcaseStory,
   popover: popoverShowcaseStory,
   qr: qrShowcaseStory,

--- a/src/showcase/assets/components/types.ts
+++ b/src/showcase/assets/components/types.ts
@@ -8,6 +8,7 @@ import { ChComboBox } from "../../../components/combobox/combo-box";
 import { ChDialog } from "../../../components/dialog/dialog";
 import { ChDropdownRender } from "../../../components/dropdown/dropdown-render";
 import { ChFlexibleLayoutRender } from "../../../components/flexible-layout/flexible-layout-render";
+import { ChImage } from "../../../components/image/image";
 import { ChLayoutSplitter } from "../../../components/layout-splitter/layout-splitter";
 import { ChMarkdown } from "../../../components/markdown/markdown";
 import { ChPopover } from "../../../components/popover/popover";
@@ -119,6 +120,7 @@ export type ShowcaseAvailableStories =
   | Mutable<ChComboBox>
   | Mutable<ChDialog>
   | Mutable<ChDropdownRender>
+  | Mutable<ChImage>
   | Mutable<ChLayoutSplitter>
   | Mutable<ChPopover>
   | Mutable<ChQr>

--- a/src/showcase/base.css
+++ b/src/showcase/base.css
@@ -91,6 +91,12 @@ legend {
   grid-auto-rows: 128px;
 }
 
+.image-test-main-wrapper {
+  display: grid;
+  grid-template-columns: max-content max-content max-content max-content;
+  grid-template-rows: max-content max-content;
+}
+
 .markdown-test-main-wrapper {
   display: grid;
   grid-template-rows: max-content 1fr;
@@ -259,6 +265,11 @@ ch-showcase ch-flexible-layout-render {
   --icon-folder-active--expanded: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/dark/folder-open.svg#active");
   --icon-folder-hover--expanded: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/dark/folder-open.svg#hover");
   --icon-folder-disabled--expanded: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/dark/folder-open.svg#disabled");
+
+  --icon-stencil-base: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/dark/stencil.svg#enabled");
+  --icon-stencil-active: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/dark/stencil.svg#active");
+  --icon-stencil-hover: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/dark/stencil.svg#hover");
+  --icon-stencil-disabled: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/dark/stencil.svg#disabled");
 }
 
 :root.light {
@@ -281,6 +292,11 @@ ch-showcase ch-flexible-layout-render {
   --icon-folder-active--expanded: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/light/folder-open.svg#active");
   --icon-folder-hover--expanded: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/light/folder-open.svg#hover");
   --icon-folder-disabled--expanded: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/light/folder-open.svg#disabled");
+
+  --icon-stencil-base: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/light/stencil.svg#enabled");
+  --icon-stencil-active: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/light/stencil.svg#active");
+  --icon-stencil-hover: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/light/stencil.svg#hover");
+  --icon-stencil-disabled: url("https://unpkg.com/@genexus/mercury@0.2.0/dist/assets/icons/objects/light/stencil.svg#disabled");
 }
 
 /* This is a WA to improve the UX */
@@ -293,63 +309,3 @@ ch-showcase ch-flexible-layout-render {
 .combo-box::part(item):hover {
   background-color: var(--accents-un-accent__primary-dim--hover);
 } */
-
-.list-box-secondary {
-  --ch-action-list-group__expandable-button-size: var(--spacing-un-spacing--l);
-  --ch-action-list-group__expandable-button-image-size: calc(100% - 4px);
-  padding: var(--spacing-un-spacing--xs);
-
-  font-size: 14px;
-  line-height: 18px;
-  letter-spacing: 0.2px;
-
-  &::part(item__action),
-  &::part(group__action),
-  &::part(group__caption) {
-    border-radius: 4px;
-    padding-block: var(--spacing-un-spacing--s);
-    padding-inline: var(--spacing-un-spacing--m);
-  }
-
-  &::part(item__action):focus-visible,
-  &::part(group__action):focus-visible {
-    outline: 1px solid var(--accents-un-accent__secondary--active);
-    outline-offset: -1px;
-  }
-
-  &::part(item__action nested-expandable) {
-    padding-inline-start: calc(
-      var(--spacing-un-spacing--l) + var(--spacing-un-spacing--s) +
-        var(--spacing-un-spacing--m)
-    );
-  }
-
-  &::part(group__action),
-  &::part(group__caption) {
-    font-weight: 600;
-    gap: var(--spacing-un-spacing--s);
-  }
-
-  &::part(item__action not-selectable):hover,
-  &::part(group__action not-selectable):hover {
-    color: var(--text-un-text__primary--hover);
-  }
-
-  &::part(item__action selectable):hover,
-  &::part(group__action selectable):hover,
-  &::part(item__action selected),
-  &::part(group__action selected) {
-    background-color: var(--accents-un-accent__primary-dim--hover);
-  }
-
-  &::part(item__action disabled),
-  &::part(group__action disabled),
-  &::part(group__caption disabled) {
-    color: var(--text-un-text__disabled);
-  }
-
-  &::part(separator) {
-    margin-block: var(--spacing-un-spacing--s);
-    background-color: var(--accents-un-accent__secondary--hover);
-  }
-}

--- a/src/showcase/models/components.js
+++ b/src/showcase/models/components.js
@@ -16,6 +16,7 @@ const components = [
   ["dropdown", "Dropdown", EXPERIMENTAL],
   ["dialog", "Dialog", EXPERIMENTAL],
   ["flexible-layout", "Flexible Layout", EXPERIMENTAL],
+  ["image", "Image", EXPERIMENTAL],
   ["tabular-grid", "Tabular Grid", STABLE],
   ["layout-splitter", "Layout Splitter", EXPERIMENTAL],
   ["markdown", "Markdown", EXPERIMENTAL],


### PR DESCRIPTION
A control to display multiple images, depending on the state (focus, hover, active or disabled) of a parent element.