### PR TITLE
`[ch-chat]` Improve `ch-chat`'s default values and fix `items` property not being reactive

### DIFF
--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -51,7 +51,7 @@ export class ChChat {
   /**
    * Specifies the callbacks required in the control.
    */
-  @Prop() readonly callbacks!: ChatInternalCallbacks;
+  @Prop() readonly callbacks?: ChatInternalCallbacks | undefined;
 
   /**
    * This property allows us to implement custom rendering for the code blocks.
@@ -66,7 +66,7 @@ export class ChChat {
   /**
    * `true` if a response for the assistant is being generated.
    */
-  @Prop() readonly generatingResponse!: boolean;
+  @Prop() readonly generatingResponse?: boolean = false;
 
   /**
    * Specifies an object containing an HTMLAnchorElement reference. Use this
@@ -84,7 +84,7 @@ export class ChChat {
   /**
    * Specifies if the chat is used in a mobile device.
    */
-  @Prop() readonly isMobile!: boolean;
+  @Prop() readonly isMobile?: boolean = false;
 
   /**
    * Specifies the items that the chat will display.
@@ -94,7 +94,7 @@ export class ChChat {
   /**
    * Specifies if the chat is waiting for the data to be loaded.
    */
-  @Prop({ mutable: true }) loadingState!: SmartGridDataState;
+  @Prop({ mutable: true }) loadingState?: SmartGridDataState = "initial";
 
   /**
    * Specifies the theme to be used for rendering the markdown.
@@ -105,7 +105,26 @@ export class ChChat {
   /**
    * Specifies the literals required in the control.
    */
-  @Prop() readonly translations!: ChatTranslations;
+  @Prop() readonly translations: ChatTranslations = {
+    accessibleName: {
+      clearChat: "Clear chat",
+      copyResponseButton: "Copy assistant response",
+      downloadCodeButton: "Download code",
+      imagePicker: "Select images",
+      removeUploadedImage: "Remove uploaded image",
+      sendButton: "Send",
+      sendInput: "Message",
+      stopGeneratingAnswerButton: "Stop generating answer"
+    },
+    placeholder: {
+      sendInput: "Ask me a question..."
+    },
+    text: {
+      copyCodeButton: "Copy code",
+      processing: `Processing...`,
+      sourceFiles: "Source files:"
+    }
+  };
 
   /**
    * This property allows us to implement custom rendering of chat items.
@@ -264,7 +283,7 @@ export class ChChat {
       };
 
       await this.#addUserMessageToRecordAndFocusInput(userMessageToAdd);
-      this.callbacks.sendChatToLLM(this.items);
+      this.callbacks?.sendChatToLLM(this.items);
 
       // Queue a new re-render
       forceUpdate(this);
@@ -286,7 +305,7 @@ export class ChChat {
 
       // Upload the image to the server asynchronously
       this.callbacks
-        .uploadImage(imageToUpload.file)
+        ?.uploadImage(imageToUpload.file)
         .then(imageSrc => {
           userContent[index + 1] = {
             type: "image_url",
@@ -297,7 +316,7 @@ export class ChChat {
           this.uploadingImagesToTheServer--;
 
           if (this.uploadingImagesToTheServer === 0) {
-            this.callbacks.sendChatToLLM(this.items);
+            this.callbacks?.sendChatToLLM(this.items);
           }
         })
         .catch(() => {
@@ -307,7 +326,7 @@ export class ChChat {
           this.uploadingImagesToTheServer--;
 
           if (this.uploadingImagesToTheServer === 0) {
-            this.callbacks.sendChatToLLM(this.items);
+            this.callbacks?.sendChatToLLM(this.items);
           }
         });
     });
@@ -326,7 +345,7 @@ export class ChChat {
   #handleStopGenerating = (event: MouseEvent) => {
     event.stopPropagation();
 
-    this.callbacks.stopGeneratingAnswer!();
+    this.callbacks?.stopGeneratingAnswer!();
   };
 
   // #handleFilesChanged = (event: ImagePickerCustomEvent<FileList | null>) => {
@@ -479,7 +498,7 @@ export class ChChat {
           }}
           part="send-container"
         >
-          {this.generatingResponse && this.callbacks.stopGeneratingAnswer && (
+          {this.generatingResponse && this.callbacks?.stopGeneratingAnswer && (
             <button
               class="stop-generating-answer-button"
               part="stop-generating-answer-button"

--- a/src/components/chat/tests/items-reactivity.e2e.ts
+++ b/src/components/chat/tests/items-reactivity.e2e.ts
@@ -1,0 +1,137 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import { ChatMessage } from "../types";
+
+const INITIAL_LOAD_RENDERED_CONTENT =
+  '<div class="loading-chat" slot="empty-chat"></div><div class="send-container" part="send-container"><div class="send-input-wrapper" part="send-input-wrapper"><ch-edit part="send-input" class="ch-edit--cursor-text ch-edit--multiline hydrated" data-text-align=""></ch-edit></div><button aria-label="Send" title="Send" class="send-or-audio-button" part="send-button" type="button"></button></div>';
+
+const EMPTY_RENDERED_CONTENT =
+  '<slot name="empty-chat"></slot><div class="send-container" part="send-container"><div class="send-input-wrapper" part="send-input-wrapper"><ch-edit part="send-input" class="ch-edit--cursor-text ch-edit--multiline hydrated" data-text-align=""></ch-edit></div><button aria-label="Send" title="Send" class="send-or-audio-button" part="send-button" type="button"></button></div>';
+
+const chatModel1: ChatMessage[] = [
+  {
+    id: "1",
+    role: "user",
+    content: "Something"
+  },
+  {
+    id: "2",
+    role: "assistant",
+    content: "Something 2"
+  },
+  {
+    id: "3",
+    role: "user",
+    content: "Something 3"
+  }
+];
+
+const chatModel2: ChatMessage[] = [
+  {
+    id: "1",
+    role: "user",
+    content: "A different text"
+  },
+  {
+    id: "2",
+    role: "assistant",
+    content: "A different text 2"
+  },
+  {
+    id: "3",
+    role: "user",
+    content: "A different text 3"
+  }
+];
+
+const USER_CELL = <T extends string>(content: T) =>
+  `<ch-smart-grid-cell part="message user" role="gridcell" class="hydrated" data-did-load="true">${content}</ch-smart-grid-cell>`;
+
+const ASSISTANT_CELL = () =>
+  `<ch-smart-grid-cell part="message assistant undefined" role="gridcell" class="hydrated" data-did-load="true"><div aria-live="polite" aria-busy="false" class="assistant-content" part="assistant-content"><ch-markdown-viewer class="hydrated"></ch-markdown-viewer><button aria-label="Copy assistant response" title="Copy assistant response" part="copy-response-button" type="button"></button></div></ch-smart-grid-cell>`;
+
+describe("[ch-chat][items reactivity]", () => {
+  let page: E2EPage;
+  let chatRef: E2EElement;
+
+  const getChatRenderedContent = () =>
+    page.evaluate(() =>
+      document.querySelector("ch-chat").shadowRoot.innerHTML.toString()
+    );
+
+  const getChatRenderedItems = () =>
+    page.evaluate(() =>
+      document
+        .querySelector("ch-chat")
+        .shadowRoot.querySelector("ch-virtual-scroller")
+        .innerHTML.toString()
+    );
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      failOnConsoleError: true,
+      html: `<ch-chat></ch-chat>`
+    });
+    chatRef = await page.find("ch-chat");
+  });
+
+  it("should have a shadowRoot", () => {
+    expect(chatRef.shadowRoot).toBeTruthy();
+  });
+
+  it("should display the loading state by default", async () => {
+    expect(await getChatRenderedContent()).toEqual(
+      INITIAL_LOAD_RENDERED_CONTENT
+    );
+  });
+
+  it("should display the loading state by default even if the model has items", async () => {
+    await chatRef.setProperty("items", chatModel1);
+    await page.waitForChanges();
+
+    expect(await getChatRenderedContent()).toEqual(
+      INITIAL_LOAD_RENDERED_CONTENT
+    );
+  });
+
+  it('should not render any items by default if loadingState = "all-records-loaded"', async () => {
+    await chatRef.setProperty("loadingState", "all-records-loaded");
+    await page.waitForChanges();
+
+    expect(await getChatRenderedContent()).toEqual(EMPTY_RENDERED_CONTENT);
+  });
+
+  it('should render items if the model is not empty and the loadingState = "all-records-loaded"', async () => {
+    await chatRef.setProperty("items", chatModel1);
+    await chatRef.setProperty("loadingState", "more-data-to-fetch");
+    await page.waitForChanges();
+
+    // Necessary to wait for the virtual scroller to render the items in the next frame
+    await page.waitForChanges();
+
+    expect(await getChatRenderedItems()).toEqual(
+      USER_CELL("Something") + ASSISTANT_CELL() + USER_CELL("Something 3")
+    );
+  });
+
+  it('should update the rendered items if the model is updated at runtime with loadingState = "all-records-loaded"', async () => {
+    await chatRef.setProperty("items", chatModel1);
+    await chatRef.setProperty("loadingState", "more-data-to-fetch");
+    await page.waitForChanges();
+
+    // Necessary to wait for the virtual scroller to render the items in the next frame
+    await page.waitForChanges();
+
+    expect(await getChatRenderedItems()).toEqual(
+      USER_CELL("Something") + ASSISTANT_CELL() + USER_CELL("Something 3")
+    );
+
+    await chatRef.setProperty("items", chatModel2);
+    await page.waitForChanges();
+
+    expect(await getChatRenderedItems()).toEqual(
+      USER_CELL("A different text") +
+        ASSISTANT_CELL() +
+        USER_CELL("A different text 3")
+    );
+  });
+});


### PR DESCRIPTION
The `items` property it can now be updated at runtime and the `ch-chat` will update its rendered items.

## Breaking changes
 - The `callbacks` property is no longer a required property. It now can be `undefined`.

 - The `generatingResponse` property is no longer a required property. It is now `false` by default.

 - The `isMobile` property is no longer a required property. It is now `false` by default.

 - The `loadingState` property is no longer a required property. It is now `"initial"` by default.

 - The `translations` property is no longer a required property. It now has a default value to implement English translations.