### PR TITLE
`[ch-tree-view-render]` Fix some cases where the tree view items would flicker with filters applied

### DIFF
--- a/src/components/tree-view/tests/filters-filterDebounce.e2e.ts
+++ b/src/components/tree-view/tests/filters-filterDebounce.e2e.ts
@@ -22,13 +22,6 @@ describe("[ch-tree-view-render][filters][filterDebounce]", () => {
   let page: E2EPage;
   let treeViewRef: E2EElement;
 
-  // It does not serialize correctly setting a RegExp as a property, so we have
-  // to evaluate the page
-  const setRegExp = (stringRegex: string) =>
-    page.evaluate(regex => {
-      document.querySelector("ch-tree-view-render").filter = new RegExp(regex);
-    }, stringRegex);
-
   const getTreeViewRenderedContent = () =>
     page.evaluate(() =>
       document

--- a/src/components/tree-view/tests/filters-filterDebounce.e2e.ts
+++ b/src/components/tree-view/tests/filters-filterDebounce.e2e.ts
@@ -1,0 +1,183 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import {
+  importObjectsModel,
+  kbExplorerModel
+} from "../../../showcase/assets/components/tree-view/models";
+import { TREE_VIEW_NODE_RENDER } from "./utils.e2e";
+import { delayTest } from "../../../testing/utils.e2e";
+import { ChTreeViewRender } from "../tree-view-render";
+
+const DEFAULT_DELAY = 250;
+const WAIT_FOR_DEFAULT_DELAY = DEFAULT_DELAY + 50;
+
+const ALL_FILTERS = [
+  "caption",
+  "checked",
+  "list",
+  "metadata",
+  "unchecked"
+] as const satisfies ChTreeViewRender["filterType"][];
+
+describe("[ch-tree-view-render][filters][filterDebounce]", () => {
+  let page: E2EPage;
+  let treeViewRef: E2EElement;
+
+  // It does not serialize correctly setting a RegExp as a property, so we have
+  // to evaluate the page
+  const setRegExp = (stringRegex: string) =>
+    page.evaluate(regex => {
+      document.querySelector("ch-tree-view-render").filter = new RegExp(regex);
+    }, stringRegex);
+
+  const getTreeViewRenderedContent = () =>
+    page.evaluate(() =>
+      document
+        .querySelector("ch-tree-view-render")
+        .shadowRoot.innerHTML.toString()
+    );
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-tree-view-render></ch-tree-view-render>`,
+      failOnConsoleError: true
+    });
+    treeViewRef = await page.find("ch-tree-view-render");
+    treeViewRef.setProperty("model", kbExplorerModel);
+    await page.waitForChanges();
+  });
+
+  it("filterDebounce property should equal to 250 by default", async () => {
+    expect(await treeViewRef.getProperty("filterDebounce")).toBe(250);
+  });
+
+  const debounceFilterTest = (filterType: "caption" | "metadata") => {
+    it(`should debounce filters if the filterType is "${filterType}"`, async () => {
+      const previousHTML = await getTreeViewRenderedContent();
+
+      treeViewRef.setProperty("filterType", filterType);
+      treeViewRef.setProperty("filter", "nothing.....");
+      await page.waitForChanges();
+
+      // Render is debounced
+      const filteredHTML = await getTreeViewRenderedContent();
+      expect(filteredHTML).toEqual(previousHTML);
+
+      // Wait for the timeout to trigger filters
+      await delayTest(WAIT_FOR_DEFAULT_DELAY);
+      await page.waitForChanges();
+
+      expect(await getTreeViewRenderedContent()).toEqual(
+        TREE_VIEW_NODE_RENDER([])
+      );
+    });
+  };
+  debounceFilterTest("caption");
+  debounceFilterTest("metadata");
+
+  const shouldNotDebounceFiltersTest = (
+    filterType: ChTreeViewRender["filterType"]
+  ) => {
+    // TODO: This test does not work correctly because it does not set the
+    // model in the same render, in other words, it does not set the model on
+    // the initial load
+    it.skip(`should not debounce filters when setting the model and filters at the initial load, even if the filterType is "${filterType}"`, async () => {
+      page = await newE2EPage({
+        html: `<ch-tree-view-render filter-type="${filterType}" filter="nothing....."></ch-tree-view-render>`,
+        failOnConsoleError: true
+      });
+
+      await page.evaluate(model => {
+        const treeViewElementRef = document.querySelector(
+          "ch-tree-view-render"
+        )!;
+        treeViewElementRef.model = model;
+        treeViewElementRef.filterList = [];
+      }, kbExplorerModel);
+
+      await page.waitForChanges();
+
+      expect(await getTreeViewRenderedContent()).toEqual(
+        TREE_VIEW_NODE_RENDER([])
+      );
+    });
+
+    it(`should not debounce filters when updating the model at runtime, even if the filterType is "${filterType}"`, async () => {
+      treeViewRef.setProperty("filterType", filterType);
+      await page.waitForChanges();
+
+      treeViewRef.setProperty("model", importObjectsModel);
+      treeViewRef.setProperty("filter", "nothing.....");
+      treeViewRef.setProperty("filterList", []);
+      await page.waitForChanges();
+
+      expect(await getTreeViewRenderedContent()).toEqual(
+        TREE_VIEW_NODE_RENDER([])
+      );
+    });
+  };
+
+  const shouldNotDebounceFiltersTest2 = (
+    filterType: ChTreeViewRender["filterType"]
+  ) =>
+    it(`should not debounce filters when lazy loading a subtree and the filterType is "${filterType}"`, async () => {
+      treeViewRef.setProperty("filterType", filterType);
+      treeViewRef.setProperty("filter", "z");
+      treeViewRef.setProperty("filterList", []);
+      await page.waitForChanges();
+
+      // Wait for the timeout to trigger filters
+      await delayTest(WAIT_FOR_DEFAULT_DELAY);
+      await page.waitForChanges();
+
+      expect(await getTreeViewRenderedContent()).toEqual(
+        TREE_VIEW_NODE_RENDER([
+          {
+            id: "root",
+            children: ["Customization"]
+          }
+        ])
+      );
+
+      await page.evaluate(() => {
+        document.querySelector(
+          "ch-tree-view-render"
+        ).lazyLoadTreeItemsCallback = () =>
+          new Promise(resolve =>
+            resolve([
+              {
+                id: "Customization.Localization",
+                caption: "Localization",
+                metadata: "Customization.Localization"
+              },
+              {
+                id: "Other item that should not be displayed",
+                caption: "Other item that should not be displayed",
+                metadata: "Other item that should not be displayed"
+              }
+            ])
+          );
+      });
+
+      await treeViewRef.callMethod("updateAllItemsProperties", {
+        expanded: true
+      });
+      // TODO: Should this be only one await? Revisit tree view implementation for async methods
+      await page.waitForChanges();
+      await page.waitForChanges();
+
+      expect(await getTreeViewRenderedContent()).toEqual(
+        TREE_VIEW_NODE_RENDER([
+          {
+            id: "root",
+            children: [
+              { id: "Customization", children: ["Customization.Localization"] }
+            ]
+          }
+        ])
+      );
+    });
+
+  ALL_FILTERS.forEach(filterType => shouldNotDebounceFiltersTest(filterType));
+  shouldNotDebounceFiltersTest2("caption");
+  shouldNotDebounceFiltersTest2("metadata");
+});

--- a/src/components/tree-view/tests/filters-filterType-list.e2e.ts
+++ b/src/components/tree-view/tests/filters-filterType-list.e2e.ts
@@ -11,7 +11,7 @@ const ITEM_EXPORT_PARTS =
 const TREE_VIEW_NODE = (children: string) =>
   `<ch-tree-view class="not-dragging-item hydrated" exportparts="drag-preview">${children}</ch-tree-view>`;
 
-describe('[ch-tree-view-render][filters][filter-type="list"]', () => {
+describe('[ch-tree-view-render][filters][filterType="list"]', () => {
   let page: E2EPage;
   let treeViewRef: E2EElement;
 

--- a/src/components/tree-view/tests/filters-filterType-metadata.e2e.ts
+++ b/src/components/tree-view/tests/filters-filterType-metadata.e2e.ts
@@ -3,26 +3,9 @@ import {
   kbExplorerModel,
   lazyLoadTreeItemsCallback
 } from "../../../showcase/assets/components/tree-view/models";
+import { TREE_VIEW_NODE_RENDER } from "./utils.e2e";
 
-const ITEM_EXPORT_PARTS =
-  "item__action,item__checkbox,item__checkbox-container,item__checkbox-input,item__checkbox-option,item__downloading,item__edit-caption,item__expandable-button,item__group,item__header,item__img,item__line,disabled,expanded,collapsed,expand-button,even-level,odd-level,last-line,lazy-loaded,start-img,end-img,editing,not-editing,selected,not-selected,checked,unchecked,indeterminate,drag-enter";
-
-const TREE_VIEW_NODE = <T extends string>(children: T) =>
-  `<ch-tree-view class="not-dragging-item hydrated" exportparts="drag-preview">${children}</ch-tree-view>` as const;
-
-const TREE_VIEW_ITEM_NODE = <T extends string>(
-  options: { id: string; level: number; class?: string },
-  children?: T
-) =>
-  `<ch-tree-view-item id="${options.id}" role="treeitem" aria-level="${
-    options.level
-  }" exportparts="${ITEM_EXPORT_PARTS}" class="${
-    options.class ? options.class + " " : ""
-  }hydrated" part="item" style="--level: ${options.level - 1};">${
-    children ?? ""
-  }</ch-tree-view-item>` as const;
-
-describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
+describe('[ch-tree-view-render][filters][filterType="metadata"]', () => {
   let page: E2EPage;
   let treeViewRef: E2EElement;
 
@@ -131,7 +114,7 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
 
     const filteredHTML = await getTreeViewRenderedContent();
 
-    expect(filteredHTML).toEqual(TREE_VIEW_NODE(""));
+    expect(filteredHTML).toEqual(TREE_VIEW_NODE_RENDER([]));
   });
 
   it("should render the items that match the filter (string 1)", async () => {
@@ -142,18 +125,22 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
     const filteredHTML = await getTreeViewRenderedContent();
 
     expect(filteredHTML).toEqual(
-      TREE_VIEW_NODE(
-        TREE_VIEW_ITEM_NODE(
-          { id: "root", level: 1 },
-          TREE_VIEW_ITEM_NODE(
-            { id: "Root_Module", level: 2 },
-            TREE_VIEW_ITEM_NODE({ id: "Root_Module.AWS_internal", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.BL", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.General", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.IDE", level: 3 })
-          )
-        )
-      )
+      TREE_VIEW_NODE_RENDER([
+        {
+          id: "root",
+          children: [
+            {
+              id: "Root_Module",
+              children: [
+                "Root_Module.AWS_internal",
+                "Root_Module.BL",
+                "Root_Module.General",
+                "Root_Module.IDE"
+              ]
+            }
+          ]
+        }
+      ])
     );
   });
 
@@ -165,15 +152,12 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
     const filteredHTML = await getTreeViewRenderedContent();
 
     expect(filteredHTML).toEqual(
-      TREE_VIEW_NODE(
-        TREE_VIEW_ITEM_NODE(
-          { id: "root", level: 1 },
-          TREE_VIEW_ITEM_NODE(
-            { id: "Root_Module", level: 2 },
-            TREE_VIEW_ITEM_NODE({ id: "Root_Module.BL", level: 3 })
-          )
-        )
-      )
+      TREE_VIEW_NODE_RENDER([
+        {
+          id: "root",
+          children: [{ id: "Root_Module", children: ["Root_Module.BL"] }]
+        }
+      ])
     );
   });
 
@@ -185,18 +169,22 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
     const filteredHTML = await getTreeViewRenderedContent();
 
     expect(filteredHTML).toEqual(
-      TREE_VIEW_NODE(
-        TREE_VIEW_ITEM_NODE(
-          { id: "root", level: 1 },
-          TREE_VIEW_ITEM_NODE(
-            { id: "Root_Module", level: 2 },
-            TREE_VIEW_ITEM_NODE({ id: "Root_Module.AWS_internal", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.BL", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.General", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.IDE", level: 3 })
-          )
-        )
-      )
+      TREE_VIEW_NODE_RENDER([
+        {
+          id: "root",
+          children: [
+            {
+              id: "Root_Module",
+              children: [
+                "Root_Module.AWS_internal",
+                "Root_Module.BL",
+                "Root_Module.General",
+                "Root_Module.IDE"
+              ]
+            }
+          ]
+        }
+      ])
     );
   });
 
@@ -208,15 +196,12 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
     const filteredHTML = await getTreeViewRenderedContent();
 
     expect(filteredHTML).toEqual(
-      TREE_VIEW_NODE(
-        TREE_VIEW_ITEM_NODE(
-          { id: "root", level: 1 },
-          TREE_VIEW_ITEM_NODE(
-            { id: "Root_Module", level: 2 },
-            TREE_VIEW_ITEM_NODE({ id: "Root_Module.BL", level: 3 })
-          )
-        )
-      )
+      TREE_VIEW_NODE_RENDER([
+        {
+          id: "root",
+          children: [{ id: "Root_Module", children: ["Root_Module.BL"] }]
+        }
+      ])
     );
   });
 
@@ -228,16 +213,17 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
     const filteredHTML = await getTreeViewRenderedContent();
 
     expect(filteredHTML).toEqual(
-      TREE_VIEW_NODE(
-        TREE_VIEW_ITEM_NODE(
-          { id: "root", level: 1 },
-          TREE_VIEW_ITEM_NODE(
-            { id: "Root_Module", level: 2 },
-            TREE_VIEW_ITEM_NODE({ id: "Root_Module.AWS_internal", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.General", level: 3 })
-          )
-        )
-      )
+      TREE_VIEW_NODE_RENDER([
+        {
+          id: "root",
+          children: [
+            {
+              id: "Root_Module",
+              children: ["Root_Module.AWS_internal", "Root_Module.General"]
+            }
+          ]
+        }
+      ])
     );
   });
 
@@ -249,21 +235,25 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
     const filteredHTML = await getTreeViewRenderedContent();
 
     expect(filteredHTML).toEqual(
-      TREE_VIEW_NODE(
-        TREE_VIEW_ITEM_NODE(
-          { id: "root", level: 1 },
-          TREE_VIEW_ITEM_NODE(
-            { id: "Root_Module", level: 2 },
-            TREE_VIEW_ITEM_NODE({ id: "Root_Module.AWS_internal", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.BL", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.General", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.IDE", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.Back", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.DataModel", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.Tests", level: 3 })
-          )
-        )
-      )
+      TREE_VIEW_NODE_RENDER([
+        {
+          id: "root",
+          children: [
+            {
+              id: "Root_Module",
+              children: [
+                "Root_Module.AWS_internal",
+                "Root_Module.BL",
+                "Root_Module.General",
+                "Root_Module.IDE",
+                "Root_Module.Back",
+                "Root_Module.DataModel",
+                "Root_Module.Tests"
+              ]
+            }
+          ]
+        }
+      ])
     );
   });
 
@@ -275,17 +265,21 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
     const filteredHTML = await getTreeViewRenderedContent();
 
     expect(filteredHTML).toEqual(
-      TREE_VIEW_NODE(
-        TREE_VIEW_ITEM_NODE(
-          { id: "root", level: 1 },
-          TREE_VIEW_ITEM_NODE(
-            { id: "Root_Module", level: 2 },
-            TREE_VIEW_ITEM_NODE({ id: "Root_Module.AWS_internal", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.General", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.DataModel", level: 3 })
-          )
-        )
-      )
+      TREE_VIEW_NODE_RENDER([
+        {
+          id: "root",
+          children: [
+            {
+              id: "Root_Module",
+              children: [
+                "Root_Module.AWS_internal",
+                "Root_Module.General",
+                "Root_Module.DataModel"
+              ]
+            }
+          ]
+        }
+      ])
     );
   });
 
@@ -299,17 +293,21 @@ describe('[ch-tree-view-render][filters][filter-type="metadata"]', () => {
     let filteredHTML = await getTreeViewRenderedContent();
 
     expect(filteredHTML).toEqual(
-      TREE_VIEW_NODE(
-        TREE_VIEW_ITEM_NODE(
-          { id: "root", level: 1 },
-          TREE_VIEW_ITEM_NODE(
-            { id: "Root_Module", level: 2 },
-            TREE_VIEW_ITEM_NODE({ id: "Root_Module.AWS_internal", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.General", level: 3 }) +
-              TREE_VIEW_ITEM_NODE({ id: "Root_Module.DataModel", level: 3 })
-          )
-        )
-      )
+      TREE_VIEW_NODE_RENDER([
+        {
+          id: "root",
+          children: [
+            {
+              id: "Root_Module",
+              children: [
+                "Root_Module.AWS_internal",
+                "Root_Module.General",
+                "Root_Module.DataModel"
+              ]
+            }
+          ]
+        }
+      ])
     );
 
     treeViewRef.setProperty("filterType", "none");

--- a/src/components/tree-view/tests/utils.e2e.ts
+++ b/src/components/tree-view/tests/utils.e2e.ts
@@ -1,0 +1,30 @@
+type TreeViewNodeTest =
+  | {
+      id: string;
+      class?: string;
+      children?: TreeViewNodeTest[];
+    }
+  | string;
+
+const ITEM_EXPORT_PARTS =
+  "item__action,item__checkbox,item__checkbox-container,item__checkbox-input,item__checkbox-option,item__downloading,item__edit-caption,item__expandable-button,item__group,item__header,item__img,item__line,disabled,expanded,collapsed,expand-button,even-level,odd-level,last-line,lazy-loaded,start-img,end-img,editing,not-editing,selected,not-selected,checked,unchecked,indeterminate,drag-enter";
+
+const TREE_VIEW_NODE = (children: string) =>
+  `<ch-tree-view class="not-dragging-item hydrated" exportparts="drag-preview">${children}</ch-tree-view>` as const;
+
+const TREE_VIEW_ITEM_NODE = (options: TreeViewNodeTest, level: number) => {
+  const isObject = typeof options === "object";
+
+  const id = isObject ? options.id : options;
+  const cssClass = isObject && options.class ? options.class + " " : "";
+  const children = isObject ? options.children ?? [] : [];
+
+  return `<ch-tree-view-item id="${id}" role="treeitem" aria-level="${level}" exportparts="${ITEM_EXPORT_PARTS}" class="${cssClass}hydrated" part="item" style="--level: ${
+    level - 1
+  };">${children
+    .map(node => TREE_VIEW_ITEM_NODE(node, level + 1))
+    .join("")}</ch-tree-view-item>` as const;
+};
+
+export const TREE_VIEW_NODE_RENDER = (children: TreeViewNodeTest[]) =>
+  TREE_VIEW_NODE(children.map(node => TREE_VIEW_ITEM_NODE(node, 1)).join(""));

--- a/src/components/tree-view/tree-view-render.tsx
+++ b/src/components/tree-view/tree-view-render.tsx
@@ -787,7 +787,7 @@ export class ChTreeViewRender {
     this.#scheduleCheckedItemsChange();
 
     // Update filters
-    this.#scheduleFilterProcessing();
+    this.#scheduleFilterProcessing("immediate");
 
     // Force re-render
     forceUpdate(this);

--- a/src/components/tree-view/tree-view-render.tsx
+++ b/src/components/tree-view/tree-view-render.tsx
@@ -1373,7 +1373,7 @@ export class ChTreeViewRender {
     this.#flattenSubModel(this.#rootNode);
 
     // Re-sync filters
-    this.#scheduleFilterProcessing();
+    this.#scheduleFilterProcessing("immediate");
 
     // The model was updated at runtime, so we need to update the references
     // Re-sync selected items
@@ -1528,6 +1528,8 @@ export class ChTreeViewRender {
 
       this.#checkIfThereAreDifferentItemsWithCheckbox(itemsWithCheckbox);
       this.#validateCheckedAndSelectedItems();
+      // Reset immediate filters, since there are not any filters to process
+      this.#immediateFilter = undefined;
 
       return;
     }

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -32,7 +32,12 @@ export const config: Config = {
     browserArgs: ["--no-sandbox", "--disable-setuid-sandbox"],
     verbose: true,
     browserHeadless: "new",
-    testPathIgnorePatterns: ["node_modules/", "src/testing/", "dist/"]
+    testPathIgnorePatterns: [
+      "node_modules/",
+      "src/testing/",
+      "dist/",
+      "src/components/tree-view/tests/utils.e2e.ts"
+    ]
   },
   bundles: [
     {


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fix: Do not debounce filters on the initial load.
   This fix also avoid an extra re-render on the initial load.

 - Fix: Do not debounce filters when updating the `model` property.

 - Fix: Do not debounce filters when lazy loading a subtree.