### PR TITLE
Rename the `ch-combo-box` control to `ch-combo-box-render`

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -590,7 +590,7 @@ export namespace Components {
          */
         "yamlSchemaUri": string;
     }
-    interface ChComboBox {
+    interface ChComboBoxRender {
         /**
           * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
          */
@@ -3507,9 +3507,9 @@ export interface ChCheckboxCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLChCheckboxElement;
 }
-export interface ChComboBoxCustomEvent<T> extends CustomEvent<T> {
+export interface ChComboBoxRenderCustomEvent<T> extends CustomEvent<T> {
     detail: T;
-    target: HTMLChComboBoxElement;
+    target: HTMLChComboBoxRenderElement;
 }
 export interface ChDialogCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -3921,23 +3921,23 @@ declare global {
         prototype: HTMLChCodeEditorElement;
         new (): HTMLChCodeEditorElement;
     };
-    interface HTMLChComboBoxElementEventMap {
+    interface HTMLChComboBoxRenderElementEventMap {
         "filterChange": string;
         "input": string;
     }
-    interface HTMLChComboBoxElement extends Components.ChComboBox, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLChComboBoxElementEventMap>(type: K, listener: (this: HTMLChComboBoxElement, ev: ChComboBoxCustomEvent<HTMLChComboBoxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+    interface HTMLChComboBoxRenderElement extends Components.ChComboBoxRender, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLChComboBoxRenderElementEventMap>(type: K, listener: (this: HTMLChComboBoxRenderElement, ev: ChComboBoxRenderCustomEvent<HTMLChComboBoxRenderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLChComboBoxElementEventMap>(type: K, listener: (this: HTMLChComboBoxElement, ev: ChComboBoxCustomEvent<HTMLChComboBoxElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLChComboBoxRenderElementEventMap>(type: K, listener: (this: HTMLChComboBoxRenderElement, ev: ChComboBoxRenderCustomEvent<HTMLChComboBoxRenderElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
         removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
         removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
         removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
-    var HTMLChComboBoxElement: {
-        prototype: HTMLChComboBoxElement;
-        new (): HTMLChComboBoxElement;
+    var HTMLChComboBoxRenderElement: {
+        prototype: HTMLChComboBoxRenderElement;
+        new (): HTMLChComboBoxRenderElement;
     };
     interface HTMLChDialogElementEventMap {
         "dialogClosed": any;
@@ -5391,7 +5391,7 @@ declare global {
         "ch-code": HTMLChCodeElement;
         "ch-code-diff-editor": HTMLChCodeDiffEditorElement;
         "ch-code-editor": HTMLChCodeEditorElement;
-        "ch-combo-box": HTMLChComboBoxElement;
+        "ch-combo-box-render": HTMLChComboBoxRenderElement;
         "ch-dialog": HTMLChDialogElement;
         "ch-dropdown": HTMLChDropdownElement;
         "ch-dropdown-render": HTMLChDropdownRenderElement;
@@ -5996,7 +5996,7 @@ declare namespace LocalJSX {
          */
         "yamlSchemaUri"?: string;
     }
-    interface ChComboBox {
+    interface ChComboBoxRender {
         /**
           * Specifies a short string, typically 1 to 3 words, that authors associate with an element to provide users of assistive technologies with a label for the element.
          */
@@ -6036,11 +6036,11 @@ declare namespace LocalJSX {
         /**
           * Emitted when a change to the element's filter is committed by the user. Only applies if `filterType !== "none"`. It contains the information about the new filter value.  This event is debounced by the `filterDebounce` value.
          */
-        "onFilterChange"?: (event: ChComboBoxCustomEvent<string>) => void;
+        "onFilterChange"?: (event: ChComboBoxRenderCustomEvent<string>) => void;
         /**
           * The `input` event is emitted when a change to the element's value is committed by the user.
          */
-        "onInput"?: (event: ChComboBoxCustomEvent<string>) => void;
+        "onInput"?: (event: ChComboBoxRenderCustomEvent<string>) => void;
         /**
           * A hint to the user of what can be entered in the control. Same as [placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder) attribute for `input` elements.
          */
@@ -8975,7 +8975,7 @@ declare namespace LocalJSX {
         "ch-code": ChCode;
         "ch-code-diff-editor": ChCodeDiffEditor;
         "ch-code-editor": ChCodeEditor;
-        "ch-combo-box": ChComboBox;
+        "ch-combo-box-render": ChComboBoxRender;
         "ch-dialog": ChDialog;
         "ch-dropdown": ChDropdown;
         "ch-dropdown-render": ChDropdownRender;
@@ -9099,7 +9099,7 @@ declare module "@stencil/core" {
             "ch-code": LocalJSX.ChCode & JSXBase.HTMLAttributes<HTMLChCodeElement>;
             "ch-code-diff-editor": LocalJSX.ChCodeDiffEditor & JSXBase.HTMLAttributes<HTMLChCodeDiffEditorElement>;
             "ch-code-editor": LocalJSX.ChCodeEditor & JSXBase.HTMLAttributes<HTMLChCodeEditorElement>;
-            "ch-combo-box": LocalJSX.ChComboBox & JSXBase.HTMLAttributes<HTMLChComboBoxElement>;
+            "ch-combo-box-render": LocalJSX.ChComboBoxRender & JSXBase.HTMLAttributes<HTMLChComboBoxRenderElement>;
             /**
              * The `ch-dialog` component represents a modal or non-modal dialog box or other
              * interactive component.

--- a/src/components/combobox/combo-box.tsx
+++ b/src/components/combobox/combo-box.tsx
@@ -176,9 +176,9 @@ type ImmediateFilter = "immediate" | "debounced" | undefined;
   formAssociated: true,
   shadow: true,
   styleUrl: "combo-box.scss",
-  tag: "ch-combo-box"
+  tag: "ch-combo-box-render"
 })
-export class ChComboBox
+export class ChComboBoxRender
   implements AccessibleNameComponent, DisableableComponent
 {
   #accessibleNameFromExternalLabel: string | undefined;
@@ -409,7 +409,7 @@ export class ChComboBox
 
   @AttachInternals() internals: ElementInternals;
 
-  @Element() el: HTMLChComboBoxElement;
+  @Element() el: HTMLChComboBoxRenderElement;
 
   /**
    * Specifies a short string, typically 1 to 3 words, that authors associate

--- a/src/components/combobox/readme.md
+++ b/src/components/combobox/readme.md
@@ -1,4 +1,4 @@
-# ch-combo-box
+# ch-combo-box-render
 
 <!-- Auto Generated Below -->
 
@@ -73,9 +73,9 @@
 ### Graph
 ```mermaid
 graph TD;
-  ch-combo-box --> ch-popover
-  ch-showcase --> ch-combo-box
-  style ch-combo-box fill:#f9f,stroke:#333,stroke-width:4px
+  ch-combo-box-render --> ch-popover
+  ch-showcase --> ch-combo-box-render
+  style ch-combo-box-render fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
 ----------------------------------------------

--- a/src/components/popover/readme.md
+++ b/src/components/popover/readme.md
@@ -61,14 +61,14 @@ relative to an element, but placed on the top layer using `position: fixed`.
 
 ### Used by
 
- - [ch-combo-box](../combobox)
+ - [ch-combo-box-render](../combobox)
  - [ch-dropdown](../dropdown/internal/dropdown)
  - [ch-showcase](../../showcase/assets/components)
 
 ### Graph
 ```mermaid
 graph TD;
-  ch-combo-box --> ch-popover
+  ch-combo-box-render --> ch-popover
   ch-dropdown --> ch-popover
   ch-showcase --> ch-popover
   style ch-popover fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/showcase/assets/components/combo-box/combo-box.showcase.tsx
+++ b/src/showcase/assets/components/combo-box/combo-box.showcase.tsx
@@ -1,5 +1,5 @@
 import { forceUpdate, h } from "@stencil/core";
-import { ChComboBox } from "../../../../components/combobox/combo-box";
+import { ChComboBoxRender } from "../../../../components/combobox/combo-box";
 import {
   ShowcaseRenderProperties,
   ShowcaseRenderProperty,
@@ -16,12 +16,12 @@ import {
   ComboBoxFilterOptions,
   ComboBoxItemModel
 } from "../../../../components/combobox/types";
-import { ChComboBoxCustomEvent } from "../../../../components";
+import { ChComboBoxRenderCustomEvent } from "../../../../components";
 
-const state: Partial<Mutable<ChComboBox>> = {};
+const state: Partial<Mutable<ChComboBoxRender>> = {};
 let itemsFilteredByTheServer: ComboBoxItemModel[] = [];
 
-const handleFilterChange = (event: ChComboBoxCustomEvent<string>) => {
+const handleFilterChange = (event: ChComboBoxRenderCustomEvent<string>) => {
   // Filters on the client
   if (state.filterOptions.alreadyProcessed !== true) {
     return;
@@ -47,7 +47,7 @@ const render = () => (
     <fieldset class="fieldset-test">
       <legend class="heading-4 field-legend-test">No label</legend>
 
-      <ch-combo-box
+      <ch-combo-box-render
         accessibleName={state.accessibleName}
         placeholder={state.placeholder}
         class="combo-box"
@@ -67,7 +67,7 @@ const render = () => (
         readonly={state.readonly}
         value={state.value}
         onFilterChange={handleFilterChange}
-      ></ch-combo-box>
+      ></ch-combo-box-render>
     </fieldset>
 
     <fieldset class="fieldset-test">
@@ -76,7 +76,7 @@ const render = () => (
       <label class="form-input__label" htmlFor="checkbox-2">
         Label for combo-box 2
       </label>
-      <ch-combo-box
+      <ch-combo-box-render
         id="checkbox-2"
         accessibleName={state.accessibleName}
         placeholder={state.placeholder}
@@ -97,7 +97,7 @@ const render = () => (
         readonly={state.readonly}
         value={state.value}
         onFilterChange={handleFilterChange}
-      ></ch-combo-box>
+      ></ch-combo-box-render>
     </fieldset>
 
     <fieldset class="fieldset-test">
@@ -107,7 +107,7 @@ const render = () => (
 
       <label class="form-input__label" htmlFor="checkbox-3">
         Label for combo-box 3
-        <ch-combo-box
+        <ch-combo-box-render
           id="checkbox-3"
           accessibleName={state.accessibleName}
           placeholder={state.placeholder}
@@ -128,170 +128,171 @@ const render = () => (
           readonly={state.readonly}
           value={state.value}
           onFilterChange={handleFilterChange}
-        ></ch-combo-box>
+        ></ch-combo-box-render>
       </label>
     </fieldset>
   </div>
 );
 
-const showcaseRenderProperties: ShowcaseRenderProperties<Mutable<ChComboBox>> =
-  [
-    {
-      caption: "Models",
-      properties: [
-        {
-          id: "model",
-          accessibleName: "Model",
-          type: "enum",
-          values: [
-            { caption: "Simple Model", value: simpleModel1 },
-            { caption: "Small Model", value: smallModel },
-            { caption: "Data Type Model in GeneXus", value: dataTypeInGeneXus }
-          ],
-          value: simpleModel1
-        }
-      ]
-    },
-    {
-      caption: "Properties",
-      properties: [
-        {
-          id: "accessibleName",
-          caption: "Accessible Name",
-          value: "Option",
-          type: "string"
-        },
-        {
-          id: "placeholder",
-          caption: "Placeholder",
-          value: "Select an option...",
-          type: "string"
-        },
-        {
-          id: "popoverInlineAlign",
-          caption: "Popover Inline Align",
-          value: "inside-start",
-          type: "enum",
-          values: [
-            {
-              value: "outside-start",
-              caption: "outside-start"
-            },
-            {
-              value: "inside-start",
-              caption: "inside-start"
-            },
-            { value: "center", caption: "center" },
-            {
-              value: "inside-end",
-              caption: "inside-end"
-            },
-            {
-              value: "outside-end",
-              caption: "outside-end"
-            }
-          ]
-        },
-        {
-          id: "destroyItemsOnClose",
-          caption: "Destroy Items On Close",
-          value: false,
-          type: "boolean"
-        },
-        {
-          id: "disabled",
-          caption: "Disabled",
-          value: false,
-          type: "boolean"
-        },
-        {
-          id: "readonly",
-          caption: "Readonly",
-          value: false,
-          type: "boolean"
-        }
-      ]
-    },
-    {
-      caption: "Filters",
-      columns: 2,
-      properties: [
-        {
-          id: "filterType",
-          caption: "Filter Type",
-          value: "none",
-          type: "enum",
-          values: [
-            { caption: "None", value: "none" },
-            { caption: "Caption", value: "caption" },
-            { caption: "Value", value: "value" },
-            { caption: "List", value: "list" }
-          ]
-        },
-        {
-          id: "filterDebounce",
-          caption: "Filter Debounce",
-          value: 250,
-          type: "number"
-        },
-        {
-          id: "filter",
-          columnSpan: 2,
-          caption: "Filter",
-          value: "",
-          type: "string"
-        },
-        {
-          id: "filterOptions",
-          type: "object",
-          render: "independent-properties",
-          properties: [
-            {
-              id: "alreadyProcessed",
-              columnSpan: 2,
-              caption: "Items are already filtered / Server filters",
-              value: false,
-              type: "boolean"
-            },
-            {
-              id: "matchCase",
-              columnSpan: 2,
-              caption: "Apply camel casing",
-              value: false,
-              type: "boolean"
-            },
-            {
-              id: "hideMatchesAndShowNonMatches",
-              columnSpan: 2,
-              caption: "Hide matches and show non-matches",
-              value: false,
-              type: "boolean"
-            },
-            {
-              id: "strict",
-              columnSpan: 2,
-              caption: "Strict filter",
-              value: false,
-              type: "boolean"
-            }
-          ] satisfies ShowcaseRenderProperty<ComboBoxFilterOptions>[]
-        }
-      ]
-    }
-  ];
+const showcaseRenderProperties: ShowcaseRenderProperties<
+  Mutable<ChComboBoxRender>
+> = [
+  {
+    caption: "Models",
+    properties: [
+      {
+        id: "model",
+        accessibleName: "Model",
+        type: "enum",
+        values: [
+          { caption: "Simple Model", value: simpleModel1 },
+          { caption: "Small Model", value: smallModel },
+          { caption: "Data Type Model in GeneXus", value: dataTypeInGeneXus }
+        ],
+        value: simpleModel1
+      }
+    ]
+  },
+  {
+    caption: "Properties",
+    properties: [
+      {
+        id: "accessibleName",
+        caption: "Accessible Name",
+        value: "Option",
+        type: "string"
+      },
+      {
+        id: "placeholder",
+        caption: "Placeholder",
+        value: "Select an option...",
+        type: "string"
+      },
+      {
+        id: "popoverInlineAlign",
+        caption: "Popover Inline Align",
+        value: "inside-start",
+        type: "enum",
+        values: [
+          {
+            value: "outside-start",
+            caption: "outside-start"
+          },
+          {
+            value: "inside-start",
+            caption: "inside-start"
+          },
+          { value: "center", caption: "center" },
+          {
+            value: "inside-end",
+            caption: "inside-end"
+          },
+          {
+            value: "outside-end",
+            caption: "outside-end"
+          }
+        ]
+      },
+      {
+        id: "destroyItemsOnClose",
+        caption: "Destroy Items On Close",
+        value: false,
+        type: "boolean"
+      },
+      {
+        id: "disabled",
+        caption: "Disabled",
+        value: false,
+        type: "boolean"
+      },
+      {
+        id: "readonly",
+        caption: "Readonly",
+        value: false,
+        type: "boolean"
+      }
+    ]
+  },
+  {
+    caption: "Filters",
+    columns: 2,
+    properties: [
+      {
+        id: "filterType",
+        caption: "Filter Type",
+        value: "none",
+        type: "enum",
+        values: [
+          { caption: "None", value: "none" },
+          { caption: "Caption", value: "caption" },
+          { caption: "Value", value: "value" },
+          { caption: "List", value: "list" }
+        ]
+      },
+      {
+        id: "filterDebounce",
+        caption: "Filter Debounce",
+        value: 250,
+        type: "number"
+      },
+      {
+        id: "filter",
+        columnSpan: 2,
+        caption: "Filter",
+        value: "",
+        type: "string"
+      },
+      {
+        id: "filterOptions",
+        type: "object",
+        render: "independent-properties",
+        properties: [
+          {
+            id: "alreadyProcessed",
+            columnSpan: 2,
+            caption: "Items are already filtered / Server filters",
+            value: false,
+            type: "boolean"
+          },
+          {
+            id: "matchCase",
+            columnSpan: 2,
+            caption: "Apply camel casing",
+            value: false,
+            type: "boolean"
+          },
+          {
+            id: "hideMatchesAndShowNonMatches",
+            columnSpan: 2,
+            caption: "Hide matches and show non-matches",
+            value: false,
+            type: "boolean"
+          },
+          {
+            id: "strict",
+            columnSpan: 2,
+            caption: "Strict filter",
+            value: false,
+            type: "boolean"
+          }
+        ] satisfies ShowcaseRenderProperty<ComboBoxFilterOptions>[]
+      }
+    ]
+  }
+];
 
-export const comboBoxShowcaseStory: ShowcaseStory<Mutable<ChComboBox>> = {
+export const comboBoxShowcaseStory: ShowcaseStory<Mutable<ChComboBoxRender>> = {
   properties: showcaseRenderProperties,
   markupWithUIModel: {
     uiModel: simpleModel1,
     uiModelType: "ComboBoxModel",
-    render: `<ch-combo-box
+    render: `<ch-combo-box-render
           class="combo-box"
           model={this.#controlUIModel}
           value={<initial value (optional)>}
           onInput={this.#handleValueChange}
           onFilterChange={this.#handleFilterChange}
-        ></ch-combo-box>`
+        ></ch-combo-box-render>`
   },
   render: render,
   state: state

--- a/src/showcase/assets/components/readme.md
+++ b/src/showcase/assets/components/readme.md
@@ -22,7 +22,7 @@
 - [ch-code](../../../components/code)
 - [ch-flexible-layout-render](../../../components/flexible-layout)
 - [ch-checkbox](../../../components/checkbox)
-- [ch-combo-box](../../../components/combobox)
+- [ch-combo-box-render](../../../components/combobox)
 - [ch-radio-group-render](../../../components/radio-group)
 - [ch-action-group-render](../../../components/action-group)
 - [ch-action-list-render](../../../components/action-list)
@@ -48,7 +48,7 @@ graph TD;
   ch-showcase --> ch-code
   ch-showcase --> ch-flexible-layout-render
   ch-showcase --> ch-checkbox
-  ch-showcase --> ch-combo-box
+  ch-showcase --> ch-combo-box-render
   ch-showcase --> ch-radio-group-render
   ch-showcase --> ch-action-group-render
   ch-showcase --> ch-action-list-render
@@ -70,7 +70,7 @@ graph TD;
   ch-flexible-layout-render --> ch-flexible-layout
   ch-flexible-layout --> ch-tab-render
   ch-flexible-layout --> ch-layout-splitter
-  ch-combo-box --> ch-popover
+  ch-combo-box-render --> ch-popover
   ch-action-group-render --> ch-dropdown
   ch-action-group-render --> ch-action-group
   ch-action-group-render --> ch-action-group-item

--- a/src/showcase/assets/components/showcase.tsx
+++ b/src/showcase/assets/components/showcase.tsx
@@ -14,7 +14,7 @@ import {
 } from "./types";
 import { showcaseStories, showcaseCustomStories } from "./showcase-stories";
 import {
-  ChComboBoxCustomEvent,
+  ChComboBoxRenderCustomEvent,
   ChRadioGroupRenderCustomEvent,
   ComboBoxModel,
   FlexibleLayoutModel,
@@ -91,7 +91,9 @@ export class ChShowcase {
         string,
         {
           model: ComboBoxModel;
-          handler: (event: ChComboBoxCustomEvent<string> | InputEvent) => void;
+          handler: (
+            event: ChComboBoxRenderCustomEvent<string> | InputEvent
+          ) => void;
         }
       >
     | undefined;
@@ -176,7 +178,7 @@ export class ChShowcase {
       const eventHandler = (
         event:
           | ChRadioGroupRenderCustomEvent<string>
-          | ChComboBoxCustomEvent<string>
+          | ChComboBoxRenderCustomEvent<string>
           | InputEvent
       ) => {
         showcaseStoryState[propertyGroupId as any] = event.detail;
@@ -592,14 +594,14 @@ export class ChShowcase {
             {property.caption}
           </label>
         ),
-        <ch-combo-box
+        <ch-combo-box-render
           id={propertyGroupId}
           accessibleName={property.accessibleName}
           class="combo-box"
           model={this.#showcaseStoryComboBoxes.get(propertyGroupId).model}
           value={property.value.toString()}
           onInput={this.#showcaseStoryComboBoxes.get(propertyGroupId).handler}
-        ></ch-combo-box>
+        ></ch-combo-box-render>
       ]);
     },
 

--- a/src/showcase/assets/components/types.ts
+++ b/src/showcase/assets/components/types.ts
@@ -4,7 +4,7 @@ import { ChActionListRender } from "../../../components/action-list/action-list-
 import { ChBarcodeScanner } from "../../../components/barcode-scanner/barcode-scanner";
 import { ChCheckBox } from "../../../components/checkbox/checkbox";
 import { ChCode } from "../../../components/code/code";
-import { ChComboBox } from "../../../components/combobox/combo-box";
+import { ChComboBoxRender } from "../../../components/combobox/combo-box";
 import { ChDialog } from "../../../components/dialog/dialog";
 import { ChDropdownRender } from "../../../components/dropdown/dropdown-render";
 import { ChEdit } from "../../../components/edit/edit";
@@ -118,7 +118,7 @@ export type ShowcaseAvailableStories =
   | Mutable<ChBarcodeScanner>
   | Mutable<ChCheckBox>
   | Mutable<ChCode>
-  | Mutable<ChComboBox>
+  | Mutable<ChComboBoxRender>
   | Mutable<ChDialog>
   | Mutable<ChDropdownRender>
   | Mutable<ChEdit>

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -34,7 +34,7 @@ export const config: Config = {
       components: ["ch-code"] // Make sure the ch-code control is not bundled with other components
     },
     {
-      components: ["ch-combo-box"] // Make sure the ch-combo-box control is not bundled with other components
+      components: ["ch-combo-box-render"] // Make sure the ch-combo-box-render control is not bundled with other components
     },
     {
       components: ["ch-dialog"] // Make sure the ch-dialog control is not bundled with other components


### PR DESCRIPTION
This change better matches the naming convention for controls that have a `model` property.

## Breaking changes
 - The `ch-combo-box` control is renamed to `ch-combo-box-render`.
 - `ChComboBox` --> `ChComboBoxRender`
 - `ChComboBoxCustomEvent` --> `ChComboBoxRenderCustomEvent`
 - `HTMLChComboBoxElement` --> `HTMLChComboBoxRenderElement`