### PR TITLE
[ch-tabular-grid] Fix the trigger of the emitRowClicked event

### DIFF
--- a/src/components/tabular-grid/tabular-grid.tsx
+++ b/src/components/tabular-grid/tabular-grid.tsx
@@ -490,11 +490,24 @@ export class ChTabularGrid {
   }
 
   @Listen("mouseup", { passive: true })
-  mouseUpHandler() {
+  mouseUpHandler(eventInfo: MouseEvent) {
+    const row = this.manager.getRowEventTarget(eventInfo);
+    const cell = this.manager.getCellEventTarget(eventInfo);
+
     if (this.manager.selection.selecting) {
       this.stopSelecting();
     }
-    this.emitRowClicked(this.rowFocused, this.cellFocused);
+
+    /**
+     * - Verifies that the mouseup event occurs over a row and not over a column or rowset legend.
+     * - Verifies that the mouseup event occurs on the same row where the mousedown or the last mousemove occurred.
+     *   This aims to prevent cases where a mousedown starts on a row in grid A and the mouseup happens on a row in grid B (drag & drop scenario).
+     * - The emitRowClicked() cannot be placed inside the if (this.manager.selection.selecting)
+     *   because the selection can be canceled during the mousemove.
+     */
+    if (row && row === this.rowFocused) {
+      this.emitRowClicked(row, cell);
+    }
   }
 
   @Listen("dblclick", { passive: true })


### PR DESCRIPTION
- Verifies that the mouseup event occurs over a row and not over a column or rowset legend.
- Verifies that the mouseup event occurs on the same row where the mousedown or the last mousemove occurred. This aims to prevent cases where a mousedown starts on a row in grid A and the mouseup happens on a row in grid B (drag & drop scenario).
