### PR TITLE
Fixes and improvements for the `ch-flexible-layout-render` control

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -18,7 +18,7 @@ import { ChPopoverAlign, ChPopoverSizeMatch, PopoverActionElement } from "./comp
 import { GxDataTransferInfo, GxImageMultiState, ImageRender, LabelPosition } from "./common/types";
 import { DropdownModel } from "./components/dropdown/types";
 import { EditInputMode, EditType } from "./components/edit/types";
-import { DraggableViewInfo, FlexibleLayoutGroupModel, FlexibleLayoutItemExtended, FlexibleLayoutItemModel, FlexibleLayoutLeafModel, FlexibleLayoutLeafType, FlexibleLayoutModel, FlexibleLayoutRenders, FlexibleLayoutViewRemoveResult, FlexibleLayoutWidget, FlexibleLayoutWidgetCloseInfo, ViewItemCloseInfo, ViewSelectedItemInfo, WidgetReorderInfo } from "./components/flexible-layout/internal/flexible-layout/types";
+import { DraggableViewInfo, FlexibleLayoutGroupModel, FlexibleLayoutItemExtended, FlexibleLayoutItemModel, FlexibleLayoutLeafConfigurationTabbed, FlexibleLayoutLeafModel, FlexibleLayoutLeafType, FlexibleLayoutModel, FlexibleLayoutRenders, FlexibleLayoutViewRemoveResult, FlexibleLayoutWidget, FlexibleLayoutWidgetCloseInfo, ViewItemCloseInfo, ViewSelectedItemInfo, WidgetReorderInfo } from "./components/flexible-layout/internal/flexible-layout/types";
 import { GridLocalization } from "./deprecated-components/grid/ch-grid";
 import { ChGridCellSelectionChangedEvent, ChGridMarkingChangedEvent, ChGridRowClickedEvent, ChGridRowContextMenuEvent, ChGridRowPressedEvent, ChGridSelectionChangedEvent } from "./deprecated-components/grid/ch-grid-types";
 import { ChGridColumnDragEvent, ChGridColumnFreeze, ChGridColumnFreezeChangedEvent, ChGridColumnHiddenChangedEvent, ChGridColumnOrderChangedEvent, ChGridColumnResizeEvent, ChGridColumnSelectorClickedEvent, ChGridColumnSizeChangedEvent, ChGridColumnSortChangedEvent, ChGridColumnSortDirection } from "./deprecated-components/grid/grid-column/ch-grid-column-types";
@@ -68,7 +68,7 @@ export { ChPopoverAlign, ChPopoverSizeMatch, PopoverActionElement } from "./comp
 export { GxDataTransferInfo, GxImageMultiState, ImageRender, LabelPosition } from "./common/types";
 export { DropdownModel } from "./components/dropdown/types";
 export { EditInputMode, EditType } from "./components/edit/types";
-export { DraggableViewInfo, FlexibleLayoutGroupModel, FlexibleLayoutItemExtended, FlexibleLayoutItemModel, FlexibleLayoutLeafModel, FlexibleLayoutLeafType, FlexibleLayoutModel, FlexibleLayoutRenders, FlexibleLayoutViewRemoveResult, FlexibleLayoutWidget, FlexibleLayoutWidgetCloseInfo, ViewItemCloseInfo, ViewSelectedItemInfo, WidgetReorderInfo } from "./components/flexible-layout/internal/flexible-layout/types";
+export { DraggableViewInfo, FlexibleLayoutGroupModel, FlexibleLayoutItemExtended, FlexibleLayoutItemModel, FlexibleLayoutLeafConfigurationTabbed, FlexibleLayoutLeafModel, FlexibleLayoutLeafType, FlexibleLayoutModel, FlexibleLayoutRenders, FlexibleLayoutViewRemoveResult, FlexibleLayoutWidget, FlexibleLayoutWidgetCloseInfo, ViewItemCloseInfo, ViewSelectedItemInfo, WidgetReorderInfo } from "./components/flexible-layout/internal/flexible-layout/types";
 export { GridLocalization } from "./deprecated-components/grid/ch-grid";
 export { ChGridCellSelectionChangedEvent, ChGridMarkingChangedEvent, ChGridRowClickedEvent, ChGridRowContextMenuEvent, ChGridRowPressedEvent, ChGridSelectionChangedEvent } from "./deprecated-components/grid/ch-grid-types";
 export { ChGridColumnDragEvent, ChGridColumnFreeze, ChGridColumnFreezeChangedEvent, ChGridColumnHiddenChangedEvent, ChGridColumnOrderChangedEvent, ChGridColumnResizeEvent, ChGridColumnSelectorClickedEvent, ChGridColumnSizeChangedEvent, ChGridColumnSortChangedEvent, ChGridColumnSortDirection } from "./deprecated-components/grid/grid-column/ch-grid-column-types";
