### PR TITLE
The trigger moment for the rowClicked event of the TabularGrid is changed

### DIFF
--- a/src/components/tabular-grid/cell/tabular-grid-cell.ts
+++ b/src/components/tabular-grid/cell/tabular-grid-cell.ts
@@ -345,6 +345,9 @@ export default class HTMLChTabularGridCellElement extends HTMLElement {
         "mousedown",
         this.caretMouseDownHandler.bind(this)
       );
+      this.caret.addEventListener("click", eventInfo =>
+        eventInfo.stopPropagation()
+      );
     }
   }
 }

--- a/src/components/tabular-grid/tabular-grid.tsx
+++ b/src/components/tabular-grid/tabular-grid.tsx
@@ -473,7 +473,7 @@ export class ChTabularGrid {
   }
 
   @Listen("mousedown", { passive: true })
-  clickHandler(eventInfo: MouseEvent) {
+  mouseDownHandler(eventInfo: MouseEvent) {
     const row = this.manager.getRowEventTarget(eventInfo);
     const cell = this.manager.getCellEventTarget(eventInfo);
 
@@ -490,22 +490,18 @@ export class ChTabularGrid {
   }
 
   @Listen("mouseup", { passive: true })
-  mouseUpHandler(eventInfo: MouseEvent) {
-    const row = this.manager.getRowEventTarget(eventInfo);
-    const cell = this.manager.getCellEventTarget(eventInfo);
-
+  mouseUpHandler() {
     if (this.manager.selection.selecting) {
       this.stopSelecting();
     }
+  }
 
-    /**
-     * - Verifies that the mouseup event occurs over a row and not over a column or rowset legend.
-     * - Verifies that the mouseup event occurs on the same row where the mousedown or the last mousemove occurred.
-     *   This aims to prevent cases where a mousedown starts on a row in grid A and the mouseup happens on a row in grid B (drag & drop scenario).
-     * - The emitRowClicked() cannot be placed inside the if (this.manager.selection.selecting)
-     *   because the selection can be canceled during the mousemove.
-     */
-    if (row && row === this.rowFocused) {
+  @Listen("click", { passive: true })
+  clickHandler(eventInfo: MouseEvent) {
+    const row = this.manager.getRowEventTarget(eventInfo);
+    const cell = this.manager.getCellEventTarget(eventInfo);
+
+    if (row) {
       this.emitRowClicked(row, cell);
     }
   }

--- a/src/deprecated-components/grid/ch-grid.tsx
+++ b/src/deprecated-components/grid/ch-grid.tsx
@@ -470,7 +470,7 @@ export class ChGrid {
   }
 
   @Listen("mousedown", { passive: true })
-  clickHandler(eventInfo: MouseEvent) {
+  mouseDownHandler(eventInfo: MouseEvent) {
     const row = this.manager.getRowEventTarget(eventInfo);
     const cell = this.manager.getCellEventTarget(eventInfo);
 
@@ -491,7 +491,16 @@ export class ChGrid {
     if (this.manager.selection.selecting) {
       this.stopSelecting();
     }
-    this.emitRowClicked(this.rowFocused, this.cellFocused);
+  }
+
+  @Listen("click", { passive: true })
+  clickHandler(eventInfo: MouseEvent) {
+    const row = this.manager.getRowEventTarget(eventInfo);
+    const cell = this.manager.getCellEventTarget(eventInfo);
+
+    if (row) {
+      this.emitRowClicked(row, cell);
+    }
   }
 
   @Listen("dblclick", { passive: true })


### PR DESCRIPTION
The rowClicked event used to be triggered after the mouseup event on a row, and now it is triggered after the click event.