### PR TITLE
Add support to determine the expanded size of the `ch-accordion-render` items

### DIFF
--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -61,8 +61,12 @@
    */
   --ch-accordion__header-background-image: #{$expandable-icon};
 
+  --ch-accordion-grid-template-rows: 1fr;
+
   display: grid;
-  grid-auto-rows: max-content;
+  grid-template-rows: var(--ch-accordion-grid-template-rows);
+  transition: grid-template-rows var(--ch-accordion-expand-collapse-duration)
+    var(--ch-accordion-expand-collapse-timing-function);
 
   // Avoid unnecessary click events in the Host
   pointer-events: none;

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -13,7 +13,8 @@ import {
 import {
   AccordionItemModel,
   AccordionItemExpandedChangeEvent,
-  AccordionModel
+  AccordionModel,
+  AccordionItemModelExpandedSize
 } from "./types";
 import { tokenMap, updateDirectionInImageCustomVar } from "../../common/utils";
 import {
@@ -311,6 +312,18 @@ export class ChAccordionRender implements ComponentInterface {
     this.#expandedItems.add(lastItemId);
   };
 
+  #computeGridTemplateRows = () =>
+    this.model
+      .map(item =>
+        item.expanded
+          ? item.expandedSize ?? "max-content"
+          : this.#getCollapsedSizeForUnit(item.expandedSize)
+      )
+      .join(" ");
+
+  #getCollapsedSizeForUnit = (expandedSize: AccordionItemModelExpandedSize) =>
+    expandedSize && expandedSize.includes("fr") ? "0fr" : "max-content";
+
   connectedCallback(): void {
     // Initialize default getImagePathCallback
     GET_IMAGE_PATH_CALLBACK_REGISTRY ??=
@@ -336,6 +349,14 @@ export class ChAccordionRender implements ComponentInterface {
       <Host
         // TODO: Add support to prevent expand/collapse when pressing the space
         // key on an input/textarea
+        style={
+          this.model != null
+            ? {
+                "--ch-accordion-grid-template-rows":
+                  this.#computeGridTemplateRows()
+              }
+            : undefined
+        }
         onClick={this.#handleHeaderToggle}
       >
         {(this.model ?? []).map(this.#renderItem)}

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -11,7 +11,7 @@ import {
   h
 } from "@stencil/core";
 import {
-  AccordionItem,
+  AccordionItemModel,
   AccordionItemExpandedChangeEvent,
   AccordionModel
 } from "./types";
@@ -175,7 +175,7 @@ export class ChAccordionRender implements ComponentInterface {
   };
 
   #updateExpandedOnItem = (
-    itemUIModel: AccordionItem,
+    itemUIModel: AccordionItemModel,
     newExpandedValue: boolean
   ) => {
     // Collapse all opened items and emit expandedChange
@@ -216,7 +216,7 @@ export class ChAccordionRender implements ComponentInterface {
     forceUpdate(this);
   };
 
-  #renderItem = (item: AccordionItem, index: number) => {
+  #renderItem = (item: AccordionItemModel, index: number) => {
     const startImage = this.#images.get(item.id);
     const startImageClasses = startImage?.classes;
     const isDisabled = item.disabled ?? this.disabled;

--- a/src/components/accordion/readme.md
+++ b/src/components/accordion/readme.md
@@ -11,7 +11,7 @@
 | ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- | ----------- |
 | `disabled`             | `disabled`             | This attribute lets you specify if all accordions are disabled. If disabled,accordions will not fire any user interaction related event (for example, `expandedChange` event). | `boolean`                                 | `false`     |
 | `getImagePathCallback` | --                     | This property specifies a callback that is executed when the path for an startImgSrc needs to be resolved.                                                                     | `(imageSrc: string) => GxImageMultiState` | `undefined` |
-| `model`                | --                     | Specifies the items of the control.                                                                                                                                            | `AccordionItem[]`                         | `undefined` |
+| `model`                | --                     | Specifies the items of the control.                                                                                                                                            | `AccordionItemModel[]`                    | `undefined` |
 | `singleItemExpanded`   | `single-item-expanded` | If `true` only one item will be expanded at the same time.                                                                                                                     | `boolean`                                 | `false`     |
 
 

--- a/src/components/accordion/tests/accordion.e2e.ts
+++ b/src/components/accordion/tests/accordion.e2e.ts
@@ -26,6 +26,14 @@ describe("[ch-accordion-render]", () => {
     duration?: string;
     timingFunction?: string;
   }) => {
+    const accordionComputedStyle = await accordionRef.getComputedStyle();
+
+    expect(accordionComputedStyle.transition).toEqual(
+      `grid-template-rows ${options.duration ?? "0s"} ${
+        options.timingFunction ?? "linear"
+      } 0s`
+    );
+
     const panelRef = await page.find("ch-accordion-render >>> .panel");
     const panelComputedStyle = await panelRef.getComputedStyle();
 

--- a/src/components/accordion/tests/expanded-size.e2e.ts
+++ b/src/components/accordion/tests/expanded-size.e2e.ts
@@ -1,0 +1,143 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import {
+  accordionSimpleModel,
+  accordionWithExpandedSizeModel
+} from "../../../showcase/assets/components/accordion/models";
+
+describe("[ch-accordion-render][expandedSize]", () => {
+  let page: E2EPage;
+  let accordionRef: E2EElement;
+
+  const getGridTemplateRowsValue = () =>
+    page.evaluate(() =>
+      getComputedStyle(
+        document.querySelector("ch-accordion-render")
+      ).getPropertyValue("--ch-accordion-grid-template-rows")
+    );
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-accordion-render></ch-accordion-render>`,
+      failOnConsoleError: true
+    });
+    accordionRef = await page.find("ch-accordion-render");
+    accordionRef.setProperty("model", accordionWithExpandedSizeModel);
+    await page.waitForChanges();
+  });
+
+  it('should set "1fr" in the "--ch-accordion-grid-template-rows" custom var if the model is empty', async () => {
+    accordionRef.setProperty("model", []);
+    await page.waitForChanges();
+
+    expect(await getGridTemplateRowsValue()).toBe("1fr");
+  });
+
+  it('should set "1fr" in the "--ch-accordion-grid-template-rows" custom var if the model is undefined', async () => {
+    accordionRef.setProperty("model", undefined);
+    await page.waitForChanges();
+
+    expect(await getGridTemplateRowsValue()).toBe("1fr");
+  });
+
+  it('should set "1fr" in the "--ch-accordion-grid-template-rows" custom var if the model is null', async () => {
+    accordionRef.setProperty("model", null);
+    await page.waitForChanges();
+
+    expect(await getGridTemplateRowsValue()).toBe("1fr");
+  });
+
+  it('should render "max-content" if no expandedSize and "0fr" when collapsed', async () => {
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 0fr");
+  });
+
+  it("should set the expanded size when an item is expanded and has expandedSize", async () => {
+    await page.click('ch-accordion-render >>> [part="item 4 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 1fr");
+
+    await page.click('ch-accordion-render >>> [part="item 3 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 1fr 1fr");
+  });
+
+  it('should restore to "0fr" when collapsing and item with expandedSize', async () => {
+    await page.click('ch-accordion-render >>> [part="item 4 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 1fr");
+
+    await page.click('ch-accordion-render >>> [part="item 4 panel expanded"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 0fr");
+  });
+
+  it('should set "max-content" when the item does not have expandedSize, even if it is expanded', async () => {
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 0fr");
+
+    await page.click('ch-accordion-render >>> [part="item 1 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 0fr");
+  });
+
+  it('should update the "--ch-accordion-grid-template-rows" custom var when updating the model at runtime', async () => {
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 0fr");
+
+    await page.click('ch-accordion-render >>> [part="item 2 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0.5fr 0fr 0fr");
+
+    accordionRef.setProperty("model", accordionSimpleModel);
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe(
+      "max-content max-content max-content max-content"
+    );
+  });
+
+  it('should properly work items with expandedSize and the "singleItemExpanded" property', async () => {
+    accordionRef.setProperty("singleItemExpanded", true);
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 0fr");
+
+    await page.click('ch-accordion-render >>> [part="item 4 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 1fr");
+
+    await page.click('ch-accordion-render >>> [part="item 3 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 1fr 0fr");
+
+    await page.click('ch-accordion-render >>> [part="item 1 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 0fr");
+  });
+
+  it('should properly work when setting the "singleItemExpanded" property at runtime', async () => {
+    await page.click('ch-accordion-render >>> [part="item 4 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 1fr");
+
+    await page.click('ch-accordion-render >>> [part="item 3 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 1fr 1fr");
+
+    accordionRef.setProperty("singleItemExpanded", true);
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 1fr 0fr");
+  });
+
+  it('should properly work when removing the "singleItemExpanded" property at runtime', async () => {
+    accordionRef.setProperty("singleItemExpanded", true);
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 0fr");
+
+    await page.click('ch-accordion-render >>> [part="item 4 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0fr 0fr 1fr");
+
+    accordionRef.setProperty("singleItemExpanded", false);
+    await page.waitForChanges();
+
+    await page.click('ch-accordion-render >>> [part="item 2 panel collapsed"]');
+    await page.waitForChanges();
+    expect(await getGridTemplateRowsValue()).toBe("max-content 0.5fr 0fr 1fr");
+  });
+});

--- a/src/components/accordion/types.ts
+++ b/src/components/accordion/types.ts
@@ -1,8 +1,8 @@
 import { ImageRender } from "../../common/types";
 
-export type AccordionModel = AccordionItem[];
+export type AccordionModel = AccordionItemModel[];
 
-export type AccordionItem = {
+export type AccordionItemModel = {
   id: string;
   accessibleName?: string;
   caption: string;

--- a/src/components/accordion/types.ts
+++ b/src/components/accordion/types.ts
@@ -8,6 +8,13 @@ export type AccordionItemModel = {
   caption: string;
   disabled?: boolean;
   expanded?: boolean;
+
+  /**
+   * Determine the expanded size of the item. It support CSS units, including fr
+   * units.
+   */
+  expandedSize?: AccordionItemModelExpandedSize;
+
   headerSlotId?: string;
   startImgSrc?: string;
   startImgType?: Exclude<ImageRender, "img">;
@@ -17,3 +24,8 @@ export type AccordionItemExpandedChangeEvent = {
   id: string;
   expanded: boolean;
 };
+
+export type AccordionItemModelExpandedSize =
+  `${number}${AccordionItemModelExpandedSizeUnit}`;
+
+export type AccordionItemModelExpandedSizeUnit = "fr";

--- a/src/showcase/assets/components/accordion/accordion.showcase.tsx
+++ b/src/showcase/assets/components/accordion/accordion.showcase.tsx
@@ -1,6 +1,10 @@
 import { forceUpdate, h } from "@stencil/core";
 import { ShowcaseRenderProperties, ShowcaseStory } from "../types";
-import { accordionDisabledModel, accordionSimpleModel } from "./models";
+import {
+  accordionDisabledModel,
+  accordionSimpleModel,
+  accordionWithExpandedSizeModel
+} from "./models";
 import {
   AccordionItemExpandedChangeEvent,
   ChAccordionRenderCustomEvent
@@ -109,7 +113,11 @@ const showcaseRenderProperties: ShowcaseRenderProperties<HTMLChAccordionRenderEl
           value: accordionSimpleModel,
           values: [
             { caption: "Simple model", value: accordionSimpleModel },
-            { caption: "Disabled model", value: accordionDisabledModel }
+            { caption: "Disabled model", value: accordionDisabledModel },
+            {
+              caption: "Expanded size model",
+              value: accordionWithExpandedSizeModel
+            }
           ]
         },
         {

--- a/src/showcase/assets/components/accordion/models.ts
+++ b/src/showcase/assets/components/accordion/models.ts
@@ -18,6 +18,27 @@ export const accordionDisabledModel: AccordionModel = [
   { id: "item 4", caption: "Item 4", headerSlotId: "item 4 header" }
 ];
 
+export const accordionWithExpandedSizeModel: AccordionModel = [
+  {
+    id: "item 1",
+    caption: "Item 1",
+    startImgSrc: FOLDER_ICON
+  },
+  {
+    id: "item 2",
+    caption: "Item 2",
+    startImgSrc: MODULE_ICON,
+    expandedSize: "0.5fr"
+  },
+  { id: "item 3", caption: "Item 3", expandedSize: "1fr" },
+  {
+    id: "item 4",
+    caption: "Item 4",
+    headerSlotId: "item 4 header",
+    expandedSize: "1fr"
+  }
+];
+
 export const getAccordionPathCallbackEdit = (
   startImgSrc: string
 ): GxImageMultiState => {


### PR DESCRIPTION
## Breaking changes
 - Renamed the `AccordionItem` type to `AccordionItemModel`.