### PR TITLE
`[ch-theme]` Support to inline StyleSheets, `attachStyleSheets` property reactivity and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ npm run test.watch -- -- src/components/edit/<path to test file.<spec|e2e>.ts>
 npm run test.watch -- -- src/components/edit/tests/edit.e2e.ts
 ```
 
+To watch only one folder, run:
+
+```bash
+npm run test.watch -- -- <folder path>
+
+## For example:
+
+npm run test.watch -- -- src/components/edit/tests/
+```
+
 ### Building for production
 
 To build the design for production, run:

--- a/src/components/theme/tests/attachStyleSheets.e2e.ts
+++ b/src/components/theme/tests/attachStyleSheets.e2e.ts
@@ -1,0 +1,168 @@
+import {
+  E2EElement,
+  E2EPage,
+  EventSpy,
+  newE2EPage
+} from "@stencil/core/testing";
+import {
+  checkThemeValues,
+  EMPTY_ADOPTED_STYLESHEETS,
+  getDocumentAdoptedStyleSheets,
+  STYLE_SHEET2,
+  STYLE_SHEET2_NAME,
+  STYLESHEET_WITH_URLS,
+  TIME_TO_DOWNLOAD_CSS
+} from "./utils.e2e";
+import { ThemeModel } from "../theme-types";
+import { delayTest } from "../../../testing/utils.e2e";
+
+const URL_NAME = "test-urls";
+
+const URL_MODEL = [
+  { name: URL_NAME, url: "showcase/theme-test.css" }
+] as const satisfies ThemeModel;
+
+const INLINE_MODEL = [
+  { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
+] as const satisfies ThemeModel;
+
+const MULTIPLE_MODEL = [
+  { name: URL_NAME, url: "showcase/theme-test.css" },
+  { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
+] as const satisfies ThemeModel;
+
+describe("[ch-theme][attachStyleSheets]", () => {
+  let page: E2EPage;
+  let themeRef: E2EElement;
+  let themeLoadedSpy: EventSpy;
+
+  const setModel = async (model: ThemeModel) => {
+    themeRef.setProperty("model", model);
+    await page.waitForChanges();
+  };
+
+  const checkValues = async (
+    successModelsToCheck: string[],
+    styleSheetsToCheck: string[]
+  ) =>
+    checkThemeValues(
+      page,
+      themeLoadedSpy,
+      successModelsToCheck,
+      styleSheetsToCheck
+    );
+
+  beforeEach(async () => {
+    page = await newE2EPage({ html: `<ch-theme></ch-theme>` });
+    themeRef = await page.find("ch-theme");
+    themeLoadedSpy = await themeRef.spyOnEvent("themeLoaded");
+  });
+
+  it("should attach the stylesheet by default (stylesheet by URL)", async () => {
+    await setModel(URL_MODEL);
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
+
+    await checkValues([URL_NAME], [STYLESHEET_WITH_URLS]);
+  });
+
+  it("should attach the stylesheet by default (inline stylesheet)", async () => {
+    await setModel(INLINE_MODEL);
+
+    await checkValues([STYLE_SHEET2_NAME], [STYLE_SHEET2]);
+  });
+
+  it("should attach multiple stylesheets by default", async () => {
+    await setModel(MULTIPLE_MODEL);
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
+
+    await checkValues(
+      [URL_NAME, STYLE_SHEET2_NAME],
+      [STYLESHEET_WITH_URLS, STYLE_SHEET2]
+    );
+  });
+
+  it('should not attach the stylesheet if "attachStyleSheets === false" (stylesheet by URL)', async () => {
+    themeRef.setProperty("attachStyleSheets", false);
+    await setModel(URL_MODEL);
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
+
+    await checkValues([URL_NAME], EMPTY_ADOPTED_STYLESHEETS);
+  });
+
+  it('should not attach the stylesheet if "attachStyleSheets === false" (inline stylesheet)', async () => {
+    themeRef.setProperty("attachStyleSheets", false);
+    await setModel(INLINE_MODEL);
+
+    await checkValues([STYLE_SHEET2_NAME], EMPTY_ADOPTED_STYLESHEETS);
+  });
+
+  it('should not attach multiple stylesheets if "attachStyleSheets === false"', async () => {
+    themeRef.setProperty("attachStyleSheets", false);
+    await setModel(MULTIPLE_MODEL);
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
+
+    await checkValues([URL_NAME, STYLE_SHEET2_NAME], EMPTY_ADOPTED_STYLESHEETS);
+  });
+
+  const testReactiveTrueFalse = (
+    model: ThemeModel,
+    description: string,
+    delay = false
+  ) => {
+    it(`attachStyleSheets should be reactive: true -> false ${description}`, async () => {
+      await setModel(model);
+      if (delay) {
+        await delayTest(TIME_TO_DOWNLOAD_CSS);
+      }
+
+      themeRef.setProperty("attachStyleSheets", false);
+      await page.waitForChanges();
+      expect(await getDocumentAdoptedStyleSheets(page)).toEqual(
+        EMPTY_ADOPTED_STYLESHEETS
+      );
+    });
+  };
+  testReactiveTrueFalse(URL_MODEL, "(stylesheet by URL)", true);
+  testReactiveTrueFalse(INLINE_MODEL, "(inline stylesheet)");
+  testReactiveTrueFalse(MULTIPLE_MODEL, "(multiple stylesheets)", true);
+
+  const testReactiveFalseTrue = (
+    model: ThemeModel,
+    description: string,
+    successModelsToCheck: string[],
+    styleSheetsToCheck: string[],
+    delay = false
+  ) => {
+    it(`attachStyleSheets should be reactive: false -> true ${description}`, async () => {
+      themeRef.setProperty("attachStyleSheets", false);
+      await setModel(model);
+      if (delay) {
+        await delayTest(TIME_TO_DOWNLOAD_CSS);
+      }
+
+      themeRef.setProperty("attachStyleSheets", true);
+      await page.waitForChanges();
+      await checkValues(successModelsToCheck, styleSheetsToCheck);
+    });
+  };
+  testReactiveFalseTrue(
+    URL_MODEL,
+    "(stylesheet by URL)",
+    [URL_NAME],
+    [STYLESHEET_WITH_URLS],
+    true
+  );
+  testReactiveFalseTrue(
+    INLINE_MODEL,
+    "(inline stylesheet)",
+    [STYLE_SHEET2_NAME],
+    [STYLE_SHEET2]
+  );
+  testReactiveFalseTrue(
+    MULTIPLE_MODEL,
+    "(multiple stylesheets)",
+    [URL_NAME, STYLE_SHEET2_NAME],
+    [STYLESHEET_WITH_URLS, STYLE_SHEET2],
+    true
+  );
+});

--- a/src/components/theme/tests/attachStyleSheets.e2e.ts
+++ b/src/components/theme/tests/attachStyleSheets.e2e.ts
@@ -8,28 +8,17 @@ import {
   checkThemeValues,
   EMPTY_ADOPTED_STYLESHEETS,
   getDocumentAdoptedStyleSheets,
+  INLINE_MODEL_2,
+  MULTIPLE_MODEL,
   STYLE_SHEET2,
   STYLE_SHEET2_NAME,
   STYLESHEET_WITH_URLS,
-  TIME_TO_DOWNLOAD_CSS
+  TIME_TO_DOWNLOAD_CSS,
+  URL_MODEL,
+  URL_NAME
 } from "./utils.e2e";
 import { ThemeModel } from "../theme-types";
 import { delayTest } from "../../../testing/utils.e2e";
-
-const URL_NAME = "test-urls";
-
-const URL_MODEL = [
-  { name: URL_NAME, url: "showcase/theme-test.css" }
-] as const satisfies ThemeModel;
-
-const INLINE_MODEL = [
-  { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
-] as const satisfies ThemeModel;
-
-const MULTIPLE_MODEL = [
-  { name: URL_NAME, url: "showcase/theme-test.css" },
-  { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
-] as const satisfies ThemeModel;
 
 describe("[ch-theme][attachStyleSheets]", () => {
   let page: E2EPage;
@@ -66,7 +55,7 @@ describe("[ch-theme][attachStyleSheets]", () => {
   });
 
   it("should attach the stylesheet by default (inline stylesheet)", async () => {
-    await setModel(INLINE_MODEL);
+    await setModel(INLINE_MODEL_2);
 
     await checkValues([STYLE_SHEET2_NAME], [STYLE_SHEET2]);
   });
@@ -91,7 +80,7 @@ describe("[ch-theme][attachStyleSheets]", () => {
 
   it('should not attach the stylesheet if "attachStyleSheets === false" (inline stylesheet)', async () => {
     themeRef.setProperty("attachStyleSheets", false);
-    await setModel(INLINE_MODEL);
+    await setModel(INLINE_MODEL_2);
 
     await checkValues([STYLE_SHEET2_NAME], EMPTY_ADOPTED_STYLESHEETS);
   });
@@ -123,7 +112,7 @@ describe("[ch-theme][attachStyleSheets]", () => {
     });
   };
   testReactiveTrueFalse(URL_MODEL, "(stylesheet by URL)", true);
-  testReactiveTrueFalse(INLINE_MODEL, "(inline stylesheet)");
+  testReactiveTrueFalse(INLINE_MODEL_2, "(inline stylesheet)");
   testReactiveTrueFalse(MULTIPLE_MODEL, "(multiple stylesheets)", true);
 
   const testReactiveFalseTrue = (
@@ -153,7 +142,7 @@ describe("[ch-theme][attachStyleSheets]", () => {
     true
   );
   testReactiveFalseTrue(
-    INLINE_MODEL,
+    INLINE_MODEL_2,
     "(inline stylesheet)",
     [STYLE_SHEET2_NAME],
     [STYLE_SHEET2]

--- a/src/components/theme/tests/base-url.e2e.ts
+++ b/src/components/theme/tests/base-url.e2e.ts
@@ -4,33 +4,15 @@ import {
   EventSpy,
   newE2EPage
 } from "@stencil/core/testing";
-import { checkThemeValues, TIME_TO_DOWNLOAD_CSS } from "./utils.e2e";
+import {
+  BASE_URL,
+  checkThemeValues,
+  STYLESHEET_WITH_TRANSFORMED_URLS,
+  STYLESHEET_WITH_URLS,
+  TIME_TO_DOWNLOAD_CSS
+} from "./utils.e2e";
 import { ThemeModel } from "../theme-types";
 import { delayTest } from "../../../testing/utils.e2e";
-
-const BASE_URL = "https://example.com/";
-
-const STYLESHEET_WITH_URLS = `.rule-1 { background-image: url("images/background.png"); }
-.rule-2 { background-image: url("/images/background.png"); }
-.rule-3 { background-image: url("../assets/images/logo.svg"); }
-.rule-4 { background-image: url("./assets/images/logo.svg"); }
-.rule-5 { background-image: url("logo.png"); }
-.not-valid-1 { background-image: url("http://example.com/image.png"); }
-.not-valid-2 { background-image: url("https://example.com/image.png"); }
-.not-valid-3 { background-image: url("data:image/png;base64,..."); }
-.not-valid-4 { background-image: url("file:///C:/images/background.png"); }
-.not-valid-5 { background-image: url("data:image/svg+xml,<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M10 17.42L5 12.42L6.41 11L10 14.59L17.59 7L19 8.42L10 17.42Z\\"/></svg>"); }`;
-
-const STYLESHEET_WITH_TRANSFORMED_URLS = `.rule-1 { background-image: url("${BASE_URL}images/background.png"); }
-.rule-2 { background-image: url("${BASE_URL}/images/background.png"); }
-.rule-3 { background-image: url("${BASE_URL}../assets/images/logo.svg"); }
-.rule-4 { background-image: url("${BASE_URL}./assets/images/logo.svg"); }
-.rule-5 { background-image: url("${BASE_URL}logo.png"); }
-.not-valid-1 { background-image: url("http://example.com/image.png"); }
-.not-valid-2 { background-image: url("https://example.com/image.png"); }
-.not-valid-3 { background-image: url("data:image/png;base64,..."); }
-.not-valid-4 { background-image: url("file:///C:/images/background.png"); }
-.not-valid-5 { background-image: url("data:image/svg+xml,<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M10 17.42L5 12.42L6.41 11L10 14.59L17.59 7L19 8.42L10 17.42Z\\"/></svg>"); }`;
 
 describe("[ch-theme][baseUrl]", () => {
   let page: E2EPage;
@@ -59,7 +41,7 @@ describe("[ch-theme][baseUrl]", () => {
     themeLoadedSpy = await themeRef.spyOnEvent("themeLoaded");
   });
 
-  it("should not transform the URLs if the base themeBaseUrl is not set (stylesheet downloaded with an URL)", async () => {
+  it("should not transform the URLs if the themeBaseUrl is not set (stylesheet downloaded with an URL)", async () => {
     await setModel(themeRef, [
       { name: "test-urls", url: "showcase/theme-test.css" }
     ]);
@@ -68,7 +50,7 @@ describe("[ch-theme][baseUrl]", () => {
     checkValues(["test-urls"], [STYLESHEET_WITH_URLS]);
   });
 
-  it("should not transform the URLs if the base themeBaseUrl is not set (inline stylesheet)", async () => {
+  it("should not transform the URLs if the themeBaseUrl is not set (inline stylesheet)", async () => {
     await setModel(themeRef, [
       { name: "test-urls", styleSheet: STYLESHEET_WITH_URLS }
     ]);

--- a/src/components/theme/tests/base-url.e2e.ts
+++ b/src/components/theme/tests/base-url.e2e.ts
@@ -1,14 +1,102 @@
-// import { E2EPage, newE2EPage } from "@stencil/core/testing";
+import {
+  E2EElement,
+  E2EPage,
+  EventSpy,
+  newE2EPage
+} from "@stencil/core/testing";
+import { checkThemeValues } from "./utils.e2e";
+import { ThemeModel } from "../theme-types";
+
+const BASE_URL = "https://example.com/";
+
+const STYLESHEET_WITH_URLS = `.rule-1 { background-image: url("images/background.png"); }
+.rule-2 { background-image: url("/images/background.png"); }
+.rule-3 { background-image: url("../assets/images/logo.svg"); }
+.rule-4 { background-image: url("./assets/images/logo.svg"); }
+.rule-5 { background-image: url("logo.png"); }
+.not-valid-1 { background-image: url("http://example.com/image.png"); }
+.not-valid-2 { background-image: url("https://example.com/image.png"); }
+.not-valid-3 { background-image: url("data:image/png;base64,..."); }
+.not-valid-4 { background-image: url("file:///C:/images/background.png"); }
+.not-valid-5 { background-image: url("data:image/svg+xml,<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M10 17.42L5 12.42L6.41 11L10 14.59L17.59 7L19 8.42L10 17.42Z\\"/></svg>"); }`;
+
+const STYLESHEET_WITH_TRANSFORMED_URLS = `.rule-1 { background-image: url("${BASE_URL}images/background.png"); }
+.rule-2 { background-image: url("${BASE_URL}/images/background.png"); }
+.rule-3 { background-image: url("${BASE_URL}../assets/images/logo.svg"); }
+.rule-4 { background-image: url("${BASE_URL}./assets/images/logo.svg"); }
+.rule-5 { background-image: url("${BASE_URL}logo.png"); }
+.not-valid-1 { background-image: url("http://example.com/image.png"); }
+.not-valid-2 { background-image: url("https://example.com/image.png"); }
+.not-valid-3 { background-image: url("data:image/png;base64,..."); }
+.not-valid-4 { background-image: url("file:///C:/images/background.png"); }
+.not-valid-5 { background-image: url("data:image/svg+xml,<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M10 17.42L5 12.42L6.41 11L10 14.59L17.59 7L19 8.42L10 17.42Z\\"/></svg>"); }`;
 
 describe("[ch-theme][baseUrl]", () => {
-  // let page: E2EPage;
+  let page: E2EPage;
+  let themeRef: E2EElement;
+  let themeLoadedSpy: EventSpy;
+
+  const setModel = async (themeRef: E2EElement, model: ThemeModel) => {
+    themeRef.setProperty("model", model);
+    await page.waitForChanges();
+  };
+
+  const checkValues = async (
+    successModelsToCheck: string[],
+    styleSheetsToCheck: string[]
+  ) =>
+    checkThemeValues(
+      page,
+      themeLoadedSpy,
+      successModelsToCheck,
+      styleSheetsToCheck
+    );
 
   beforeEach(async () => {
-    // page = await newE2EPage({
-    //   html: `<ch-theme></ch-theme>`
-    // });
+    page = await newE2EPage({ html: `<ch-theme></ch-theme>` });
+    themeRef = await page.find("ch-theme");
+    themeLoadedSpy = await themeRef.spyOnEvent("themeLoaded");
   });
 
-  it.todo("should applyBaseUrl for stylesheets that comes from an url");
-  it.todo("should applyBaseUrl for inline stylesheets");
+  it("should not transform the URLs if the base themeBaseUrl is not set (stylesheet downloaded with an URL)", async () => {
+    await setModel(themeRef, [
+      { name: "test-urls", url: "showcase/theme-test.css" }
+    ]);
+
+    checkValues(["test-urls"], [STYLESHEET_WITH_URLS]);
+  });
+
+  it("should not transform the URLs if the base themeBaseUrl is not set (inline stylesheet)", async () => {
+    await setModel(themeRef, [
+      { name: "test-urls", styleSheet: STYLESHEET_WITH_URLS }
+    ]);
+
+    checkValues(["test-urls"], [STYLESHEET_WITH_URLS]);
+  });
+
+  // TODO: Fix the function (applyBaseUrl) used for this
+  it.skip("should add the baseUrl if the themeBaseUrl property is set (stylesheet downloaded with an URL)", async () => {
+    await setModel(themeRef, [
+      {
+        name: "test-urls",
+        url: "showcase/theme-test.css",
+        themeBaseUrl: BASE_URL
+      }
+    ]);
+
+    checkValues(["test-urls"], [STYLESHEET_WITH_TRANSFORMED_URLS]);
+  });
+
+  // TODO: Fix the function (applyBaseUrl) used for this
+  it.skip("should add the baseUrl if the themeBaseUrl property is set (inline stylesheet)", async () => {
+    await setModel(themeRef, [
+      {
+        name: "test-urls",
+        styleSheet: STYLESHEET_WITH_URLS,
+        themeBaseUrl: BASE_URL
+      }
+    ]);
+
+    checkValues(["test-urls"], [STYLESHEET_WITH_TRANSFORMED_URLS]);
+  });
 });

--- a/src/components/theme/tests/base-url.e2e.ts
+++ b/src/components/theme/tests/base-url.e2e.ts
@@ -4,8 +4,9 @@ import {
   EventSpy,
   newE2EPage
 } from "@stencil/core/testing";
-import { checkThemeValues } from "./utils.e2e";
+import { checkThemeValues, TIME_TO_DOWNLOAD_CSS } from "./utils.e2e";
 import { ThemeModel } from "../theme-types";
+import { delayTest } from "../../../testing/utils.e2e";
 
 const BASE_URL = "https://example.com/";
 
@@ -62,6 +63,7 @@ describe("[ch-theme][baseUrl]", () => {
     await setModel(themeRef, [
       { name: "test-urls", url: "showcase/theme-test.css" }
     ]);
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
 
     checkValues(["test-urls"], [STYLESHEET_WITH_URLS]);
   });
@@ -83,6 +85,7 @@ describe("[ch-theme][baseUrl]", () => {
         themeBaseUrl: BASE_URL
       }
     ]);
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
 
     checkValues(["test-urls"], [STYLESHEET_WITH_TRANSFORMED_URLS]);
   });

--- a/src/components/theme/tests/base-url.e2e.ts
+++ b/src/components/theme/tests/base-url.e2e.ts
@@ -1,0 +1,14 @@
+// import { E2EPage, newE2EPage } from "@stencil/core/testing";
+
+describe("[ch-theme][baseUrl]", () => {
+  // let page: E2EPage;
+
+  beforeEach(async () => {
+    // page = await newE2EPage({
+    //   html: `<ch-theme></ch-theme>`
+    // });
+  });
+
+  it.todo("should applyBaseUrl for stylesheets that comes from an url");
+  it.todo("should applyBaseUrl for inline stylesheets");
+});

--- a/src/components/theme/tests/basic.e2e.ts
+++ b/src/components/theme/tests/basic.e2e.ts
@@ -24,7 +24,7 @@ describe("[ch-theme][basic]", () => {
   });
 
   it("should not have Shadow DOM", async () => {
-    expect(themeRef.shadowRoot).toBeFalsy();
+    expect(themeRef.shadowRoot).toBeNull();
   });
 
   it('the "attachStyleSheets" property should be true by default', async () => {
@@ -190,5 +190,9 @@ describe("[ch-theme][basic]", () => {
 
   it.todo(
     "should not hide the UI when all stylesheets are already loaded by another ch-theme"
+  );
+
+  it.todo(
+    'should work with an item that is an object { name: "something", url: "..." }'
   );
 });

--- a/src/components/theme/tests/reuse.e2e.ts
+++ b/src/components/theme/tests/reuse.e2e.ts
@@ -1,0 +1,131 @@
+import {
+  E2EElement,
+  E2EPage,
+  EventSpy,
+  newE2EPage
+} from "@stencil/core/testing";
+import { ChThemeLoadedEvent, ThemeModel } from "../theme-types";
+import {
+  CSS_CONTENT,
+  CSS_NAME,
+  CSS_URL,
+  STYLE_SHEET1,
+  STYLE_SHEET1_NAME,
+  STYLE_SHEET2,
+  STYLE_SHEET2_NAME
+} from "./utils.e2e";
+
+describe("[ch-theme][reuse]", () => {
+  let page: E2EPage;
+  let markdownViewerRef: E2EElement;
+  let theme1Ref: E2EElement;
+  let theme2Ref: E2EElement;
+  let themeLoaded1Spy: EventSpy;
+  let themeLoaded2Spy: EventSpy;
+
+  const setModel = async (themeRef: E2EElement, model: ThemeModel) => {
+    themeRef.setProperty("model", model);
+    await page.waitForChanges();
+  };
+
+  const getDocumentAdoptedStyleSheets = () =>
+    page.evaluate(() =>
+      document.adoptedStyleSheets.map(sheet => sheet.cssRules[0].cssText)
+    );
+
+  const getMarkdownViewerAdoptedStyleSheets = () =>
+    page.evaluate(() =>
+      document
+        .querySelector("ch-markdown-viewer")
+        .shadowRoot.adoptedStyleSheets.map(sheet => sheet.cssRules[0].cssText)
+    );
+
+  const checkValues = async (
+    successModelsToCheck: string[],
+    styleSheetsToCheck: string[],
+    spy: 1 | 2 = 1
+  ) => {
+    const adoptedStyleSheets = await getDocumentAdoptedStyleSheets();
+    expect(adoptedStyleSheets).toEqual(styleSheetsToCheck);
+
+    if (spy === 1) {
+      expect(themeLoaded1Spy).toHaveReceivedEventTimes(1);
+      expect(themeLoaded1Spy).toHaveReceivedEventDetail({
+        success: successModelsToCheck
+      } satisfies ChThemeLoadedEvent);
+    } else {
+      expect(themeLoaded2Spy).toHaveReceivedEventTimes(1);
+      expect(themeLoaded2Spy).toHaveReceivedEventDetail({
+        success: successModelsToCheck
+      } satisfies ChThemeLoadedEvent);
+    }
+  };
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-theme id="theme-a"></ch-theme>
+      <ch-theme id="theme-b"></ch-theme>
+      <ch-markdown-viewer theme=""></ch-markdown-viewer>`
+    });
+    markdownViewerRef = await page.find("ch-markdown-viewer");
+    theme1Ref = await page.find("[id='theme-a']");
+    theme2Ref = await page.find("[id='theme-b']");
+    themeLoaded1Spy = await theme1Ref.spyOnEvent("themeLoaded");
+    themeLoaded2Spy = await theme2Ref.spyOnEvent("themeLoaded");
+  });
+
+  it("should work with multiple ch-theme defined for the same root", async () => {
+    await setModel(theme1Ref, [
+      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
+    ]);
+    await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1]);
+
+    await setModel(theme2Ref, [
+      { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
+    ]);
+    await checkValues([STYLE_SHEET2_NAME], [STYLE_SHEET1, STYLE_SHEET2], 2);
+  });
+
+  it("should work with multiple ch-theme defined for the same root, even if the item have inline stylesheets", async () => {
+    await setModel(theme1Ref, [
+      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
+    ]);
+    await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1]);
+
+    await setModel(theme2Ref, [
+      { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 },
+      { name: CSS_NAME, url: CSS_URL }
+    ]);
+    await checkValues(
+      [STYLE_SHEET2_NAME, CSS_NAME],
+      [STYLE_SHEET1, STYLE_SHEET2, CSS_CONTENT],
+      2
+    );
+  });
+
+  it.skip("should adopt/reuse the stylesheet defined by another ch-theme (same root)", async () => {
+    await setModel(theme2Ref, [
+      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
+    ]);
+    await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1]);
+
+    await setModel(theme2Ref, STYLE_SHEET1_NAME);
+    await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1], 2);
+  });
+
+  it.skip("should adopt/reuse the stylesheet defined by another ch-theme (different root)", async () => {
+    await setModel(theme1Ref, [
+      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
+    ]);
+
+    markdownViewerRef.setProperty("theme", STYLE_SHEET1_NAME);
+    await page.waitForChanges();
+    expect(await getMarkdownViewerAdoptedStyleSheets()).toContainEqual(
+      STYLE_SHEET1
+    );
+  });
+
+  it.skip("should not duplicate the stylesheet adoption when another ch-theme loads the same CSS", async () => {
+    // TODO: Add implementation
+  });
+});

--- a/src/components/theme/tests/reuse.e2e.ts
+++ b/src/components/theme/tests/reuse.e2e.ts
@@ -35,7 +35,9 @@ describe("[ch-theme][reuse]", () => {
     page.evaluate(() =>
       document
         .querySelector("ch-markdown-viewer")
-        .shadowRoot.adoptedStyleSheets.map(sheet => sheet.cssRules[0].cssText)
+        .shadowRoot.adoptedStyleSheets.map(stylesheet =>
+          [...stylesheet.cssRules].map(rule => rule.cssText).join("\n")
+        )
     );
 
   const checkValues = async (
@@ -93,8 +95,8 @@ describe("[ch-theme][reuse]", () => {
     );
   });
 
-  it.skip("should adopt/reuse the stylesheet defined by another ch-theme (same root)", async () => {
-    await setModel(theme2Ref, [
+  it("should adopt/reuse the stylesheet defined by another ch-theme (same root)", async () => {
+    await setModel(theme1Ref, [
       { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
     ]);
     await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1]);
@@ -103,7 +105,7 @@ describe("[ch-theme][reuse]", () => {
     await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1], 2);
   });
 
-  it.skip("should adopt/reuse the stylesheet defined by another ch-theme (different root)", async () => {
+  it("should adopt/reuse the stylesheet defined by another ch-theme (different root)", async () => {
     await setModel(theme1Ref, [
       { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
     ]);

--- a/src/components/theme/tests/reuse.e2e.ts
+++ b/src/components/theme/tests/reuse.e2e.ts
@@ -10,11 +10,16 @@ import {
   CSS_CONTENT,
   CSS_NAME,
   CSS_URL,
+  INLINE_MODEL_1,
+  INLINE_MODEL_2,
   STYLE_SHEET1,
   STYLE_SHEET1_NAME,
   STYLE_SHEET2,
   STYLE_SHEET2_NAME,
-  TIME_TO_DOWNLOAD_CSS
+  STYLESHEET_WITH_URLS,
+  TIME_TO_DOWNLOAD_CSS,
+  URL_MODEL,
+  URL_NAME
 } from "./utils.e2e";
 import { delayTest } from "../../../testing/utils.e2e";
 
@@ -66,21 +71,15 @@ describe("[ch-theme][reuse]", () => {
   });
 
   it("should work with multiple ch-theme defined for the same root", async () => {
-    await setModel(theme1Ref, [
-      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
-    ]);
+    await setModel(theme1Ref, INLINE_MODEL_1);
     await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1]);
 
-    await setModel(theme2Ref, [
-      { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
-    ]);
+    await setModel(theme2Ref, INLINE_MODEL_2);
     await checkValues([STYLE_SHEET2_NAME], [STYLE_SHEET1, STYLE_SHEET2], 2);
   });
 
   it("should work with multiple ch-theme defined for the same root, even if the item have inline stylesheets", async () => {
-    await setModel(theme1Ref, [
-      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
-    ]);
+    await setModel(theme1Ref, INLINE_MODEL_1);
     await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1]);
 
     await setModel(theme2Ref, [
@@ -95,20 +94,35 @@ describe("[ch-theme][reuse]", () => {
     );
   });
 
-  it("should adopt/reuse the stylesheet defined by another ch-theme (same root)", async () => {
-    await setModel(theme1Ref, [
-      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
-    ]);
+  it("should adopt/reuse the stylesheet with URL defined by another ch-theme (same root)", async () => {
+    await setModel(theme1Ref, URL_MODEL);
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
+    await checkValues([URL_NAME], [STYLESHEET_WITH_URLS]);
+
+    await setModel(theme2Ref, URL_NAME);
+    await checkValues([URL_NAME], [STYLESHEET_WITH_URLS], 2);
+  });
+
+  it("should adopt/reuse the inline stylesheet defined by another ch-theme (same root)", async () => {
+    await setModel(theme1Ref, INLINE_MODEL_1);
     await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1]);
 
     await setModel(theme2Ref, STYLE_SHEET1_NAME);
     await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1], 2);
   });
 
-  it("should adopt/reuse the stylesheet defined by another ch-theme (different root)", async () => {
-    await setModel(theme1Ref, [
-      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
-    ]);
+  it.skip("should adopt/reuse the stylesheet with URL defined by another ch-theme (different root)", async () => {
+    await setModel(theme1Ref, URL_MODEL);
+
+    markdownViewerRef.setProperty("theme", URL_NAME);
+    await page.waitForChanges();
+    expect(await getMarkdownViewerAdoptedStyleSheets()).toContainEqual(
+      STYLESHEET_WITH_URLS
+    );
+  });
+
+  it.skip("should adopt/reuse the inline stylesheet defined by another ch-theme (different root)", async () => {
+    await setModel(theme1Ref, INLINE_MODEL_1);
 
     markdownViewerRef.setProperty("theme", STYLE_SHEET1_NAME);
     await page.waitForChanges();

--- a/src/components/theme/tests/reuse.e2e.ts
+++ b/src/components/theme/tests/reuse.e2e.ts
@@ -6,6 +6,7 @@ import {
 } from "@stencil/core/testing";
 import { ChThemeLoadedEvent, ThemeModel } from "../theme-types";
 import {
+  checkThemeValues,
   CSS_CONTENT,
   CSS_NAME,
   CSS_URL,
@@ -28,11 +29,6 @@ describe("[ch-theme][reuse]", () => {
     await page.waitForChanges();
   };
 
-  const getDocumentAdoptedStyleSheets = () =>
-    page.evaluate(() =>
-      document.adoptedStyleSheets.map(sheet => sheet.cssRules[0].cssText)
-    );
-
   const getMarkdownViewerAdoptedStyleSheets = () =>
     page.evaluate(() =>
       document
@@ -44,22 +40,13 @@ describe("[ch-theme][reuse]", () => {
     successModelsToCheck: string[],
     styleSheetsToCheck: string[],
     spy: 1 | 2 = 1
-  ) => {
-    const adoptedStyleSheets = await getDocumentAdoptedStyleSheets();
-    expect(adoptedStyleSheets).toEqual(styleSheetsToCheck);
-
-    if (spy === 1) {
-      expect(themeLoaded1Spy).toHaveReceivedEventTimes(1);
-      expect(themeLoaded1Spy).toHaveReceivedEventDetail({
-        success: successModelsToCheck
-      } satisfies ChThemeLoadedEvent);
-    } else {
-      expect(themeLoaded2Spy).toHaveReceivedEventTimes(1);
-      expect(themeLoaded2Spy).toHaveReceivedEventDetail({
-        success: successModelsToCheck
-      } satisfies ChThemeLoadedEvent);
-    }
-  };
+  ) =>
+    checkThemeValues(
+      page,
+      spy === 1 ? themeLoaded1Spy : themeLoaded2Spy,
+      successModelsToCheck,
+      styleSheetsToCheck
+    );
 
   beforeEach(async () => {
     page = await newE2EPage({

--- a/src/components/theme/tests/reuse.e2e.ts
+++ b/src/components/theme/tests/reuse.e2e.ts
@@ -4,7 +4,7 @@ import {
   EventSpy,
   newE2EPage
 } from "@stencil/core/testing";
-import { ChThemeLoadedEvent, ThemeModel } from "../theme-types";
+import { ThemeModel } from "../theme-types";
 import {
   checkThemeValues,
   CSS_CONTENT,
@@ -13,8 +13,10 @@ import {
   STYLE_SHEET1,
   STYLE_SHEET1_NAME,
   STYLE_SHEET2,
-  STYLE_SHEET2_NAME
+  STYLE_SHEET2_NAME,
+  TIME_TO_DOWNLOAD_CSS
 } from "./utils.e2e";
+import { delayTest } from "../../../testing/utils.e2e";
 
 describe("[ch-theme][reuse]", () => {
   let page: E2EPage;
@@ -83,6 +85,7 @@ describe("[ch-theme][reuse]", () => {
       { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 },
       { name: CSS_NAME, url: CSS_URL }
     ]);
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
     await checkValues(
       [STYLE_SHEET2_NAME, CSS_NAME],
       [STYLE_SHEET1, STYLE_SHEET2, CSS_CONTENT],

--- a/src/components/theme/tests/style.e2e.ts
+++ b/src/components/theme/tests/style.e2e.ts
@@ -1,0 +1,58 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import { ThemeModel } from "../theme-types";
+
+const STYLE_TO_HIDE_ROOT_NODE =
+  "<style>:host,html{visibility:hidden !important}</style>";
+
+describe("[ch-theme][style]", () => {
+  let page: E2EPage;
+  let themeRef: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage({ html: `<ch-theme></ch-theme>` });
+    themeRef = await page.find("ch-theme");
+  });
+
+  const avoidFlashEnabledTest = (
+    model: undefined | null | ThemeModel,
+    additionalDescription: string
+  ) => {
+    it(`should hide the root node if avoidFlashOfUnstyledContent is set, ${additionalDescription}`, async () => {
+      themeRef.setProperty("model", model);
+      await page.waitForChanges();
+
+      // TODO: For some reason, we have to query the reference again to have
+      // the updated innerHTML...
+      themeRef = await page.find("ch-theme");
+
+      expect(themeRef.innerHTML).toBe(STYLE_TO_HIDE_ROOT_NODE);
+    });
+  };
+  avoidFlashEnabledTest(undefined, "model = undefined");
+  avoidFlashEnabledTest(null, "model = null");
+  avoidFlashEnabledTest([], "model = []");
+  avoidFlashEnabledTest("", 'model = ""');
+  avoidFlashEnabledTest("dummy", 'model = "dummy"');
+
+  const avoidFlashDisabledTest = (
+    model: undefined | null | ThemeModel,
+    additionalDescription: string
+  ) => {
+    it(`should NOT hide the root node if avoidFlashOfUnstyledContent is false, ${additionalDescription}`, async () => {
+      themeRef.setProperty("model", model);
+      themeRef.setProperty("avoidFlashOfUnstyledContent", false);
+      await page.waitForChanges();
+
+      // TODO: For some reason, we have to query the reference again to have
+      // the updated innerHTML...
+      themeRef = await page.find("ch-theme");
+
+      expect(themeRef.innerHTML).toBe("");
+    });
+  };
+  avoidFlashDisabledTest(undefined, "model = undefined");
+  avoidFlashDisabledTest(null, "model = null");
+  avoidFlashDisabledTest([], "model = []");
+  avoidFlashDisabledTest("", 'model = ""');
+  avoidFlashDisabledTest("dummy", 'model = "dummy"');
+});

--- a/src/components/theme/tests/stylesheet.e2e.ts
+++ b/src/components/theme/tests/stylesheet.e2e.ts
@@ -12,8 +12,10 @@ import {
   STYLE_SHEET1,
   STYLE_SHEET1_NAME,
   STYLE_SHEET2,
-  STYLE_SHEET2_NAME
+  STYLE_SHEET2_NAME,
+  TIME_TO_DOWNLOAD_CSS
 } from "./utils.e2e";
+import { delayTest } from "../../../testing/utils.e2e";
 
 describe("[ch-theme][stylesheet]", () => {
   let page: E2EPage;
@@ -76,6 +78,8 @@ describe("[ch-theme][stylesheet]", () => {
       { name: CSS_NAME, url: CSS_URL }
     ] satisfies ThemeModel);
     await page.waitForChanges();
+
+    await delayTest(TIME_TO_DOWNLOAD_CSS);
 
     await checkValues(
       [STYLE_SHEET1_NAME, STYLE_SHEET2_NAME, CSS_NAME],

--- a/src/components/theme/tests/stylesheet.e2e.ts
+++ b/src/components/theme/tests/stylesheet.e2e.ts
@@ -1,0 +1,85 @@
+import {
+  E2EElement,
+  E2EPage,
+  EventSpy,
+  newE2EPage
+} from "@stencil/core/testing";
+import { ChThemeLoadedEvent, ThemeModel } from "../theme-types";
+import {
+  CSS_CONTENT,
+  CSS_NAME,
+  CSS_URL,
+  STYLE_SHEET1,
+  STYLE_SHEET1_NAME,
+  STYLE_SHEET2,
+  STYLE_SHEET2_NAME
+} from "./utils.e2e";
+
+describe("[ch-theme][stylesheet]", () => {
+  let page: E2EPage;
+  let themeRef: E2EElement;
+  let themeLoadedSpy: EventSpy;
+
+  const getAdoptedStyleSheets = () =>
+    page.evaluate(() =>
+      document.adoptedStyleSheets.map(sheet => sheet.cssRules[0].cssText)
+    );
+
+  const checkValues = async (
+    successModelsToCheck: string[],
+    styleSheetsToCheck: string[]
+  ) => {
+    const adoptedStyleSheets = await getAdoptedStyleSheets();
+
+    // It contains the style of the inline stylesheet
+    expect(adoptedStyleSheets).toEqual(styleSheetsToCheck);
+
+    expect(themeLoadedSpy).toHaveReceivedEventTimes(1);
+    expect(themeLoadedSpy).toHaveReceivedEventDetail({
+      success: successModelsToCheck
+    } satisfies ChThemeLoadedEvent);
+  };
+
+  beforeEach(async () => {
+    page = await newE2EPage({ html: `<ch-theme></ch-theme>` });
+    themeRef = await page.find("ch-theme");
+    themeLoadedSpy = await themeRef.spyOnEvent("themeLoaded");
+  });
+
+  it("should support the stylesheet property", async () => {
+    themeRef.setProperty("model", {
+      name: STYLE_SHEET1_NAME,
+      styleSheet: STYLE_SHEET1
+    } satisfies ThemeModel);
+    await page.waitForChanges();
+
+    await checkValues([STYLE_SHEET1_NAME], [STYLE_SHEET1]);
+  });
+
+  it("should support multiple stylesheets loaded at the root", async () => {
+    themeRef.setProperty("model", [
+      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 },
+      { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
+    ] satisfies ThemeModel);
+    await page.waitForChanges();
+
+    await checkValues(
+      [STYLE_SHEET1_NAME, STYLE_SHEET2_NAME],
+      [STYLE_SHEET1, STYLE_SHEET2]
+    );
+  });
+
+  it("should support loading stylesheet and URLs at the same time", async () => {
+    themeRef.setProperty("model", [
+      { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 },
+      { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 },
+      { name: CSS_NAME, url: CSS_URL }
+    ] satisfies ThemeModel);
+    await page.waitForChanges();
+
+    await checkValues(
+      [STYLE_SHEET1_NAME, STYLE_SHEET2_NAME, CSS_NAME],
+      [STYLE_SHEET1, STYLE_SHEET2, CSS_CONTENT]
+    );
+  });
+});

--- a/src/components/theme/tests/theme.e2e.ts
+++ b/src/components/theme/tests/theme.e2e.ts
@@ -1,35 +1,31 @@
-import { E2EPage, newE2EPage } from "@stencil/core/testing";
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { ChThemeCustomEvent } from "../../../components";
 import { ChThemeLoadedEvent } from "../theme-types";
 import { delayTest } from "../../../testing/utils.e2e";
 
 const TIMEOUT = 500;
-const DELAY = TIMEOUT + 220;
+const TIMEOUT_DELAY = TIMEOUT + 220;
 
-describe("[ch-theme]", () => {
+describe("[ch-theme][basic]", () => {
   let page: E2EPage;
+  let themeRef: E2EElement;
 
   beforeEach(async () => {
-    page = await newE2EPage();
+    page = await newE2EPage({ html: `<ch-theme></ch-theme>` });
+    themeRef = await page.find("ch-theme");
   });
 
   it("should always be hidden", async () => {
-    await page.setContent(`<ch-theme></ch-theme>`);
-    const themeRef = await page.find("ch-theme");
-
     expect((await themeRef.getComputedStyle()).display).toEqual("none");
   });
 
   it("should not have Shadow DOM", async () => {
-    await page.setContent(`<ch-theme></ch-theme>`);
-    const themeRef = await page.find("ch-theme");
-
-    expect(themeRef.shadowRoot).toBeNull();
+    expect(themeRef.shadowRoot).toBeFalsy();
   });
 
   it("should hide the root node if avoidFlashOfUnstyledContent is set", async () => {
     await page.setContent(`<ch-theme model="dummy"></ch-theme>`);
-    const themeRef = await page.find("ch-theme");
+    themeRef = await page.find("ch-theme");
 
     expect(themeRef.innerHTML).toBe(
       "<style>:host,html{visibility:hidden !important}</style>"
@@ -40,17 +36,17 @@ describe("[ch-theme]", () => {
     await page.setContent(
       `<ch-theme avoid-flash-of-unstyled-content="false" model="url"></ch-theme>`
     );
-    const themeRef = await page.find("ch-theme");
+    themeRef = await page.find("ch-theme");
 
     expect(themeRef.innerHTML).toBe("");
   });
 
   it("should not fire the themeLoaded event if the model is undefined", async () => {
     await page.setContent(`<ch-theme timeout="${TIMEOUT}"></ch-theme>`);
-    const themeRef = await page.find("ch-theme");
+    themeRef = await page.find("ch-theme");
 
     const themeLoadedSpy = await themeRef.spyOnEvent("themeLoaded");
-    await delayTest(DELAY);
+    await delayTest(TIMEOUT_DELAY);
 
     expect(themeLoadedSpy).not.toHaveReceivedEvent();
   });
@@ -64,15 +60,12 @@ describe("[ch-theme]", () => {
       }
     });
     await page.setContent(`<ch-theme timeout="${TIMEOUT}"></ch-theme>`);
-    await delayTest(DELAY);
+    await delayTest(TIMEOUT_DELAY);
 
     expect(consoleMessages.length).toBe(0);
   });
 
   it("should fire the themeLoaded event when setting a valid model", async () => {
-    await page.setContent(`<ch-theme></ch-theme>`);
-
-    const themeRef = await page.find("ch-theme");
     const themeLoadedEvent = themeRef.waitForEvent("themeLoaded");
 
     themeRef.setProperty("model", {
@@ -100,10 +93,10 @@ describe("[ch-theme]", () => {
       `<ch-theme model="dummy" timeout="${TIMEOUT}"></ch-theme>`
     );
 
-    const themeRef = await page.find("ch-theme");
+    themeRef = await page.find("ch-theme");
     const themeLoadedSpy = await themeRef.spyOnEvent("themeLoaded");
 
-    await delayTest(DELAY);
+    await delayTest(TIMEOUT_DELAY);
 
     expect(themeLoadedSpy).toHaveReceivedEventDetail({
       success: []
@@ -113,9 +106,6 @@ describe("[ch-theme]", () => {
   });
 
   it("should adopt the stylesheet when the root node is the document", async () => {
-    await page.setContent(`<ch-theme></ch-theme>`);
-
-    const themeRef = await page.find("ch-theme");
     const themeLoadedEvent = themeRef.waitForEvent("themeLoaded");
 
     themeRef.setProperty("model", {
@@ -144,9 +134,6 @@ describe("[ch-theme]", () => {
   });
 
   it("should maintain the stylesheet in the document when disconnecting the ch-theme", async () => {
-    await page.setContent(`<ch-theme></ch-theme>`);
-
-    const themeRef = await page.find("ch-theme");
     const themeLoadedEvent = themeRef.waitForEvent("themeLoaded");
 
     themeRef.setProperty("model", {

--- a/src/components/theme/tests/theme.e2e.ts
+++ b/src/components/theme/tests/theme.e2e.ts
@@ -197,15 +197,7 @@ describe("[ch-theme]", () => {
     // TODO: Add implementation
   });
 
-  it.skip("should adopt the stylesheet defined by another ch-theme", async () => {
-    // TODO: Add implementation
-  });
-
-  it.skip("should reuse the stylesheet defined by another ch-theme", async () => {
-    // TODO: Add implementation
-  });
-
-  it.skip("should not duplicate the stylesheet adoption when another ch-theme loads the same CSS", async () => {
-    // TODO: Add implementation
-  });
+  it.todo(
+    "should not hide the UI when all stylesheets are already loaded by another ch-theme"
+  );
 });

--- a/src/components/theme/tests/theme.e2e.ts
+++ b/src/components/theme/tests/theme.e2e.ts
@@ -15,6 +15,10 @@ describe("[ch-theme][basic]", () => {
     themeRef = await page.find("ch-theme");
   });
 
+  it("should have the hidden attribute set", async () => {
+    expect(themeRef.getAttribute("hidden")).toEqual("");
+  });
+
   it("should always be hidden", async () => {
     expect((await themeRef.getComputedStyle()).display).toEqual("none");
   });
@@ -23,22 +27,22 @@ describe("[ch-theme][basic]", () => {
     expect(themeRef.shadowRoot).toBeFalsy();
   });
 
-  it("should hide the root node if avoidFlashOfUnstyledContent is set", async () => {
-    await page.setContent(`<ch-theme model="dummy"></ch-theme>`);
-    themeRef = await page.find("ch-theme");
+  it('the "attachStyleSheets" property should be true by default', async () => {
+    expect(await themeRef.getProperty("attachStyleSheets")).toBe(true);
+  });
 
-    expect(themeRef.innerHTML).toBe(
-      "<style>:host,html{visibility:hidden !important}</style>"
+  it('the "avoidFlashOfUnstyledContent" property should be true by default', async () => {
+    expect(await themeRef.getProperty("avoidFlashOfUnstyledContent")).toBe(
+      true
     );
   });
 
-  it("should not hide the root node if avoidFlashOfUnstyledContent is false", async () => {
-    await page.setContent(
-      `<ch-theme avoid-flash-of-unstyled-content="false" model="url"></ch-theme>`
-    );
-    themeRef = await page.find("ch-theme");
+  it('the "model" property should be undefined by default', async () => {
+    expect(await themeRef.getProperty("model")).toBeUndefined();
+  });
 
-    expect(themeRef.innerHTML).toBe("");
+  it('the "timeout" property should equal to 10000 by default', async () => {
+    expect(await themeRef.getProperty("timeout")).toBe(10000);
   });
 
   it("should not fire the themeLoaded event if the model is undefined", async () => {

--- a/src/components/theme/tests/utils.e2e.ts
+++ b/src/components/theme/tests/utils.e2e.ts
@@ -1,6 +1,8 @@
 import { E2EPage, EventSpy } from "@stencil/core/testing";
 import { ChThemeLoadedEvent } from "../theme-types";
 
+export const TIME_TO_DOWNLOAD_CSS = 200;
+
 export const CSS_NAME = "chameleon/scrollbar";
 export const CSS_URL = "showcase/scrollbar.css";
 export const CSS_CONTENT = `:host(.ch-scrollable), .ch-scrollable, .scrollable {

--- a/src/components/theme/tests/utils.e2e.ts
+++ b/src/components/theme/tests/utils.e2e.ts
@@ -1,6 +1,7 @@
 import { E2EPage, EventSpy } from "@stencil/core/testing";
-import { ChThemeLoadedEvent } from "../theme-types";
+import { ChThemeLoadedEvent, ThemeModel } from "../theme-types";
 
+export const URL_NAME = "test-urls";
 export const BASE_URL = "https://example.com/";
 export const TIME_TO_DOWNLOAD_CSS = 200;
 export const EMPTY_ADOPTED_STYLESHEETS = [];
@@ -17,6 +18,23 @@ export const STYLE_SHEET1_NAME = "stylesheet 1";
 export const STYLE_SHEET2_NAME = "stylesheet 2";
 export const STYLE_SHEET1 = ".custom-rule { background-color: red; }";
 export const STYLE_SHEET2 = ".custom-rule-2 { color: black; }";
+
+export const URL_MODEL = [
+  { name: URL_NAME, url: "showcase/theme-test.css" }
+] as const satisfies ThemeModel;
+
+export const INLINE_MODEL_1 = [
+  { name: STYLE_SHEET1_NAME, styleSheet: STYLE_SHEET1 }
+] as const satisfies ThemeModel;
+
+export const INLINE_MODEL_2 = [
+  { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
+] as const satisfies ThemeModel;
+
+export const MULTIPLE_MODEL = [
+  { name: URL_NAME, url: "showcase/theme-test.css" },
+  { name: STYLE_SHEET2_NAME, styleSheet: STYLE_SHEET2 }
+] as const satisfies ThemeModel;
 
 export const STYLESHEET_WITH_URLS = `.rule-1 { background-image: url("images/background.png"); }
 .rule-2 { background-image: url("/images/background.png"); }

--- a/src/components/theme/tests/utils.e2e.ts
+++ b/src/components/theme/tests/utils.e2e.ts
@@ -1,0 +1,12 @@
+export const CSS_NAME = "chameleon/scrollbar";
+export const CSS_URL = "showcase/scrollbar.css";
+export const CSS_CONTENT = `:host(.ch-scrollable), .ch-scrollable, .scrollable {
+  scrollbar-width: thin; scrollbar-color: var(--accents__primary--hover) transparent;
+  &::-webkit-scrollbar { width: 8px; height: 8px; background-color: transparent; }
+  &::-webkit-scrollbar-thumb { background-color: var(--accents__primary--hover); }
+}`;
+
+export const STYLE_SHEET1_NAME = "stylesheet 1";
+export const STYLE_SHEET2_NAME = "stylesheet 2";
+export const STYLE_SHEET1 = ".custom-rule { background-color: red; }";
+export const STYLE_SHEET2 = ".custom-rule-2 { color: black; }";

--- a/src/components/theme/tests/utils.e2e.ts
+++ b/src/components/theme/tests/utils.e2e.ts
@@ -1,7 +1,9 @@
 import { E2EPage, EventSpy } from "@stencil/core/testing";
 import { ChThemeLoadedEvent } from "../theme-types";
 
+export const BASE_URL = "https://example.com/";
 export const TIME_TO_DOWNLOAD_CSS = 200;
+export const EMPTY_ADOPTED_STYLESHEETS = [];
 
 export const CSS_NAME = "chameleon/scrollbar";
 export const CSS_URL = "showcase/scrollbar.css";
@@ -15,6 +17,28 @@ export const STYLE_SHEET1_NAME = "stylesheet 1";
 export const STYLE_SHEET2_NAME = "stylesheet 2";
 export const STYLE_SHEET1 = ".custom-rule { background-color: red; }";
 export const STYLE_SHEET2 = ".custom-rule-2 { color: black; }";
+
+export const STYLESHEET_WITH_URLS = `.rule-1 { background-image: url("images/background.png"); }
+.rule-2 { background-image: url("/images/background.png"); }
+.rule-3 { background-image: url("../assets/images/logo.svg"); }
+.rule-4 { background-image: url("./assets/images/logo.svg"); }
+.rule-5 { background-image: url("logo.png"); }
+.not-valid-1 { background-image: url("http://example.com/image.png"); }
+.not-valid-2 { background-image: url("https://example.com/image.png"); }
+.not-valid-3 { background-image: url("data:image/png;base64,..."); }
+.not-valid-4 { background-image: url("file:///C:/images/background.png"); }
+.not-valid-5 { background-image: url("data:image/svg+xml,<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M10 17.42L5 12.42L6.41 11L10 14.59L17.59 7L19 8.42L10 17.42Z\\"/></svg>"); }`;
+
+export const STYLESHEET_WITH_TRANSFORMED_URLS = `.rule-1 { background-image: url("${BASE_URL}images/background.png"); }
+.rule-2 { background-image: url("${BASE_URL}/images/background.png"); }
+.rule-3 { background-image: url("${BASE_URL}../assets/images/logo.svg"); }
+.rule-4 { background-image: url("${BASE_URL}./assets/images/logo.svg"); }
+.rule-5 { background-image: url("${BASE_URL}logo.png"); }
+.not-valid-1 { background-image: url("http://example.com/image.png"); }
+.not-valid-2 { background-image: url("https://example.com/image.png"); }
+.not-valid-3 { background-image: url("data:image/png;base64,..."); }
+.not-valid-4 { background-image: url("file:///C:/images/background.png"); }
+.not-valid-5 { background-image: url("data:image/svg+xml,<svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M10 17.42L5 12.42L6.41 11L10 14.59L17.59 7L19 8.42L10 17.42Z\\"/></svg>"); }`;
 
 export const getDocumentAdoptedStyleSheets = (page: E2EPage) =>
   page.evaluate(() =>

--- a/src/components/theme/tests/utils.e2e.ts
+++ b/src/components/theme/tests/utils.e2e.ts
@@ -1,3 +1,6 @@
+import { E2EPage, EventSpy } from "@stencil/core/testing";
+import { ChThemeLoadedEvent } from "../theme-types";
+
 export const CSS_NAME = "chameleon/scrollbar";
 export const CSS_URL = "showcase/scrollbar.css";
 export const CSS_CONTENT = `:host(.ch-scrollable), .ch-scrollable, .scrollable {
@@ -10,3 +13,25 @@ export const STYLE_SHEET1_NAME = "stylesheet 1";
 export const STYLE_SHEET2_NAME = "stylesheet 2";
 export const STYLE_SHEET1 = ".custom-rule { background-color: red; }";
 export const STYLE_SHEET2 = ".custom-rule-2 { color: black; }";
+
+export const getDocumentAdoptedStyleSheets = (page: E2EPage) =>
+  page.evaluate(() =>
+    document.adoptedStyleSheets.map(stylesheet =>
+      [...stylesheet.cssRules].map(rule => rule.cssText).join("\n")
+    )
+  );
+
+export const checkThemeValues = async (
+  page: E2EPage,
+  themeLoadedSpy: EventSpy,
+  successModelsToCheck: string[],
+  styleSheetsToCheck: string[]
+) => {
+  const adoptedStyleSheets = await getDocumentAdoptedStyleSheets(page);
+  expect(adoptedStyleSheets).toEqual(styleSheetsToCheck);
+
+  expect(themeLoadedSpy).toHaveReceivedEventTimes(1);
+  expect(themeLoadedSpy).toHaveReceivedEventDetail({
+    success: successModelsToCheck
+  } satisfies ChThemeLoadedEvent);
+};

--- a/src/components/theme/theme-stylesheet.ts
+++ b/src/components/theme/theme-stylesheet.ts
@@ -130,6 +130,13 @@ async function requestStyleSheet(url: string): Promise<string> {
   }
 }
 
+/**
+ * @example
+ * const baseUrl = "https://example.com/"
+ * const cssText = "background-image: url(images/background.png);"
+ *
+ * result: "background-image: url(https://example.com/images/background.png);"
+ */
 function applyBaseUrl(baseUrl: string | undefined, cssText: string): string {
   if (baseUrl) {
     return cssText.replace(BASEURL_REGEX, `$1${baseUrl}$2`);

--- a/src/components/theme/theme-stylesheet.ts
+++ b/src/components/theme/theme-stylesheet.ts
@@ -46,7 +46,6 @@ export async function getTheme(
       createThemePromise(themeModel.name, timeout)
     ).get(themeModel.name);
 
-  // TODO: Check if this works properly with inline stylesheets
   if ((themeModel as ThemeItemModelUrl).url) {
     instanceTheme(themeModel);
   }

--- a/src/components/theme/theme-stylesheet.ts
+++ b/src/components/theme/theme-stylesheet.ts
@@ -28,6 +28,23 @@ export async function getTheme(
   themeModel: ThemeItemModel,
   timeout: number
 ): Promise<Theme> {
+  const promise =
+    THEMES.get(themeModel.name) ??
+    THEMES.set(themeModel.name, createThemePromise(themeModel, timeout)).get(
+      themeModel.name
+    );
+
+  if ((themeModel as ThemeItemModelUrl).url) {
+    instanceTheme(themeModel);
+  }
+
+  return promise;
+}
+
+async function createThemePromise(
+  themeModel: ThemeItemModel,
+  timeout: number
+): Promise<Theme> {
   // If it has an inlined styleSheet, directly resolve the promise
   if ((themeModel as ThemeItemModelStyleSheet).styleSheet) {
     return Promise.resolve({
@@ -38,22 +55,10 @@ export async function getTheme(
       )
     });
   }
-
-  const promise =
-    THEMES.get(themeModel.name) ??
-    THEMES.set(
-      themeModel.name,
-      createThemePromise(themeModel.name, timeout)
-    ).get(themeModel.name);
-
-  if ((themeModel as ThemeItemModelUrl).url) {
-    instanceTheme(themeModel);
-  }
-
-  return promise;
+  return createThemePromiseUrl(themeModel.name, timeout);
 }
 
-function createThemePromise(name: string, timeout: number): Promise<Theme> {
+function createThemePromiseUrl(name: string, timeout: number): Promise<Theme> {
   return new Promise<Theme>((resolve, reject) => {
     PROMISE_RESOLVER.set(name, {
       name,

--- a/src/components/theme/theme-types.ts
+++ b/src/components/theme/theme-types.ts
@@ -1,10 +1,19 @@
 export type ThemeModel = string | string[] | ThemeItemModel | ThemeItemModel[];
 
-export type ThemeItemModel = {
+export type ThemeItemBaseModel = {
   name: string;
-  url?: string;
   themeBaseUrl?: string;
   attachStyleSheet?: boolean;
+};
+
+export type ThemeItemModel = ThemeItemModelUrl | ThemeItemModelStyleSheet;
+
+export type ThemeItemModelUrl = ThemeItemBaseModel & {
+  url?: string;
+};
+
+export type ThemeItemModelStyleSheet = ThemeItemBaseModel & {
+  styleSheet: string;
 };
 
 export type Theme = {

--- a/src/components/theme/theme-types.ts
+++ b/src/components/theme/theme-types.ts
@@ -2,6 +2,19 @@ export type ThemeModel = string | string[] | ThemeItemModel | ThemeItemModel[];
 
 export type ThemeItemBaseModel = {
   name: string;
+
+  /**
+   * Specifies a base URL to set on each URL of the downloaded stylesheet.
+   * This is useful when the stylesheet contains relative URLs that need to be
+   * transformed into absolute URLs, but the base resolution is only known at
+   * runtime.
+   *
+   * @example
+   * const baseUrl = "https://example.com/"
+   * const stylesheet = "background-image: url(images/background.png);"
+   *
+   * result: "background-image: url(https://example.com/images/background.png);"
+   */
   themeBaseUrl?: string;
   attachStyleSheet?: boolean;
 };

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -12,6 +12,7 @@ import {
   ChThemeLoadedEvent,
   Theme,
   ThemeItemModel,
+  ThemeItemModelUrl,
   ThemeModel
 } from "./theme-types";
 import { getTheme } from "./theme-stylesheet";
@@ -130,7 +131,7 @@ export class ChTheme {
       item => item.name === theme.name
     );
 
-    if (themeItemModel.url) {
+    if ((themeItemModel as ThemeItemModelUrl).url) {
       return themeItemModel.attachStyleSheet ?? this.attachStyleSheets;
     }
     return true;

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -12,6 +12,7 @@ import {
   ChThemeLoadedEvent,
   Theme,
   ThemeItemModel,
+  ThemeItemModelStyleSheet,
   ThemeItemModelUrl,
   ThemeModel
 } from "./theme-types";
@@ -128,13 +129,20 @@ export class ChTheme {
   };
 
   #mustAttachTheme = (normalizedModel: ThemeItemModel[], theme: Theme) => {
+    // TODO: "normalizedModel" should be a Set to reduce lookup times
     const themeItemModel = normalizedModel.find(
       item => item.name === theme.name
     );
 
-    if ((themeItemModel as ThemeItemModelUrl).url) {
+    // TODO: What's the meaning of this condition?
+    if (
+      (themeItemModel as ThemeItemModelUrl).url ||
+      (themeItemModel as ThemeItemModelStyleSheet).styleSheet
+    ) {
       return themeItemModel.attachStyleSheet ?? this.attachStyleSheets;
     }
+
+    // TODO: Why do we return `true` instead of `false`?
     return true;
   };
 

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -34,12 +34,6 @@ export class ChTheme {
   @State() loaded: boolean = false;
 
   /**
-   * `true` to visually hide the contents of the root node while the control's
-   * style is not loaded.
-   */
-  @Prop() readonly avoidFlashOfUnstyledContent: boolean = true;
-
-  /**
    * Indicates whether the theme should be attached to the Document or
    * the ShadowRoot after loading.
    * The value can be overridden by the `attachStyleSheet` property of the model.
@@ -47,13 +41,19 @@ export class ChTheme {
   @Prop() readonly attachStyleSheets: boolean = true;
 
   /**
+   * `true` to visually hide the contents of the root node while the control's
+   * style is not loaded.
+   */
+  @Prop() readonly avoidFlashOfUnstyledContent: boolean = true;
+
+  /**
    * Specify themes to load
    */
-  @Prop() readonly model: ThemeModel;
+  @Prop() readonly model: ThemeModel | undefined | null;
   @Watch("model")
   modelChanged(_, oldModel: ThemeModel) {
     // TODO: Make fully reactive the model property
-    if (oldModel === undefined) {
+    if (!oldModel) {
       this.#loadModel();
     }
   }
@@ -71,13 +71,14 @@ export class ChTheme {
 
   connectedCallback() {
     this.el.hidden = true;
-
-    if (this.model !== undefined) {
-      this.#loadModel();
-    }
+    this.#loadModel();
   }
 
   #loadModel = async () => {
+    if (!this.model || (Array.isArray(this.model) && this.model.length === 0)) {
+      return;
+    }
+
     const model = this.#normalizeModel();
     const themePromises = model.map(item => getTheme(item, this.timeout));
 

--- a/src/showcase/theme-test.css
+++ b/src/showcase/theme-test.css
@@ -1,0 +1,39 @@
+.rule-1 {
+  background-image: url("images/background.png");
+}
+
+.rule-2 {
+  background-image: url("/images/background.png");
+}
+
+.rule-3 {
+  background-image: url("../assets/images/logo.svg");
+}
+
+.rule-4 {
+  background-image: url("./assets/images/logo.svg");
+}
+
+.rule-5 {
+  background-image: url("logo.png");
+}
+
+.not-valid-1 {
+  background-image: url("http://example.com/image.png");
+}
+
+.not-valid-2 {
+  background-image: url("https://example.com/image.png");
+}
+
+.not-valid-3 {
+  background-image: url("data:image/png;base64,...");
+}
+
+.not-valid-4 {
+  background-image: url("file:///C:/images/background.png");
+}
+
+.not-valid-5 {
+  background-image: url('data:image/svg+xml,<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M10 17.42L5 12.42L6.41 11L10 14.59L17.59 7L19 8.42L10 17.42Z"/></svg>');
+}

--- a/stencil.config.optimized-dev.ts
+++ b/stencil.config.optimized-dev.ts
@@ -8,5 +8,6 @@ export const config: Config = {
     output => output.type === "www"
   ),
   plugins: [sass()],
+  testing: defaultConfig.testing,
   tsconfig: "tsconfig-optimized-dev.json"
 };

--- a/stencil.config.optimized-test-watch.ts
+++ b/stencil.config.optimized-test-watch.ts
@@ -8,5 +8,6 @@ export const config: Config = {
     output => output.type === "www"
   ),
   plugins: [sass()],
+  testing: defaultConfig.testing,
   tsconfig: "tsconfig-optimized-test-watch.json"
 };

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -36,6 +36,7 @@ export const config: Config = {
       "node_modules/",
       "src/testing/",
       "dist/",
+      "src/components/theme/tests/utils.e2e.ts",
       "src/components/tree-view/tests/utils.e2e.ts"
     ]
   },


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Add support to inline StyleSheets.
 This is achieved with the `stylesheet` property for `ThemeItemModel`.

 - Fix `ch-theme` not working with `null` and empty array models.

 - Make reactive the `attachStyleSheets` property.

 - Improve documentation for the `themeBaseUrl` property.