@@ -987,6 +987,10 @@ export namespace Components {
           * Update the selected widget from a `"tabbed"` type leaf. Only works if the parent leaf is `"tabbed"` type.
          */
         "updateSelectedWidget": (parentLeafId: string, newSelectedWidgetId: string) => Promise<void>;
+        /**
+          * Given the viewId, it updates the info of the view if the view is a leaf. The `type` of the properties argument must match the `type` of the view to update.
+         */
+        "updateViewInfo": (viewId: string, properties: Partial<Omit<FlexibleLayoutLeafConfigurationTabbed, "selectedWidgetId" | "widget" | "widgets">>) => Promise<void>;
         /**
           * Update the widget info.
          */

--- a/src/components/flexible-layout/flexible-layout-render.tsx
+++ b/src/components/flexible-layout/flexible-layout-render.tsx
@@ -584,6 +584,13 @@ export class ChFlexibleLayoutRender {
     // Mark the item as rendered
     widget.wasRendered = true;
 
+    const leafUIModel = this.#itemsInfo.get(leafInfo.id)
+      .item as FlexibleLayoutLeafConfigurationTabbed;
+
+    // TODO: This is a WA to fix the selectedWidgetId update. The leafInfo
+    // member should share memory with the leaf to avoid these issues
+    leafUIModel.selectedWidgetId = widget.id;
+
     leafInfo.selectedWidgetId = widget.id;
   };
 

--- a/src/components/flexible-layout/flexible-layout-render.tsx
+++ b/src/components/flexible-layout/flexible-layout-render.tsx
@@ -24,7 +24,8 @@ import {
   FlexibleLayoutWidget,
   FlexibleLayoutLeafType,
   FlexibleLayoutWidgetExtended,
-  FlexibleLayoutWidgetCloseInfo
+  FlexibleLayoutWidgetCloseInfo,
+  FlexibleLayoutLeafConfigurationTabbed
 } from "./internal/flexible-layout/types";
 import { ChFlexibleLayoutCustomEvent } from "../../components";
 import { removeElement } from "../../common/array";
@@ -363,6 +364,43 @@ export class ChFlexibleLayoutRender {
     // Queue re-renders
     forceUpdate(this);
     forceUpdate(this.#flexibleLayoutRef);
+  }
+
+  /**
+   * Given the viewId, it updates the info of the view if the view is a leaf.
+   * The `type` of the properties argument must match the `type` of the view to
+   * update.
+   */
+  @Method()
+  async updateViewInfo(
+    viewId: string,
+    properties: Partial<
+      Omit<
+        FlexibleLayoutLeafConfigurationTabbed,
+        "selectedWidgetId" | "widget" | "widgets"
+      >
+    >
+  ) {
+    const viewUIModel = this.#itemsInfo.get(viewId) as LeafExtended;
+
+    if (
+      !viewUIModel ||
+      !viewUIModel.leafInfo ||
+      viewUIModel.item.type !== properties.type
+    ) {
+      return;
+    }
+
+    for (const key in properties) {
+      // TODO: Avoid property duplication. Share the memory between the
+      // `leafInfo` member and the `item` member
+      viewUIModel.item[key] = properties[key];
+      viewUIModel.leafInfo[key] = properties[key];
+    }
+
+    // Queue re-renders
+    forceUpdate(this);
+    this.#flexibleLayoutRef.refreshLeaf(viewUIModel.item.id);
   }
 
   /**

--- a/src/components/flexible-layout/flexible-layout-render.tsx
+++ b/src/components/flexible-layout/flexible-layout-render.tsx
@@ -733,6 +733,15 @@ export class ChFlexibleLayoutRender {
     const widgetInfo = this.#widgetsInfo.get(widgetId).info;
     const widgetRender = this.renders[widgetInfo.renderId ?? widgetId];
 
+    if (!widgetRender) {
+      console.error(
+        `Could not find a render for the "${widgetId}" widget. The render "${
+          widgetInfo.renderId ?? widgetId
+        }" does not exists in the "renders" property.`
+      );
+      return;
+    }
+
     return widgetInfo.addWrapper ? (
       <div
         key={widgetId}

--- a/src/components/flexible-layout/internal/flexible-layout/flexible-layout.tsx
+++ b/src/components/flexible-layout/internal/flexible-layout/flexible-layout.tsx
@@ -172,7 +172,7 @@ export class ChFlexibleLayout {
     }
 
     const viewRef = this.el.shadowRoot.querySelector(
-      `ch-tab[id='${viewInfo.id}']`
+      LEAF_SELECTOR(viewInfo.id)
     ) as HTMLChTabRenderElement;
     await viewRef.removePage(itemId, forceRerender);
   }

--- a/src/components/flexible-layout/readme.md
+++ b/src/components/flexible-layout/readme.md
@@ -123,6 +123,25 @@ Type: `Promise<void>`
 
 
 
+### `updateViewInfo(viewId: string, properties: Partial<Omit<FlexibleLayoutLeafConfigurationTabbed, "selectedWidgetId" | "widget" | "widgets">>) => Promise<void>`
+
+Given the viewId, it updates the info of the view if the view is a leaf.
+The `type` of the properties argument must match the `type` of the view to
+update.
+
+#### Parameters
+
+| Name         | Type                                                                                                                                                                                                                       | Description |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `viewId`     | `string`                                                                                                                                                                                                                   |             |
+| `properties` | `{ type?: "tabbed"; closeButtonHidden?: boolean; dragOutsideDisabled?: boolean; showCaptions?: boolean; sortable?: boolean; tabDirection?: FlexibleLayoutLeafTabDirection; tabPosition?: FlexibleLayoutLeafTabPosition; }` |             |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `updateWidgetInfo(widgetId: string, properties: Partial<Omit<FlexibleLayoutWidget, "id" | "wasRendered">>) => Promise<void>`
 
 Update the widget info.


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fixes:
   + Fix broken `removeWidget` method.

   + Fix `selectedWidgetId` update not working in all cases.

 - Features:
   + Add initial support for the `updateViewInfo` method.

   + Add diagnostic to show an error when a widget has no rendering.
      When a widget does not have a render mapping in the `renders` property, a console error will be displayed in the devTools and the widget won't be render to avoid throwing an actual JS' error.