### PR TITLE
Fixes and improvements for the `ch-navigation-list-render` component

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -156,5 +156,5 @@ export type ChameleonImagePathCallbackControls = {
 };
 
 export type ItemLink = {
-  url: string;
+  url?: string;
 };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -156,5 +156,5 @@ export type ChameleonImagePathCallbackControls = {
 };
 
 export type ItemLink = {
-  url?: string;
+  url: string;
 };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -7,6 +7,8 @@ import {
   ImageRender
 } from "./types";
 
+const VALID_CSS_URL_PATH_REGEX = /^\s*(var\(|url\()/;
+
 export function debounce(
   func: () => void,
   wait: number,
@@ -242,6 +244,12 @@ export const unsubscribeToRTLChanges = (subscriberId: string) => {
   }
 };
 
+// TODO: Test more use cases
+export const formatImagePath = <T extends string>(imageSrc: T) =>
+  VALID_CSS_URL_PATH_REGEX.test(imageSrc)
+    ? imageSrc
+    : (`url(${imageSrc})` as const);
+
 export const updateDirectionInImageCustomVar = <T extends "start" | "end">(
   image: GxImageMultiState | undefined,
   direction: T
@@ -259,23 +267,23 @@ export const updateDirectionInImageCustomVar = <T extends "start" | "end">(
     let states = "start-img--base";
 
     const startImg: GxImageMultiStateStartStyles = {
-      "--ch-start-img--base": image.base
+      "--ch-start-img--base": formatImagePath(image.base)
     };
 
     if (image.active) {
-      startImg["--ch-start-img--active"] = image.active;
+      startImg["--ch-start-img--active"] = formatImagePath(image.active);
       states += " start-img--active";
     }
     if (image.focus) {
-      startImg["--ch-start-img--focus"] = image.focus;
+      startImg["--ch-start-img--focus"] = formatImagePath(image.focus);
       states += " start-img--focus";
     }
     if (image.hover) {
-      startImg["--ch-start-img--hover"] = image.hover;
+      startImg["--ch-start-img--hover"] = formatImagePath(image.hover);
       states += " start-img--hover";
     }
     if (image.disabled) {
-      startImg["--ch-start-img--disabled"] = image.disabled;
+      startImg["--ch-start-img--disabled"] = formatImagePath(image.disabled);
       states += " start-img--disabled";
     }
 
@@ -284,23 +292,23 @@ export const updateDirectionInImageCustomVar = <T extends "start" | "end">(
 
   let states = "end-img--base";
   const endImg: GxImageMultiStateEndStyles = {
-    "--ch-end-img--base": image.base
+    "--ch-end-img--base": formatImagePath(image.base)
   };
 
   if (image.active) {
-    endImg["--ch-end-img--active"] = image.active;
+    endImg["--ch-end-img--active"] = formatImagePath(image.active);
     states += " end-img--active";
   }
   if (image.focus) {
-    endImg["--ch-end-img--focus"] = image.focus;
+    endImg["--ch-end-img--focus"] = formatImagePath(image.focus);
     states += " end-img--focus";
   }
   if (image.hover) {
-    endImg["--ch-end-img--hover"] = image.hover;
+    endImg["--ch-end-img--hover"] = formatImagePath(image.hover);
     states += " end-img--hover";
   }
   if (image.disabled) {
-    endImg["--ch-end-img--disabled"] = image.disabled;
+    endImg["--ch-end-img--disabled"] = formatImagePath(image.disabled);
     states += " end-img--disabled";
   }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -245,14 +245,18 @@ export const unsubscribeToRTLChanges = (subscriberId: string) => {
 };
 
 // TODO: Test more use cases
-export const formatImagePath = <T extends string>(imageSrc: T) =>
-  VALID_CSS_URL_PATH_REGEX.test(imageSrc)
+export const formatImagePath = <T extends string | undefined>(
+  imageSrc: T,
+  imageType: ImageRender
+) =>
+  !imageSrc || imageType === "img" || VALID_CSS_URL_PATH_REGEX.test(imageSrc)
     ? imageSrc
     : (`url(${imageSrc})` as const);
 
 export const updateDirectionInImageCustomVar = <T extends "start" | "end">(
   image: GxImageMultiState | undefined,
-  direction: T
+  direction: T,
+  imageType: ImageRender = "background"
 ):
   | {
       classes: string;
@@ -267,23 +271,35 @@ export const updateDirectionInImageCustomVar = <T extends "start" | "end">(
     let states = "start-img--base";
 
     const startImg: GxImageMultiStateStartStyles = {
-      "--ch-start-img--base": formatImagePath(image.base)
+      "--ch-start-img--base": formatImagePath(image.base, imageType)
     };
 
     if (image.active) {
-      startImg["--ch-start-img--active"] = formatImagePath(image.active);
+      startImg["--ch-start-img--active"] = formatImagePath(
+        image.active,
+        imageType
+      );
       states += " start-img--active";
     }
     if (image.focus) {
-      startImg["--ch-start-img--focus"] = formatImagePath(image.focus);
+      startImg["--ch-start-img--focus"] = formatImagePath(
+        image.focus,
+        imageType
+      );
       states += " start-img--focus";
     }
     if (image.hover) {
-      startImg["--ch-start-img--hover"] = formatImagePath(image.hover);
+      startImg["--ch-start-img--hover"] = formatImagePath(
+        image.hover,
+        imageType
+      );
       states += " start-img--hover";
     }
     if (image.disabled) {
-      startImg["--ch-start-img--disabled"] = formatImagePath(image.disabled);
+      startImg["--ch-start-img--disabled"] = formatImagePath(
+        image.disabled,
+        imageType
+      );
       states += " start-img--disabled";
     }
 
@@ -292,23 +308,26 @@ export const updateDirectionInImageCustomVar = <T extends "start" | "end">(
 
   let states = "end-img--base";
   const endImg: GxImageMultiStateEndStyles = {
-    "--ch-end-img--base": formatImagePath(image.base)
+    "--ch-end-img--base": formatImagePath(image.base, imageType)
   };
 
   if (image.active) {
-    endImg["--ch-end-img--active"] = formatImagePath(image.active);
+    endImg["--ch-end-img--active"] = formatImagePath(image.active, imageType);
     states += " end-img--active";
   }
   if (image.focus) {
-    endImg["--ch-end-img--focus"] = formatImagePath(image.focus);
+    endImg["--ch-end-img--focus"] = formatImagePath(image.focus, imageType);
     states += " end-img--focus";
   }
   if (image.hover) {
-    endImg["--ch-end-img--hover"] = formatImagePath(image.hover);
+    endImg["--ch-end-img--hover"] = formatImagePath(image.hover, imageType);
     states += " end-img--hover";
   }
   if (image.disabled) {
-    endImg["--ch-end-img--disabled"] = formatImagePath(image.disabled);
+    endImg["--ch-end-img--disabled"] = formatImagePath(
+      image.disabled,
+      imageType
+    );
     states += " end-img--disabled";
   }
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -30,7 +30,7 @@ import { Color, Size } from "./deprecated-components/icon/icon";
 import { GroupExtended, LayoutSplitterItemAddResult, LayoutSplitterItemRemoveResult, LayoutSplitterLeafModel, LayoutSplitterModel } from "./components/layout-splitter/types";
 import { MarkdownCodeRender } from "./deprecated-components/markdown/parsers/types";
 import { MarkdownViewerCodeRender } from "./components/markdown-viewer/parsers/types";
-import { NavigationListItemModel, NavigationListModel } from "./components/navigation-list/types";
+import { NavigationListHyperlinkClickEvent, NavigationListItemModel, NavigationListModel } from "./components/navigation-list/types";
 import { DataModelItemLabels, EntityInfo, ErrorText, ItemInfo, Mode } from "./components/next/data-modeling-item/next-data-modeling-item";
 import { DataModel, EntityItem, EntityItemType, EntityNameToATTs } from "./components/next/data-modeling/data-model";
 import { DataModelItemLabels as DataModelItemLabels1, ErrorText as ErrorText1 } from "./components/next/data-modeling-item/next-data-modeling-item";
@@ -89,7 +89,7 @@ export { Color, Size } from "./deprecated-components/icon/icon";
 export { GroupExtended, LayoutSplitterItemAddResult, LayoutSplitterItemRemoveResult, LayoutSplitterLeafModel, LayoutSplitterModel } from "./components/layout-splitter/types";
 export { MarkdownCodeRender } from "./deprecated-components/markdown/parsers/types";
 export { MarkdownViewerCodeRender } from "./components/markdown-viewer/parsers/types";
-export { NavigationListItemModel, NavigationListModel } from "./components/navigation-list/types";
+export { NavigationListHyperlinkClickEvent, NavigationListItemModel, NavigationListModel } from "./components/navigation-list/types";
 export { DataModelItemLabels, EntityInfo, ErrorText, ItemInfo, Mode } from "./components/next/data-modeling-item/next-data-modeling-item";
 export { DataModel, EntityItem, EntityItemType, EntityNameToATTs } from "./components/next/data-modeling/data-model";
 export { DataModelItemLabels as DataModelItemLabels1, ErrorText as ErrorText1 } from "./components/next/data-modeling-item/next-data-modeling-item";
@@ -4952,7 +4952,7 @@ declare global {
     };
     interface HTMLChNavigationListRenderElementEventMap {
         "buttonClick": NavigationListItemModel;
-        "hyperlinkClick": PointerEvent;
+        "hyperlinkClick": NavigationListHyperlinkClickEvent;
     }
     /**
      * @status experimental
@@ -7916,7 +7916,7 @@ declare namespace LocalJSX {
         /**
           * Fired when an hyperlink is clicked. This event can be prevented.
          */
-        "onHyperlinkClick"?: (event: ChNavigationListRenderCustomEvent<PointerEvent>) => void;
+        "onHyperlinkClick"?: (event: ChNavigationListRenderCustomEvent<NavigationListHyperlinkClickEvent>) => void;
         /**
           * Specifies the items of the control.
          */

--- a/src/components/edit/tests/edit.e2e.ts
+++ b/src/components/edit/tests/edit.e2e.ts
@@ -133,7 +133,7 @@ describe("[ch-edit][default]", () => {
 
   it("should have the right size the startImgSrc ", async () => {
     await page.setContent(
-      `<ch-edit start-img-src="something" style="--ch-edit__image-size: 16px"></ch-edit>`
+      `<ch-edit start-img-src="var(something)" style="--ch-edit__image-size: 16px"></ch-edit>`
     );
     await page.waitForChanges();
     const imageComputedStyle = await page.evaluate(

--- a/src/components/navigation-list/navigation-list-render.tsx
+++ b/src/components/navigation-list/navigation-list-render.tsx
@@ -63,6 +63,7 @@ const isSelectedLink = (
   navigationListState: ChNavigationListRender
 ) =>
   !!item.link &&
+  !!navigationListState.selectedLink?.link?.url &&
   navigationListState.selectedLink.link.url === item.link.url &&
   navigationListState.selectedLink.id === item.id;
 

--- a/src/components/navigation-list/navigation-list-render.tsx
+++ b/src/components/navigation-list/navigation-list-render.tsx
@@ -53,7 +53,8 @@ const registerDefaultGetImagePathCallback = (
               navigationListState.gxSettings,
               navigationListState.gxImageConstructor
             )
-          : item.startImgSrc
+          : item.startImgSrc,
+        item.startImgType
       )
     })
   );

--- a/src/components/navigation-list/navigation-list-render.tsx
+++ b/src/components/navigation-list/navigation-list-render.tsx
@@ -12,7 +12,11 @@ import {
 } from "@stencil/core";
 
 import { GxImageMultiState, ItemLink } from "../../common/types";
-import { NavigationListItemModel, NavigationListModel } from "./types";
+import {
+  NavigationListHyperlinkClickEvent,
+  NavigationListItemModel,
+  NavigationListModel
+} from "./types";
 
 import { adoptCommonThemes } from "../../common/theme";
 import {
@@ -241,7 +245,7 @@ export class ChNavigationListRender implements ComponentInterface {
    * Fired when an hyperlink is clicked.
    * This event can be prevented.
    */
-  @Event() hyperlinkClick: EventEmitter<PointerEvent>;
+  @Event() hyperlinkClick: EventEmitter<NavigationListHyperlinkClickEvent>;
 
   #expandNewSelectedLink = (model: NavigationListModel) => {
     // for let index ... is the fastest for
@@ -295,7 +299,7 @@ export class ChNavigationListRender implements ComponentInterface {
     const itemUIModel = navigationListItem.model;
 
     if (itemUIModel.link) {
-      const eventInfo = this.hyperlinkClick.emit(event);
+      const eventInfo = this.hyperlinkClick.emit({ event, item: itemUIModel });
 
       if (eventInfo.defaultPrevented) {
         event.preventDefault();

--- a/src/components/navigation-list/navigation-list-render.tsx
+++ b/src/components/navigation-list/navigation-list-render.tsx
@@ -298,6 +298,7 @@ export class ChNavigationListRender implements ComponentInterface {
       return;
     }
     const itemUIModel = navigationListItem.model;
+    const canExpandSubItems = this.expanded;
 
     if (itemUIModel.link) {
       const eventInfo = this.hyperlinkClick.emit({ event, item: itemUIModel });
@@ -318,7 +319,8 @@ export class ChNavigationListRender implements ComponentInterface {
       }
     }
 
-    if (itemUIModel.items != null) {
+    // TODO: Add an unit test for this
+    if (canExpandSubItems && itemUIModel.items != null) {
       itemUIModel.expanded = !itemUIModel.expanded;
       forceUpdate(this);
     }

--- a/src/components/navigation-list/navigation-list-render.tsx
+++ b/src/components/navigation-list/navigation-list-render.tsx
@@ -27,6 +27,7 @@ import {
   subscribe,
   syncStateWithObservableAncestors
 } from "../sidebar/expanded-change-obervables";
+import { formatImagePath } from "../../common/utils";
 
 // - - - - - - - - - - - - - - - - - - - -
 //                Registry
@@ -41,13 +42,15 @@ const registerDefaultGetImagePathCallback = (
     "getImagePathCallback",
     "ch-navigation-list-render",
     (item: NavigationListItemModel) => ({
-      base: navigationListState.useGxRender
-        ? fromGxImageToURL(
-            item.startImgSrc,
-            navigationListState.gxSettings,
-            navigationListState.gxImageConstructor
-          )
-        : item.startImgSrc
+      base: formatImagePath(
+        navigationListState.useGxRender
+          ? fromGxImageToURL(
+              item.startImgSrc,
+              navigationListState.gxSettings,
+              navigationListState.gxImageConstructor
+            )
+          : item.startImgSrc
+      )
     })
   );
 

--- a/src/components/navigation-list/readme.md
+++ b/src/components/navigation-list/readme.md
@@ -31,7 +31,7 @@
 | Event            | Description                                                      | Type                                                                                                                                                                                                                   |
 | ---------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `buttonClick`    | Fired when an button is clicked. This event can be prevented.    | `CustomEvent<{ id?: string; caption: string; disabled?: boolean; expanded?: boolean; metadata?: string; startImgSrc?: string; startImgType?: "mask" \| "background"; link?: ItemLink; items?: NavigationListModel; }>` |
-| `hyperlinkClick` | Fired when an hyperlink is clicked. This event can be prevented. | `CustomEvent<PointerEvent>`                                                                                                                                                                                            |
+| `hyperlinkClick` | Fired when an hyperlink is clicked. This event can be prevented. | `CustomEvent<{ event: PointerEvent; item: NavigationListItemModel; }>`                                                                                                                                                 |
 
 
 ## CSS Custom Properties

--- a/src/components/navigation-list/types.ts
+++ b/src/components/navigation-list/types.ts
@@ -13,3 +13,8 @@ export type NavigationListItemModel = {
   link?: ItemLink;
   items?: NavigationListModel;
 };
+
+export type NavigationListHyperlinkClickEvent = {
+  event: PointerEvent;
+  item: NavigationListItemModel;
+};

--- a/src/components/tree-view/internal/tree-view-item/tree-view-item.tsx
+++ b/src/components/tree-view/internal/tree-view-item/tree-view-item.tsx
@@ -658,7 +658,8 @@ export class ChTreeViewItem {
         this.#startImageExpanded = this.startImgSrc
           ? (updateDirectionInImageCustomVar(
               (img as TreeViewItemImageMultiState).expanded,
-              "start"
+              "start",
+              this.startImgType
             ) as GxImageMultiStateStart)
           : undefined;
       }
@@ -666,7 +667,8 @@ export class ChTreeViewItem {
       this.#startImage = this.startImgSrc
         ? (updateDirectionInImageCustomVar(
             parsedImg,
-            "start"
+            "start",
+            this.startImgType
           ) as GxImageMultiStateStart)
         : undefined;
     }
@@ -688,7 +690,8 @@ export class ChTreeViewItem {
         this.#endImageExpanded = this.endImgSrc
           ? (updateDirectionInImageCustomVar(
               (img as TreeViewItemImageMultiState).expanded,
-              "end"
+              "end",
+              this.endImgType
             ) as GxImageMultiStateEnd)
           : undefined;
       }
@@ -696,7 +699,8 @@ export class ChTreeViewItem {
       this.#endImage = this.endImgSrc
         ? (updateDirectionInImageCustomVar(
             parsedImg,
-            "end"
+            "end",
+            this.endImgType
           ) as GxImageMultiStateEnd)
         : undefined;
     }

--- a/src/showcase/assets/components/accordion/models.ts
+++ b/src/showcase/assets/components/accordion/models.ts
@@ -1,8 +1,8 @@
 import { GxImageMultiState } from "../../../../common/types";
 import { AccordionModel } from "../../../../components/accordion/types";
 
-const FOLDER_ICON = "folder";
-const MODULE_ICON = "module";
+const FOLDER_ICON = "var(folder)";
+const MODULE_ICON = "var(module)";
 
 export const accordionSimpleModel: AccordionModel = [
   { id: "item 1", caption: "Item 1", startImgSrc: FOLDER_ICON },

--- a/src/showcase/assets/components/edit/models.ts
+++ b/src/showcase/assets/components/edit/models.ts
@@ -1,7 +1,7 @@
 import { GxImageMultiState } from "../../../../common/types";
 
-const FOLDER_ICON = "folder";
-const MODULE_ICON = "module";
+const FOLDER_ICON = "var(folder)";
+const MODULE_ICON = "var(module)";
 
 export const getImagePathCallbackEdit = (
   startImgSrc: string

--- a/src/showcase/assets/components/image/models.ts
+++ b/src/showcase/assets/components/image/models.ts
@@ -1,7 +1,7 @@
 import { GxImageMultiState } from "../../../../common/types";
 
-const FOLDER_ICON = "folder";
-const MODULE_ICON = "module";
+const FOLDER_ICON = "var(folder)";
+const MODULE_ICON = "var(module)";
 
 export const getImagePathCallbackImage = (
   imgSrc: string

--- a/src/showcase/assets/components/navigation-list/navigation-list.showcase.tsx
+++ b/src/showcase/assets/components/navigation-list/navigation-list.showcase.tsx
@@ -3,14 +3,15 @@ import { ShowcaseRenderProperties, ShowcaseStory } from "../types";
 import { unanimoShowcase } from "./models";
 import { ChNavigationListRenderCustomEvent } from "../../../../components";
 import { renderBooleanPropertyOrEmpty } from "../utils";
+import { NavigationListHyperlinkClickEvent } from "../../../../components/navigation-list/types";
 
 const state: Partial<HTMLChNavigationListRenderElement> = {};
 
 // The current implementation of the showcase navigates when the hash of the
 // URL changes
 const preventNavigation = (
-  event: ChNavigationListRenderCustomEvent<PointerEvent>
-) => event.detail.preventDefault();
+  event: ChNavigationListRenderCustomEvent<NavigationListHyperlinkClickEvent>
+) => event.detail.event.preventDefault();
 
 const render = () => (
   <div class="tab-test-main-wrapper">

--- a/src/showcase/assets/components/sidebar/sidebar.showcase.tsx
+++ b/src/showcase/assets/components/sidebar/sidebar.showcase.tsx
@@ -7,6 +7,7 @@ import {
 import { ChNavigationListRenderCustomEvent } from "../../../../components";
 import { unanimoShowcase } from "../navigation-list/models";
 import { renderBooleanPropertyOrEmpty } from "../utils";
+import { NavigationListHyperlinkClickEvent } from "../../../../components/navigation-list/types";
 
 const state: Partial<
   HTMLChSidebarElement &
@@ -18,8 +19,8 @@ const state: Partial<
 // The current implementation of the showcase navigates when the hash of the
 // URL changes
 const preventNavigation = (
-  event: ChNavigationListRenderCustomEvent<PointerEvent>
-) => event.detail.preventDefault();
+  event: ChNavigationListRenderCustomEvent<NavigationListHyperlinkClickEvent>
+) => event.detail.event.preventDefault();
 
 const handleExpandedChange = () => {
   state.expanded = !state.expanded;

--- a/src/showcase/assets/components/tree-view/models.ts
+++ b/src/showcase/assets/components/tree-view/models.ts
@@ -32,8 +32,8 @@ const THIRD_LEVEL_SIZE = 20;
 
 const ASSETS_PREFIX = "showcase/pages/assets/icons/";
 
-const FOLDER_ICON = "folder";
-const MODULE_ICON = "module";
+const FOLDER_ICON = "var(folder)";
+const MODULE_ICON = "var(module)";
 
 export const getImagePathCallbackTreeView: TreeViewImagePathCallback = (
   item: TreeViewItemModel,

--- a/src/showcase/base.css
+++ b/src/showcase/base.css
@@ -71,10 +71,6 @@
 
 .card-markup {
   position: relative;
-
-  pre {
-    margin: 0; /* WA until this is fixed by Unanimo/Mercury */
-  }
 }
 
 .copy-button {

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -70,6 +70,9 @@ export const config: Config = {
       components: ["ch-tab-render"] // Make sure the ch-tab-render control is not bundled with other components
     },
     {
+      components: ["ch-navigation-list-render", "ch-navigation-list-item"]
+    },
+    {
       components: ["ch-next-data-modeling", "ch-next-data-modeling-item"]
     },
     {


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Add `formatImagePath` to improve support for image paths.

 - Support more image paths in the `ch-navigation-list-render` items.

 - Add the item model info in the `hyperlinkClick` event.

 - Fix edge cases with the `selectedLink` property.
 
 - Don't expand/collapse sub items if the sidebar is collapsed.


## Breaking changes
 - The `hyperlinkClick` event now has `NavigationListHyperlinkClickEvent` as a type