### PR TITLE
`[ch-action-list-render]` Fix `selection="single"` issues

### DIFF
--- a/src/components/action-list/action-list-render.tsx
+++ b/src/components/action-list/action-list-render.tsx
@@ -37,7 +37,8 @@ import { mouseEventModifierKey } from "../common/helpers";
 import { actionListKeyboardNavigation } from "./keyboard-navigation";
 import {
   ACTION_LIST_ITEM_TAG,
-  getActionListOrGroupItemFromEvent
+  getActionListOrGroupItemFromEvent,
+  getParentArray
 } from "./utils";
 import { updateItemProperty } from "./update-item-property";
 import { actionListDefaultTranslations } from "./translations";
@@ -587,7 +588,7 @@ export class ChActionListRender {
     this.modifyItemCaptionCallback(itemId, newCaption)
       .then(() => {
         // Sort items in parent model
-        this.#sortModel(this.#getParentArray(itemUIModel));
+        this.#sortModel(getParentArray(itemUIModel));
 
         // Update filters
         // this.#scheduleFilterProcessing();
@@ -631,7 +632,7 @@ export class ChActionListRender {
     itemInfo.fixed = newFixedValue;
 
     // Sort items in parent model
-    this.#sortModel(this.#getParentArray(itemUIModel));
+    this.#sortModel(getParentArray(itemUIModel));
 
     // Queue a re-render to update the fixed binding and the order of the items
     forceUpdate(this);
@@ -655,10 +656,6 @@ export class ChActionListRender {
       }
     );
   }
-
-  #getParentArray = (itemUIModel: ActionListItemModelExtended) =>
-    (itemUIModel as ActionListItemModelExtendedRoot).root ??
-    (itemUIModel as ActionListItemModelExtendedGroup).parentItem.items;
 
   #getItemOrGroupInfo = (itemId: string) =>
     this.#flattenedModel.get(itemId).item as

--- a/src/components/action-list/selections.ts
+++ b/src/components/action-list/selections.ts
@@ -1,0 +1,16 @@
+import { ActionListModel } from "./types";
+
+export const setActionListSelectedItems = (
+  model: ActionListModel,
+  selectedItems: Set<string>
+) => {
+  for (let index = 0; index < model.length; index++) {
+    const itemUIModel = model[index];
+
+    if (itemUIModel.type === "actionable" && itemUIModel.selected) {
+      selectedItems.add(itemUIModel.id);
+    } else if (itemUIModel.type === "group" && itemUIModel.items != null) {
+      setActionListSelectedItems(itemUIModel.items, selectedItems);
+    }
+  }
+};

--- a/src/components/action-list/tests/selection.e2e.ts
+++ b/src/components/action-list/tests/selection.e2e.ts
@@ -1,9 +1,61 @@
-import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import {
+  E2EElement,
+  E2EPage,
+  EventSpy,
+  newE2EPage
+} from "@stencil/core/testing";
 import { ticketList } from "../../../showcase/assets/components/action-list/models";
+import {
+  ActionListItemModel,
+  ActionListItemType,
+  ActionListModel
+} from "../types";
+
+const FIRST_ITEM_ID = "2023 employee contracts";
+
+const actionListModelSimple: ActionListModel = [
+  {
+    id: FIRST_ITEM_ID,
+    type: "actionable",
+    caption: "2023 employee contracts"
+  },
+  {
+    id: "Investors reports",
+    type: "actionable",
+    caption: "Investors reports",
+    selected: true
+  }
+];
+
+const actionListModelSimpleEventSpyDetail = [
+  {
+    item: {
+      caption: "2023 employee contracts",
+      id: FIRST_ITEM_ID,
+      selected: true,
+      type: "actionable"
+    },
+    root: [
+      {
+        caption: "2023 employee contracts",
+        id: FIRST_ITEM_ID,
+        selected: true,
+        type: "actionable"
+      },
+      {
+        caption: "Investors reports",
+        id: "Investors reports",
+        selected: false,
+        type: "actionable"
+      }
+    ]
+  }
+];
 
 describe("[ch-action-list-render][selection]", () => {
   let page: E2EPage;
   let actionListRef: E2EElement;
+  let selectedItemsChangeEventSpy: EventSpy;
 
   beforeEach(async () => {
     page = await newE2EPage({
@@ -12,6 +64,9 @@ describe("[ch-action-list-render][selection]", () => {
     });
     actionListRef = await page.find("ch-action-list-render");
     actionListRef.setProperty("model", ticketList);
+    selectedItemsChangeEventSpy = await actionListRef.spyOnEvent(
+      "selectedItemsChange"
+    );
     await page.waitForChanges();
   });
 
@@ -29,4 +84,53 @@ describe("[ch-action-list-render][selection]", () => {
 
     await page.click("ch-action-list-render >>> ch-action-list-item");
   });
+
+  const selectionTests = (modelFirst: boolean) => {
+    const descriptionPrefix = modelFirst
+      ? '[set model and then set selection="single"]'
+      : '[set selection="single" and then set model]';
+
+    it(`${descriptionPrefix} should work selection="single" when there is a selected item and the user selects other item`, async () => {
+      if (modelFirst) {
+        actionListRef.setProperty("model", actionListModelSimple);
+        actionListRef.setProperty("selection", "single");
+      } else {
+        actionListRef.setProperty("selection", "single");
+        actionListRef.setProperty("model", actionListModelSimple);
+      }
+      await page.waitForChanges();
+
+      const actionListItemRef = await page.find(
+        `ch-action-list-render >>> [id='${FIRST_ITEM_ID}'] >>> button`
+      );
+      await actionListItemRef.press("Space");
+      await page.waitForChanges();
+      expect(selectedItemsChangeEventSpy).toHaveReceivedEventDetail(
+        actionListModelSimpleEventSpyDetail
+      );
+    });
+
+    it(`${descriptionPrefix} should work selection="single" when there is a selected item and updateItemProperties selects other item`, async () => {
+      if (modelFirst) {
+        actionListRef.setProperty("model", actionListModelSimple);
+        actionListRef.setProperty("selection", "single");
+      } else {
+        actionListRef.setProperty("selection", "single");
+        actionListRef.setProperty("model", actionListModelSimple);
+      }
+      await page.waitForChanges();
+
+      await actionListRef.callMethod("updateItemProperties", FIRST_ITEM_ID, {
+        type: "actionable",
+        selected: true
+      } satisfies Partial<ActionListItemModel> & { type: ActionListItemType });
+      await page.waitForChanges();
+      expect(selectedItemsChangeEventSpy).toHaveReceivedEventDetail(
+        actionListModelSimpleEventSpyDetail
+      );
+    });
+  };
+
+  selectionTests(true);
+  selectionTests(false);
 });

--- a/src/components/action-list/update-item-property.ts
+++ b/src/components/action-list/update-item-property.ts
@@ -1,15 +1,16 @@
 import {
   ActionListItemModel,
   ActionListItemModelExtended,
-  ActionListItemModelExtendedGroup,
-  ActionListItemModelExtendedRoot,
   ActionListItemType,
   ActionListModel
 } from "./types";
+import { getParentArray } from "./utils";
 
 export const updateItemProperty = (
   itemId: string,
-  properties: Partial<ActionListItemModel> & { type: ActionListItemType },
+  propertiesToUpdate: Partial<ActionListItemModel> & {
+    type: ActionListItemType;
+  },
   flattenedTreeModel: Map<string, ActionListItemModelExtended>,
   newSelectedItems: Set<string>
 ): ActionListModel | undefined => {
@@ -19,29 +20,30 @@ export const updateItemProperty = (
   }
   const itemInfo = itemUIModel.item;
 
-  if (properties.type !== itemInfo.type) {
+  // Types doesn't match
+  if (propertiesToUpdate.type !== itemInfo.type) {
     return undefined;
   }
 
-  Object.keys(properties).forEach(propertyName => {
-    if (properties[propertyName] !== undefined) {
-      itemInfo[propertyName] = properties[propertyName];
-    }
-  });
+  // Update properties
+  for (const propertyName in propertiesToUpdate) {
+    const propertyValue = propertiesToUpdate[propertyName];
 
-  if (properties.type === "separator") {
+    if (propertyValue !== undefined) {
+      itemInfo[propertyName] = propertyValue;
+    }
+  }
+
+  if (propertiesToUpdate.type === "separator") {
     return undefined;
   }
 
   // Accumulate selection/deselection
-  if (properties.selected) {
+  if (propertiesToUpdate.selected) {
     newSelectedItems.add(itemId);
-  } else if (properties.selected === false) {
+  } else if (propertiesToUpdate.selected === false) {
     newSelectedItems.delete(itemId);
   }
 
-  return (
-    (itemUIModel as ActionListItemModelExtendedRoot).root ??
-    (itemUIModel as ActionListItemModelExtendedGroup).parentItem.items
-  );
+  return getParentArray(itemUIModel);
 };

--- a/src/components/action-list/utils.ts
+++ b/src/components/action-list/utils.ts
@@ -1,6 +1,9 @@
 import {
   ActionListItemActionable,
   ActionListItemGroup,
+  ActionListItemModelExtended,
+  ActionListItemModelExtendedGroup,
+  ActionListItemModelExtendedRoot,
   ActionListModel
 } from "./types";
 
@@ -37,3 +40,7 @@ export const getActionListOrGroupItemIndex = (
     (el: ActionListItemActionable | ActionListItemGroup) =>
       el.id && el.id === item.id
   );
+
+export const getParentArray = (itemUIModel: ActionListItemModelExtended) =>
+  (itemUIModel as ActionListItemModelExtendedRoot).root ??
+  (itemUIModel as ActionListItemModelExtendedGroup).parentItem.items;


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fixed `selection="single"` not working when the model is set with a selected item and the user selects a different item.

 - Fixed `selection="single"` not working when the model is set with a selected item and the `updateItemProperties` method is called to select a different item.

 - Fixed `selection="single"` not working when the model is updated at runtime.