### PR TITLE
`[ch-combo-box-render]` Fix the display of `cursor: pointer` throughout the popover

### DIFF
--- a/src/components/combo-box/combo-box.scss
+++ b/src/components/combo-box/combo-box.scss
@@ -178,6 +178,10 @@ ch-popover {
   --ch-popover-separation-x: var(--ch-combo-box-separation-x);
   --ch-popover-separation-y: var(--ch-combo-box-separation-y);
 
+  // We must reset the cursor to avoid the inheriting "cursor: pointer" from
+  // the Host
+  cursor: auto;
+
   // --ch-popover-min-inline-size: var(--ch-popover-action-width);
 
   &:not(.hydrated) {

--- a/src/components/combo-box/tests/styling.e2e.ts
+++ b/src/components/combo-box/tests/styling.e2e.ts
@@ -1,0 +1,73 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import { simpleModelComboBox1 } from "../../../showcase/assets/components/combo-box/models";
+
+describe("[ch-combo-box-render][styling]", () => {
+  let page: E2EPage;
+  let comboBoxRef: E2EElement;
+  let comboBoxDivRef: E2EElement;
+  let inputRef: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-combo-box-render></ch-combo-box-render>`,
+      failOnConsoleError: true
+    });
+    comboBoxRef = await page.find("ch-combo-box-render");
+    comboBoxDivRef = await page.find(
+      "ch-combo-box-render >>> [role='combobox']"
+    );
+    inputRef = await page.find("ch-combo-box-render >>> input");
+    await comboBoxRef.setProperty("model", simpleModelComboBox1);
+    await page.waitForChanges();
+  });
+
+  it('the Host should have "cursor: pointer" by default', async () => {
+    expect((await comboBoxRef.getComputedStyle()).cursor).toEqual("pointer");
+  });
+
+  it('the div (role="combobox") should have "cursor: pointer" by default', async () => {
+    expect((await comboBoxDivRef.getComputedStyle()).cursor).toEqual("pointer");
+  });
+
+  it('the inner input should have "pointer-events: none" by default', async () => {
+    expect((await inputRef.getComputedStyle()).pointerEvents).toEqual("none");
+  });
+
+  it('the ch-popover should have "cursor: initial" by default', async () => {
+    await comboBoxRef.click();
+    await page.waitForChanges();
+    const popoverRef = await page.find("ch-combo-box-render >>> ch-popover");
+
+    const computedStyle = await popoverRef.getComputedStyle();
+    expect(computedStyle.cursor).toEqual("auto");
+  });
+
+  it('the Host should have "cursor: text" when suggest = true', async () => {
+    await comboBoxRef.setProperty("suggest", true);
+    await page.waitForChanges();
+    expect((await comboBoxRef.getComputedStyle()).cursor).toEqual("text");
+  });
+
+  it('the div (role="combobox") should have "cursor: text" when suggest = true', async () => {
+    await comboBoxRef.setProperty("suggest", true);
+    await page.waitForChanges();
+    expect((await comboBoxDivRef.getComputedStyle()).cursor).toEqual("text");
+  });
+
+  it('the inner input not should have "pointer-events: none" when suggest = true', async () => {
+    await comboBoxRef.setProperty("suggest", true);
+    await page.waitForChanges();
+    expect((await inputRef.getComputedStyle()).pointerEvents).toEqual("auto");
+  });
+
+  it('the ch-popover should have "cursor: initial" when suggest = true', async () => {
+    await comboBoxRef.setProperty("suggest", true);
+    await page.waitForChanges();
+    await comboBoxRef.press("H");
+    await page.waitForChanges();
+    const popoverRef = await page.find("ch-combo-box-render >>> ch-popover");
+
+    const computedStyle = await popoverRef.getComputedStyle();
+    expect(computedStyle.cursor).toEqual("auto");
+  });
+});


### PR DESCRIPTION
This will allow us to properly differentiate non-interactive elements in the popover.