### PR TITLE
Use CommonThemes instead of GlobalStyleSheet

### DIFF
--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -1,0 +1,19 @@
+import { getTheme } from "../components/theme/theme-stylesheet";
+
+export const CHAMELEON_THEMES = {
+  SCROLLBAR: "chameleon/scrollbar"
+};
+
+const CHAMELEON_COMMON_THEMES = [CHAMELEON_THEMES.SCROLLBAR];
+const CHAMELEON_THEMES_TIMEOUT = 10000;
+
+export function adoptCommonThemes(adoptedStyleSheets: CSSStyleSheet[]) {
+  CHAMELEON_COMMON_THEMES.forEach(name => {
+    getTheme({ name }, CHAMELEON_THEMES_TIMEOUT)
+      .then(theme => {
+        adoptedStyleSheets.push(theme.styleSheet);
+      })
+      .catch(() => {});
+  });
+  console.log("adoptCommonThemes");
+}

--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -15,5 +15,4 @@ export function adoptCommonThemes(adoptedStyleSheets: CSSStyleSheet[]) {
       })
       .catch(() => {});
   });
-  console.log("adoptCommonThemes");
 }

--- a/src/components/tabular-grid/tabular-grid-manager.ts
+++ b/src/components/tabular-grid/tabular-grid-manager.ts
@@ -7,7 +7,7 @@ import HTMLChTabularGridCellElement from "./cell/tabular-grid-cell";
 import { TabularGridManagerSelection } from "./tabular-grid-manager-selection";
 import { TabularGridManagerRowDrag } from "./tabular-grid-manager-row-drag";
 import { TabularGridManagerRowActions } from "./tabular-grid-manager-row-actions";
-import { adoptGlobalStyleSheet } from "../../deprecated-components/style/ch-global-stylesheet";
+import { adoptCommonThemes } from "../../common/theme";
 import { TabularGridManagerColumnResize } from "./tabular-grid-manager-column-resize";
 
 enum StyleRule {
@@ -33,7 +33,7 @@ export class TabularGridManager {
     this.styleSheet.insertRule(`:host {}`, StyleRule.BASE_LAYER);
     this.styleSheet.insertRule(".main {}", StyleRule.COLUMNS_WIDTH);
     this.grid.shadowRoot.adoptedStyleSheets.push(this.styleSheet);
-    adoptGlobalStyleSheet(this.grid.shadowRoot.adoptedStyleSheets);
+    adoptCommonThemes(this.grid.shadowRoot.adoptedStyleSheets);
 
     this.columns = new TabularGridManagerColumns(this);
     this.selection = new TabularGridManagerSelection(this);

--- a/src/deprecated-components/window/ch-window.tsx
+++ b/src/deprecated-components/window/ch-window.tsx
@@ -9,7 +9,7 @@ import {
   Element,
   Host
 } from "@stencil/core";
-import { adoptGlobalStyleSheet } from "../style/ch-global-stylesheet";
+import { adoptCommonThemes } from "../../common/theme";
 
 export type ChWindowAlign =
   | "outside-start"
@@ -339,7 +339,7 @@ export class ChWindow {
   };
 
   private loadGlobalStyleSheet() {
-    adoptGlobalStyleSheet(this.el.shadowRoot.adoptedStyleSheets);
+    adoptCommonThemes(this.el.shadowRoot.adoptedStyleSheets);
   }
 
   render() {


### PR DESCRIPTION
## Breaking changes

The use of `<ch-style>` to style scrollbars in <ch-tabular-grid> and <ch-window> is no longer supported.
Instead, use
```tsx
const SCROLLBAR_STYLE = { name: "chameleon/scrollbar", url: "<url_to_css>" } as const;

Render:
<ch-theme model={SCROLLBAR_STYLE}></ch-theme>
```