### PR TITLE
Fix tab closing issues in the `ch-tab-render` and `ch-flexible-layout-render` controls. Also, reduce memory usage.

### DIFF
--- a/src/components/flexible-layout/internal/flexible-layout/flexible-layout.tsx
+++ b/src/components/flexible-layout/internal/flexible-layout/flexible-layout.tsx
@@ -450,40 +450,53 @@ export class ChFlexibleLayout {
     this.dragBarDisabled = false;
   };
 
-  private renderTab = (viewInfo: FlexibleLayoutLeafInfo<"tabbed">) => (
-    <ch-tab-render
-      id={viewInfo.id}
-      key={viewInfo.id}
-      slot={viewInfo.id}
-      contain={this.contain}
-      class={{
-        [`ch-tab-${viewInfo.tabDirection}--end`]: viewInfo.tabPosition === "end"
-      }}
-      part={`leaf ${viewInfo.tabDirection} ${viewInfo.tabPosition ?? "start"} ${
-        viewInfo.id
-      }`}
-      exportparts={viewInfo.exportParts}
-      closeButton={viewInfo.closeButton ?? this.closeButton}
-      dragOutside={viewInfo.dragOutside ?? this.dragOutside}
-      direction={viewInfo.tabDirection}
-      disabled={viewInfo.disabled}
-      model={viewInfo.widgets}
-      overflow={this.overflow}
-      selectedId={viewInfo.selectedWidgetId}
-      showCaptions={viewInfo.showCaptions}
-      sortable={viewInfo.sortable ?? this.sortable}
-      tabButtonHidden={viewInfo.tabButtonHidden}
-      // onExpandMainGroup={tabType === "main" ? this.handleMainGroupExpand : null}
-      onItemClose={this.handleItemClose(viewInfo.id)}
-      onItemDragStart={this.handleDragStart(viewInfo.id)}
-      onSelectedItemChange={this.handleItemChange(viewInfo.id)}
-    >
-      {viewInfo.widgets.map(
-        widget =>
-          widget.wasRendered && <slot name={widget.id} slot={widget.id} />
-      )}
-    </ch-tab-render>
-  );
+  private renderTab = (viewInfo: FlexibleLayoutLeafInfo<"tabbed">) => {
+    const closeButtonEnabled = viewInfo.closeButton ?? this.closeButton;
+    const dragOutsideEnabled = viewInfo.dragOutside ?? this.dragOutside;
+    const sortableEnabled = viewInfo.sortable ?? this.sortable;
+
+    return (
+      <ch-tab-render
+        id={viewInfo.id}
+        key={viewInfo.id}
+        slot={viewInfo.id}
+        contain={this.contain}
+        class={{
+          [`ch-tab-${viewInfo.tabDirection}--end`]:
+            viewInfo.tabPosition === "end"
+        }}
+        part={`leaf ${viewInfo.tabDirection} ${
+          viewInfo.tabPosition ?? "start"
+        } ${viewInfo.id}`}
+        exportparts={viewInfo.exportParts}
+        closeButton={closeButtonEnabled}
+        dragOutside={dragOutsideEnabled}
+        direction={viewInfo.tabDirection}
+        disabled={viewInfo.disabled}
+        model={viewInfo.widgets}
+        overflow={this.overflow}
+        selectedId={viewInfo.selectedWidgetId}
+        showCaptions={viewInfo.showCaptions}
+        sortable={sortableEnabled}
+        tabButtonHidden={viewInfo.tabButtonHidden}
+        // onExpandMainGroup={tabType === "main" ? this.handleMainGroupExpand : null}
+        onItemClose={
+          closeButtonEnabled ? this.handleItemClose(viewInfo.id) : undefined
+        }
+        onItemDragStart={
+          dragOutsideEnabled && sortableEnabled
+            ? this.handleDragStart(viewInfo.id)
+            : undefined
+        }
+        onSelectedItemChange={this.handleItemChange(viewInfo.id)}
+      >
+        {viewInfo.widgets.map(
+          widget =>
+            widget.wasRendered && <slot name={widget.id} slot={widget.id} />
+        )}
+      </ch-tab-render>
+    );
+  };
 
   private renderView = <T extends FlexibleLayoutLeafType>(
     leaf: FlexibleLayoutLeafInfo<T>

--- a/src/components/flexible-layout/internal/flexible-layout/flexible-layout.tsx
+++ b/src/components/flexible-layout/internal/flexible-layout/flexible-layout.tsx
@@ -280,7 +280,7 @@ export class ChFlexibleLayout {
   //   forceUpdate(this);
   // };
 
-  private handleItemChange =
+  #handleItemChange =
     (viewId: string) =>
     (event: ChTabRenderCustomEvent<TabSelectedItemInfo>) => {
       // Check if the selected item change event comes from a tab of the
@@ -301,7 +301,7 @@ export class ChFlexibleLayout {
       this.selectedViewItemChange.emit(eventInfo);
     };
 
-  private handleItemClose =
+  #handleItemClose =
     (viewId: string) => (event: ChTabRenderCustomEvent<TabItemCloseInfo>) => {
       event.stopPropagation();
 
@@ -319,7 +319,7 @@ export class ChFlexibleLayout {
       }
     };
 
-  private handleDragStart =
+  #handleDragStart =
     (viewId: string) => async (event: ChTabRenderCustomEvent<number>) => {
       event.stopPropagation();
 
@@ -450,7 +450,7 @@ export class ChFlexibleLayout {
     this.dragBarDisabled = false;
   };
 
-  private renderTab = (viewInfo: FlexibleLayoutLeafInfo<"tabbed">) => {
+  #renderTab = (viewInfo: FlexibleLayoutLeafInfo<"tabbed">) => {
     const closeButtonEnabled = viewInfo.closeButton ?? this.closeButton;
     const dragOutsideEnabled = viewInfo.dragOutside ?? this.dragOutside;
     const sortableEnabled = viewInfo.sortable ?? this.sortable;
@@ -481,14 +481,14 @@ export class ChFlexibleLayout {
         tabButtonHidden={viewInfo.tabButtonHidden}
         // onExpandMainGroup={tabType === "main" ? this.handleMainGroupExpand : null}
         onItemClose={
-          closeButtonEnabled ? this.handleItemClose(viewInfo.id) : undefined
+          closeButtonEnabled ? this.#handleItemClose(viewInfo.id) : undefined
         }
         onItemDragStart={
           dragOutsideEnabled && sortableEnabled
-            ? this.handleDragStart(viewInfo.id)
+            ? this.#handleDragStart(viewInfo.id)
             : undefined
         }
-        onSelectedItemChange={this.handleItemChange(viewInfo.id)}
+        onSelectedItemChange={this.#handleItemChange(viewInfo.id)}
       >
         {viewInfo.widgets.map(
           widget =>
@@ -498,13 +498,13 @@ export class ChFlexibleLayout {
     );
   };
 
-  private renderView = <T extends FlexibleLayoutLeafType>(
+  #renderView = <T extends FlexibleLayoutLeafType>(
     leaf: FlexibleLayoutLeafInfo<T>
   ) =>
     leaf.type === "single-content" ? (
       <slot key={leaf.id} slot={leaf.id} name={leaf.id} />
     ) : (
-      this.renderTab(leaf)
+      this.#renderTab(leaf)
     );
 
   render() {
@@ -522,7 +522,7 @@ export class ChFlexibleLayout {
           exportparts={"bar," + this.layoutSplitterParts}
           ref={el => (this.#layoutSplitterRef = el)}
         >
-          {this.#getAllLeafs().map(this.renderView)}
+          {this.#getAllLeafs().map(this.#renderView)}
         </ch-layout-splitter>
 
         <div

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -940,7 +940,11 @@ export class ChTabRender implements DraggableView {
             ? { [DECORATIVE_IMAGE]: `url("${item.startImgSrc}")` }
             : null
         }
-        onAuxClick={!isDisabled ? this.#handleClose(index, item.id) : undefined}
+        onAuxClick={
+          !isDisabled && this.closeButton
+            ? this.#handleClose(index, item.id)
+            : undefined
+        }
         onClick={
           !(item.id === this.selectedId) && !isDisabled
             ? this.#handleSelectedItemChange(index, item.id)

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -44,7 +44,11 @@ import {
   SELECTED_PART
 } from "./utils";
 import { insertIntoIndex, removeElement } from "../../common/array";
-import { focusComposedPath } from "../common/helpers";
+import {
+  focusComposedPath,
+  MouseEventButton,
+  MouseEventButtons
+} from "../common/helpers";
 import { CssContainProperty, CssOverflowProperty } from "../../common/types";
 
 // Custom vars
@@ -810,6 +814,14 @@ export class ChTabRender implements DraggableView {
     });
   };
 
+  #preventMouseDownOnScroll = (event: MouseEvent) => {
+    // We have to prevent the mousedown event to make work the close with the
+    // mouse wheel, because when the page has scroll, the auxClick is not fired
+    if (event.buttons === MouseEventButtons.WHEEL) {
+      event.preventDefault();
+    }
+  };
+
   #handleClose = (index: number, itemId: string) => (event: MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
@@ -939,6 +951,11 @@ export class ChTabRender implements DraggableView {
           isPseudoElementImg(item.startImgSrc, item.startImgType)
             ? { [DECORATIVE_IMAGE]: `url("${item.startImgSrc}")` }
             : null
+        }
+        onMouseDown={
+          !isDisabled && this.closeButton
+            ? this.#preventMouseDownOnScroll
+            : undefined
         }
         onAuxClick={
           !isDisabled && this.closeButton

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -823,6 +823,11 @@ export class ChTabRender implements DraggableView {
   };
 
   #handleClose = (index: number, itemId: string) => (event: MouseEvent) => {
+    // Ensure the auxClick can is not fired with the right click
+    if (event.button !== MouseEventButton.WHEEL) {
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/components/tab/utils.ts
+++ b/src/components/tab/utils.ts
@@ -40,7 +40,6 @@ export const LIST_PART_INLINE = {
 };
 
 // Ids
-export const CAPTION_ID = (name: string) => `caption-${name}`;
 export const PAGE_ID = (name: string) => `page-${name}`;
 
 // Export part functions
@@ -73,7 +72,7 @@ export const BLOCK_START_PARTS = PARTS + ",block,block:start";
 export const BLOCK_END_PARTS = PARTS + ",block,block:end";
 
 export const CAPTION_PARTS = (widgets: FlexibleLayoutWidget[]) =>
-  widgets.map(item => CAPTION_ID(item.id)).join(",");
+  widgets.map(item => item.id).join(",");
 
 export const tabTypeToPart: {
   [key in `${FlexibleLayoutLeafTabDirection}-${FlexibleLayoutLeafTabPosition}`]: (

--- a/src/components/test/test-flexible-layout/renders.tsx
+++ b/src/components/test/test-flexible-layout/renders.tsx
@@ -471,7 +471,7 @@ export const layoutRenders: FlexibleLayoutRenders = {
   ),
   [KB_EXPLORER]: () => (
     <ch-tree-view-render
-      class="tree-view-secondary"
+      class="tree-view tree-view-secondary"
       slot={KB_EXPLORER}
       key={KB_EXPLORER}
       lazyLoadTreeItemsCallback={lazyLoadTreeItems}
@@ -483,7 +483,7 @@ export const layoutRenders: FlexibleLayoutRenders = {
   ),
   [PREFERENCES]: () => (
     <ch-tree-view-render
-      class="tree-view-secondary"
+      class="tree-view tree-view-secondary"
       slot={PREFERENCES}
       key={PREFERENCES}
       dragDisabled={true}
@@ -497,17 +497,7 @@ export const layoutRenders: FlexibleLayoutRenders = {
   ),
   [START_PAGE]: () => (
     <div slot={START_PAGE} key={START_PAGE}>
-      <h1
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          fontSize: "64px",
-          color: "#c5c8c6",
-          "text-align": "center"
-        }}
-      >
-        GeneXus
-      </h1>
+      <h1 class="heading-1 welcome-message">GeneXus</h1>
     </div>
   ),
   [STRUCT_EDITOR]: () => (
@@ -654,7 +644,7 @@ export const layoutRenders: FlexibleLayoutRenders = {
   ),
   [HEAVY_TREE]: () => (
     <ch-tree-view-render
-      class="tree-view-secondary"
+      class="tree-view tree-view-secondary"
       slot={HEAVY_TREE}
       key={HEAVY_TREE}
       dragDisabled={true}
@@ -667,7 +657,7 @@ export const layoutRenders: FlexibleLayoutRenders = {
   ),
   [IMPORT_OBJECTS]: () => (
     <ch-tree-view-render
-      class="tree-view-secondary"
+      class="tree-view tree-view-secondary"
       slot={IMPORT_OBJECTS}
       key={IMPORT_OBJECTS}
       checkbox

--- a/src/components/test/test-flexible-layout/renders.tsx
+++ b/src/components/test/test-flexible-layout/renders.tsx
@@ -497,12 +497,13 @@ export const layoutRenders: FlexibleLayoutRenders = {
   ),
   [START_PAGE]: () => (
     <div slot={START_PAGE} key={START_PAGE}>
-      <h1 class="heading-1 welcome-message">GeneXus</h1>
+      <h2 class="heading-1 welcome-message">GeneXus</h2>
     </div>
   ),
   [STRUCT_EDITOR]: () => (
     <div slot={STRUCT_EDITOR} key={STRUCT_EDITOR}>
-      Grid render... <input type="text" />
+      Grid render...
+      <ch-edit class="form-input" accessibleName="Name" type="text"></ch-edit>
       <ch-grid>
         <ch-grid-columnset>
           <ch-grid-column
@@ -629,12 +630,22 @@ export const layoutRenders: FlexibleLayoutRenders = {
   ),
   [ATTRS_CONTAINERS_AND_OTHERS]: () => (
     <div slot={ATTRS_CONTAINERS_AND_OTHERS} key={ATTRS_CONTAINERS_AND_OTHERS}>
-      Panel AttrsContainersAndOthers <input type="text" />
+      Panel AttrsContainersAndOthers
+      <ch-edit
+        class="form-input"
+        accessibleName="Panel name"
+        type="text"
+      ></ch-edit>
     </div>
   ),
   [PROPERTIES]: () => (
     <div slot={PROPERTIES} key={PROPERTIES}>
-      Properties render... <input type="text" />
+      Properties render...
+      <ch-edit
+        class="form-input"
+        accessibleName="Property name"
+        type="text"
+      ></ch-edit>
     </div>
   ),
   [OUTPUT]: () => (

--- a/src/components/test/test-flexible-layout/test-flexible-layout.scss
+++ b/src/components/test/test-flexible-layout/test-flexible-layout.scss
@@ -6,6 +6,14 @@
 
 ch-test-flexible-layout {
   display: contents;
+
+  .welcome-message {
+    margin-block-start: var(--spacing--l, var(--mer-spacing--md));
+    text-align: center;
+    font-size: 64px;
+    line-height: 80px;
+    opacity: 0.75;
+  }
 }
 
 .flexible-layout {

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,11 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
     />
+    <meta
+      name="description"
+      content="A library of white-label, highly-customizable and reusable web components.
+      "
+    />
     <title>Chameleon</title>
     <link
       rel="icon"

--- a/src/index.html
+++ b/src/index.html
@@ -274,184 +274,180 @@
         setLanguageDirectionInBrowser
       } from "./showcase/models/language-manager.js";
 
-      window.addEventListener("appload", () => {
-        const layoutSplitterRef = document.querySelector("ch-layout-splitter");
-        const treeViewRef = document.querySelector("ch-tree-view-render");
-        const searchInputRef = document.querySelector(".form-input-search");
-        const mainPage = document.querySelector(".main-page");
-        const showcase = document.querySelector("ch-showcase");
-        const home = document.querySelector(".home");
-        const toggleThemeRef = document.getElementById(
-          "segmented-control-theme"
-        );
-        const toggleDSRef = document.getElementById("segmented-control-ds");
-        const toggleRtlRef = document.getElementById("segmented-control-rtl");
-        const chameleonHome = document.getElementById("chameleon-home");
+      const layoutSplitterRef = document.querySelector("ch-layout-splitter");
+      const treeViewRef = document.querySelector("ch-tree-view-render");
+      const searchInputRef = document.querySelector(".form-input-search");
+      const mainPage = document.querySelector(".main-page");
+      const showcase = document.querySelector("ch-showcase");
+      const home = document.querySelector(".home");
+      const toggleThemeRef = document.getElementById("segmented-control-theme");
+      const toggleDSRef = document.getElementById("segmented-control-ds");
+      const toggleRtlRef = document.getElementById("segmented-control-rtl");
+      const chameleonHome = document.getElementById("chameleon-home");
 
-        // Initialize Design Systems
-        toggleDSRef.model = [
-          {
-            id: "unanimo",
-            caption: "Unanimo"
-          },
-          {
-            id: "mercury",
-            caption: "Mercury"
+      // Initialize Design Systems
+      toggleDSRef.model = [
+        {
+          id: "unanimo",
+          caption: "Unanimo"
+        },
+        {
+          id: "mercury",
+          caption: "Mercury"
+        }
+      ];
+
+      // Initialize themes
+      toggleThemeRef.model = [
+        {
+          id: "light",
+          caption: "Light"
+        },
+        {
+          id: "dark",
+          caption: "Dark"
+        }
+      ];
+
+      // Initialize language directions
+      toggleRtlRef.model = [
+        {
+          id: "ltr",
+          caption: "LTR"
+        },
+        {
+          id: "rtl",
+          caption: "RTL"
+        }
+      ];
+
+      toggleDSRef.selectedId = getDesignSystem();
+      toggleThemeRef.selectedId = getTheme();
+      toggleRtlRef.selectedId = getLanguageDirection();
+
+      const setMainPage = () => {
+        mainPage.hidden = false;
+        showcase.hidden = true;
+        showcase.componentName = undefined;
+        showcase.pageSrc = undefined;
+      };
+
+      const setPage = () => {
+        if (window.location.hash && window.location.hash !== "#") {
+          const componentName = window.location.hash.replace("#", "");
+          const treeItemInformation = treeViewComponents.find(
+            treeItem => treeItem.id === componentName
+          );
+
+          // If the hash is a valid page
+          if (treeItemInformation) {
+            showcase.componentName = componentName;
+            showcase.pageSrc = `showcase/pages/${componentName}.html`;
+            showcase.pageName = treeItemInformation.caption;
+            showcase.status = `(${
+              treeItemInformation.metadata.split("---")[1]
+            })`;
+
+            mainPage.hidden = true;
+            showcase.hidden = false;
+
+            // Mark the new selected item in the Tree View
+            treeViewRef.updateItemsProperties([componentName], {
+              selected: true
+            });
+            return;
           }
-        ];
+        }
 
-        // Initialize themes
-        toggleThemeRef.model = [
-          {
-            id: "light",
-            caption: "Light"
-          },
-          {
-            id: "dark",
-            caption: "Dark"
-          }
-        ];
+        // Go to Main page
+        setMainPage();
+      };
 
-        // Initialize language directions
-        toggleRtlRef.model = [
-          {
-            id: "ltr",
-            caption: "LTR"
-          },
-          {
-            id: "rtl",
-            caption: "RTL"
-          }
-        ];
+      // Initialize sample
+      setPage();
 
-        toggleDSRef.selectedId = getDesignSystem();
-        toggleThemeRef.selectedId = getTheme();
-        toggleRtlRef.selectedId = getLanguageDirection();
-
-        const setMainPage = () => {
-          mainPage.hidden = false;
-          showcase.hidden = true;
-          showcase.componentName = undefined;
-          showcase.pageSrc = undefined;
-        };
-
-        const setPage = () => {
-          if (window.location.hash && window.location.hash !== "#") {
-            const componentName = window.location.hash.replace("#", "");
-            const treeItemInformation = treeViewComponents.find(
-              treeItem => treeItem.id === componentName
-            );
-
-            // If the hash is a valid page
-            if (treeItemInformation) {
-              showcase.componentName = componentName;
-              showcase.pageSrc = `showcase/pages/${componentName}.html`;
-              showcase.pageName = treeItemInformation.caption;
-              showcase.status = `(${
-                treeItemInformation.metadata.split("---")[1]
-              })`;
-
-              mainPage.hidden = true;
-              showcase.hidden = false;
-
-              // Mark the new selected item in the Tree View
-              treeViewRef.updateItemsProperties([componentName], {
-                selected: true
-              });
-              return;
-            }
-          }
-
-          // Go to Main page
-          setMainPage();
-        };
-
-        // Initialize sample
-        setPage();
-
-        // WA to reset the page when clicking in the logo
-        chameleonHome.addEventListener("click", () => {
-          mainPage.hidden = false;
-          showcase.hidden = true;
-          showcase.componentName = undefined;
-          showcase.pageSrc = undefined;
-        });
-
-        // Add event lister for the design system changes
-        toggleDSRef.addEventListener("selectedItemChange", () => {
-          const newDS = getDesignSystem() === "unanimo" ? "mercury" : "unanimo";
-
-          storeDesignSystem(newDS);
-          setDesignSystemInBrowser(newDS);
-          showcase.designSystem = newDS;
-        });
-
-        // Add event lister for the color scheme changes
-        toggleThemeRef.addEventListener("selectedItemChange", () => {
-          const colorScheme = getTheme() === "light" ? "dark" : "light";
-
-          storeTheme(colorScheme);
-          setThemeInBrowser(colorScheme);
-          showcase.colorScheme = colorScheme;
-        });
-
-        // Add event lister for the language direction changes
-        toggleRtlRef.addEventListener("selectedItemChange", () => {
-          const newLanguageDirection =
-            getLanguageDirection() === "rtl" ? "ltr" : "rtl";
-
-          storeLanguageDirection(newLanguageDirection);
-          setLanguageDirectionInBrowser(newLanguageDirection);
-        });
-
-        const layoutSplitterModel = {
-          id: "root",
-          direction: "rows",
-          items: [
-            { id: "header", size: "48px", dragBar: { hidden: true } },
-            {
-              id: "content",
-              direction: "columns",
-              size: "1fr",
-              items: [
-                {
-                  id: "aside",
-                  size: "250px",
-                  minSize: "235px",
-                  dragBar: {
-                    hidden: false,
-                    size: 1
-                  }
-                },
-                {
-                  id: "main",
-                  size: "1fr",
-                  minSize: "500px"
-                }
-              ]
-            }
-          ]
-        };
-
-        layoutSplitterRef.model = layoutSplitterModel;
-        treeViewRef.model = treeViewComponents;
-
-        searchInputRef.addEventListener("input", () => {
-          treeViewRef.filter = searchInputRef.value;
-        });
-
-        // When the selected item of the Tree View changes, the main page must be updated
-        treeViewRef.addEventListener("selectedItemsChange", () => {
-          if (event.detail?.length > 0) {
-            const componentName = event.detail[0].item.id;
-
-            // This is a WA until we have the ch-navigation-list component
-            window.location.hash = `#${componentName}`;
-          }
-        });
-
-        window.addEventListener("hashchange", setPage);
+      // WA to reset the page when clicking in the logo
+      chameleonHome.addEventListener("click", () => {
+        mainPage.hidden = false;
+        showcase.hidden = true;
+        showcase.componentName = undefined;
+        showcase.pageSrc = undefined;
       });
+
+      // Add event lister for the design system changes
+      toggleDSRef.addEventListener("selectedItemChange", () => {
+        const newDS = getDesignSystem() === "unanimo" ? "mercury" : "unanimo";
+
+        storeDesignSystem(newDS);
+        setDesignSystemInBrowser(newDS);
+        showcase.designSystem = newDS;
+      });
+
+      // Add event lister for the color scheme changes
+      toggleThemeRef.addEventListener("selectedItemChange", () => {
+        const colorScheme = getTheme() === "light" ? "dark" : "light";
+
+        storeTheme(colorScheme);
+        setThemeInBrowser(colorScheme);
+        showcase.colorScheme = colorScheme;
+      });
+
+      // Add event lister for the language direction changes
+      toggleRtlRef.addEventListener("selectedItemChange", () => {
+        const newLanguageDirection =
+          getLanguageDirection() === "rtl" ? "ltr" : "rtl";
+
+        storeLanguageDirection(newLanguageDirection);
+        setLanguageDirectionInBrowser(newLanguageDirection);
+      });
+
+      const layoutSplitterModel = {
+        id: "root",
+        direction: "rows",
+        items: [
+          { id: "header", size: "48px", dragBar: { hidden: true } },
+          {
+            id: "content",
+            direction: "columns",
+            size: "1fr",
+            items: [
+              {
+                id: "aside",
+                size: "250px",
+                minSize: "235px",
+                dragBar: {
+                  hidden: false,
+                  size: 1
+                }
+              },
+              {
+                id: "main",
+                size: "1fr",
+                minSize: "500px"
+              }
+            ]
+          }
+        ]
+      };
+
+      layoutSplitterRef.model = layoutSplitterModel;
+      treeViewRef.model = treeViewComponents;
+
+      searchInputRef.addEventListener("input", () => {
+        treeViewRef.filter = searchInputRef.value;
+      });
+
+      // When the selected item of the Tree View changes, the main page must be updated
+      treeViewRef.addEventListener("selectedItemsChange", () => {
+        if (event.detail?.length > 0) {
+          const componentName = event.detail[0].item.id;
+
+          // This is a WA until we have the ch-navigation-list component
+          window.location.hash = `#${componentName}`;
+        }
+      });
+
+      window.addEventListener("hashchange", setPage);
     </script>
   </body>
 </html>

--- a/src/showcase/assets/components/showcase.tsx
+++ b/src/showcase/assets/components/showcase.tsx
@@ -48,7 +48,6 @@ const flexibleLayoutConfiguration: FlexibleLayoutModel = {
   items: [
     {
       id: MAIN_WIDGET,
-      closeButton: true,
       size: "1fr",
       minSize: "220px",
       selectedWidgetId: MAIN_WIDGET,
@@ -492,6 +491,8 @@ export class ChShowcase {
   #customShowcaseRender = () =>
     this.#showcaseStory ? (
       <ch-flexible-layout-render
+        // TODO: Fix error when adding the closeButton and closing the last item
+        closeButton
         model={flexibleLayoutConfiguration}
         renders={this.#flexibleLayoutRender}
         ref={el => (this.#flexibleLayoutRef = el)}
@@ -760,7 +761,7 @@ export class ChShowcase {
 
     return (
       <Host>
-        <h1 class="heading-1">
+        <h1>
           {this.pageName} {this.status}
         </h1>
 

--- a/src/showcase/assets/components/showcase.tsx
+++ b/src/showcase/assets/components/showcase.tsx
@@ -492,7 +492,6 @@ export class ChShowcase {
     this.#showcaseStory ? (
       <ch-flexible-layout-render
         // TODO: Fix error when adding the closeButton and closing the last item
-        closeButton
         model={flexibleLayoutConfiguration}
         renders={this.#flexibleLayoutRender}
         ref={el => (this.#flexibleLayoutRef = el)}
@@ -761,7 +760,7 @@ export class ChShowcase {
 
     return (
       <Host>
-        <h1>
+        <h1 class="heading-1">
           {this.pageName} {this.status}
         </h1>
 

--- a/src/showcase/assets/components/tab/tab.showcase.tsx
+++ b/src/showcase/assets/components/tab/tab.showcase.tsx
@@ -101,7 +101,7 @@ const render = () => (
       >
         {renderedItems.has("item1") && (
           <ch-tree-view-render
-            class="tree-view-secondary"
+            class="tree-view tree-view-secondary"
             slot="item1"
             showLines="last"
             model={kbExplorerModel}
@@ -111,7 +111,7 @@ const render = () => (
 
         {renderedItems.has("item2") && (
           <ch-tree-view-render
-            class="tree-view-secondary"
+            class="tree-view tree-view-secondary"
             slot="item2"
             showLines="last"
             model={preferencesModel}

--- a/src/showcase/index.css
+++ b/src/showcase/index.css
@@ -163,10 +163,6 @@ header {
   margin: var(--spacing--l, var(--mer-spacing--md));
 }
 
-.heading-1 {
-  margin-block-end: var(--spacing--m, var(--mer-spacing--xs));
-}
-
 .heading-2 {
   display: grid;
   grid-template-columns: max-content max-content;


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fix disabled `closeButton` not working on the `ch-flexible-layout-render`.

 - Fix tab closing not working when the container has scroll.

 - Fix tab closing working with the right click.

 - Reduce memory consumption by implementing event delegation.

## Breaking changes
 - Removed the `caption-` prefix of the tab button part. Now the part only contains the item ID.