### PR TITLE
`[ch-radio-group-render]` Add support to specify the direction of the radio group items

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2352,6 +2352,10 @@ export namespace Components {
      */
     interface ChRadioGroupRender {
         /**
+          * Specifies the direction of the items.
+         */
+        "direction": "horizontal" | "vertical";
+        /**
           * This attribute lets you specify if the radio-group is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
          */
         "disabled": boolean;
@@ -8434,6 +8438,10 @@ declare namespace LocalJSX {
      * It contains radio items to allow users to select one option from the list of options.
      */
     interface ChRadioGroupRender {
+        /**
+          * Specifies the direction of the items.
+         */
+        "direction"?: "horizontal" | "vertical";
         /**
           * This attribute lets you specify if the radio-group is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
          */

--- a/src/components/radio-group/radio-group-render.scss
+++ b/src/components/radio-group/radio-group-render.scss
@@ -21,12 +21,19 @@ $option-checked-color: currentColor;
    */
   --ch-radio-group__radio-option-size: 50%;
 
-  display: inline-grid;
-  grid-auto-rows: max-content;
-
   // This property is necessary to ensure the focus is not delegated to the
   // checked radio when clicking the background of the control, but not an item
   pointer-events: none;
+}
+
+:host(.ch-radio-group--direction-horizontal) {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+:host(.ch-radio-group--direction-vertical) {
+  display: inline-grid;
+  grid-auto-rows: max-content;
 }
 
 .radio-item {

--- a/src/components/radio-group/radio-group-render.tsx
+++ b/src/components/radio-group/radio-group-render.tsx
@@ -46,6 +46,11 @@ export class ChRadioGroupRender {
   @AttachInternals() internals: ElementInternals;
 
   /**
+   * Specifies the direction of the items.
+   */
+  @Prop() readonly direction: "horizontal" | "vertical" = "horizontal";
+
+  /**
    * This attribute lets you specify if the radio-group is disabled.
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
@@ -139,6 +144,13 @@ export class ChRadioGroupRender {
   }
 
   render() {
-    return <Host role="radiogroup">{this.model?.map(this.#itemRender)}</Host>;
+    return (
+      <Host
+        role="radiogroup"
+        class={`ch-radio-group--direction-${this.direction}`}
+      >
+        {this.model?.map(this.#itemRender)}
+      </Host>
+    );
   }
 }

--- a/src/components/radio-group/readme.md
+++ b/src/components/radio-group/readme.md
@@ -13,11 +13,12 @@ It contains radio items to allow users to select one option from the list of opt
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                                                                                  | Type                    | Default     |
-| ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ----------- |
-| `disabled` | `disabled` | This attribute lets you specify if the radio-group is disabled. If disabled, it will not fire any user interaction related event (for example, click event). | `boolean`               | `false`     |
-| `model`    | --         | This property lets you define the items of the ch-radio-group-render control.                                                                                | `RadioGroupItemModel[]` | `undefined` |
-| `value`    | `value`    | The value of the control.                                                                                                                                    | `string`                | `undefined` |
+| Property    | Attribute   | Description                                                                                                                                                  | Type                         | Default        |
+| ----------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | -------------- |
+| `direction` | `direction` | Specifies the direction of the items.                                                                                                                        | `"horizontal" \| "vertical"` | `"horizontal"` |
+| `disabled`  | `disabled`  | This attribute lets you specify if the radio-group is disabled. If disabled, it will not fire any user interaction related event (for example, click event). | `boolean`                    | `false`        |
+| `model`     | --          | This property lets you define the items of the ch-radio-group-render control.                                                                                | `RadioGroupItemModel[]`      | `undefined`    |
+| `value`     | `value`     | The value of the control.                                                                                                                                    | `string`                     | `undefined`    |
 
 
 ## Events

--- a/src/showcase/assets/components/radio-group/radio-group.showcase.tsx
+++ b/src/showcase/assets/components/radio-group/radio-group.showcase.tsx
@@ -48,6 +48,7 @@ const render = () => (
           id="radio-group-1"
           // name="radio-group-1"
           class="radio-group"
+          direction={state.direction}
           disabled={state.disabled}
           model={state.model}
           value={state.value}
@@ -71,6 +72,7 @@ const render = () => (
           id="radio-group-2"
           // name="radio-group-2"
           class="radio-group"
+          direction={state.direction}
           disabled={state.disabled}
           model={state.model}
           value={state.value}
@@ -94,6 +96,7 @@ const render = () => (
             id="radio-group-3"
             // name="radio-group-3"
             class="radio-group"
+            direction={state.direction}
             disabled={state.disabled}
             model={state.model}
             value={state.value}
@@ -133,6 +136,17 @@ const showcaseRenderProperties: ShowcaseRenderProperties<HTMLChRadioGroupRenderE
           type: "string"
         },
         {
+          id: "direction",
+          caption: "Direction",
+          value: "horizontal",
+          values: [
+            { caption: "Horizontal", value: "horizontal" },
+            { caption: "Vertical", value: "vertical" }
+          ],
+          render: "radio-group",
+          type: "enum"
+        },
+        {
           id: "disabled",
           caption: "Disabled",
           value: false,
@@ -150,6 +164,7 @@ export const radioGroupShowcaseStory: ShowcaseStory<HTMLChRadioGroupRenderElemen
       uiModelType: "RadioGroupModel",
       render: () => `<ch-radio-group-render
           class="radio-group"${renderBooleanPropertyOrEmpty("disabled", state)}
+          direction="${state.direction}"
           model={this.#controlUIModel}
           value="${state.value}"
           onInput={this.#handleValueChange}


### PR DESCRIPTION
## Breaking changes
 - `[ch-radio-group-render]` The default direction of the control's items is now horizontal.