### PR TITLE
`[ch-tooltip]` If the mouse leaves the tooltip, only keep it visible if the focus is "focus-visible". Also improve rendering performance.

### DIFF
--- a/src/components/tooltip/tests/basic.e2e.ts
+++ b/src/components/tooltip/tests/basic.e2e.ts
@@ -1,0 +1,66 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+
+describe("[ch-tooltip][basic]", () => {
+  let page: E2EPage;
+  let tooltipRef: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-tooltip></ch-tooltip>`,
+      failOnConsoleError: true
+    });
+    tooltipRef = await page.find("ch-tooltip");
+  });
+
+  const testDefault = (
+    propertyName: string,
+    propertyValue: any,
+    propertyValueDescription: string
+  ) =>
+    it(`the "${propertyName}" property should be ${
+      typeof propertyValue === "string"
+        ? `"${propertyValueDescription}"`
+        : propertyValueDescription
+    } by default`, async () => {
+      expect(await tooltipRef.getProperty(propertyName)).toBe(propertyValue);
+    });
+
+  const getCustomVarValue = (customVar: string) =>
+    page.evaluate(
+      (customVarName: string) =>
+        getComputedStyle(document.querySelector("ch-tooltip")).getPropertyValue(
+          customVarName
+        ),
+      customVar
+    );
+
+  it("should have Shadow DOM", async () => {
+    expect(tooltipRef.shadowRoot).toBeTruthy();
+  });
+
+  testDefault("actionElement", undefined, "undefined");
+  testDefault("blockAlign", "outside-end", "outside-end");
+  testDefault("delay", 100, "100");
+  testDefault("inlineAlign", "center", "center");
+
+  it('should have "display: contents" by default', async () => {
+    expect((await tooltipRef.getComputedStyle()).display).toBe("contents");
+  });
+
+  it('should have "--ch-tooltip-separation: 0px" by default', async () => {
+    expect(await getCustomVarValue("--ch-tooltip-separation")).toBe("0px");
+  });
+
+  it('should have "--ch-tooltip-separation-x: 0px" by default', async () => {
+    expect(await getCustomVarValue("--ch-tooltip-separation-x")).toBe("0px");
+  });
+
+  it('should have "--ch-tooltip-separation-y: 0px" by default', async () => {
+    expect(await getCustomVarValue("--ch-tooltip-separation-y")).toBe("0px");
+  });
+
+  it("should not render the ch-popover by default", async () => {
+    const popoverRef = await page.find("ch-tooltip >>> ch-popover");
+    expect(popoverRef).toBeFalsy();
+  });
+});

--- a/src/components/tooltip/tests/show.e2e.ts
+++ b/src/components/tooltip/tests/show.e2e.ts
@@ -1,0 +1,154 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+
+const BUTTON_1_SELECTOR = "[id='button-1']";
+const BUTTON_2_SELECTOR = "[id='button-2']";
+
+const performTest = (actionElementBindingType: "nested" | "reference") => {
+  const description =
+    actionElementBindingType === "nested"
+      ? "inside action element"
+      : "action element by ref";
+
+  const tooltipHTML =
+    actionElementBindingType === "nested"
+      ? `
+      <button id="button-2" type="button">
+        Action 2
+        <ch-tooltip></ch-tooltip>
+      </button>`
+      : `
+      <button id="button-2" type="button">
+        Action 2
+      </button>
+      <ch-tooltip></ch-tooltip>`;
+
+  describe(`[ch-tooltip][${description}][show]`, () => {
+    let page: E2EPage;
+    let button1Ref: E2EElement;
+    let button2Ref: E2EElement;
+    let tooltipRef: E2EElement;
+
+    beforeEach(async () => {
+      page = await newE2EPage({
+        html: `<button id="button-1" type="button">Action 1</button>
+              ${tooltipHTML}`,
+        failOnConsoleError: true
+      });
+      button1Ref = await page.find(BUTTON_1_SELECTOR);
+      button2Ref = await page.find(BUTTON_2_SELECTOR);
+      tooltipRef = await page.find("ch-tooltip");
+      tooltipRef.setProperty("delay", 0); // Avoid any race condition by removing the delay
+
+      // Set the actionElement binding
+      if (actionElementBindingType === "reference") {
+        await page.evaluate((actionElementSelector: string) => {
+          const actionElementRef = document.querySelector(
+            actionElementSelector
+          ) as HTMLButtonElement;
+
+          document.querySelector("ch-tooltip").actionElement = actionElementRef;
+        }, BUTTON_2_SELECTOR);
+      } else {
+        tooltipRef.setProperty("actionElement", null);
+      }
+
+      await page.waitForChanges();
+    });
+
+    const getPopoverRef = () => page.find("ch-tooltip >>> ch-popover");
+
+    it("should show the popover when hovering the action button", async () => {
+      await button2Ref.hover();
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeTruthy();
+    });
+
+    it("should hide the popover when the mouse leaves the action button, after it was opened with hover", async () => {
+      await button2Ref.hover();
+      await page.waitForChanges();
+
+      await button1Ref.hover();
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeFalsy();
+    });
+
+    it("should show the popover when clicking the action button", async () => {
+      await button2Ref.click();
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeTruthy();
+    });
+
+    it("should hide the popover when the mouse leaves the action button, after if it was opened with click", async () => {
+      await button2Ref.click();
+      await page.waitForChanges();
+
+      await button1Ref.hover();
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeFalsy();
+    });
+
+    it("should show the popover when focusing the action button", async () => {
+      await button2Ref.focus();
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeTruthy();
+    });
+
+    it.skip("should not hide the popover when the mouse leaves the action button, because it was focused via JS", async () => {
+      await button2Ref.focus();
+      await page.waitForChanges();
+
+      await button1Ref.hover();
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeFalsy();
+    });
+
+    it("should show the popover when focusing the action button with the Tab key", async () => {
+      await button1Ref.focus();
+      await button1Ref.press("Tab");
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeTruthy();
+    });
+
+    it("should not hide the popover when the mouse leaves the action button, because the action is focused with the Tab key", async () => {
+      await button1Ref.focus();
+      await button1Ref.press("Tab");
+      await page.waitForChanges();
+
+      await button1Ref.hover();
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeTruthy();
+    });
+
+    it("should hide the popover when the focused element changes (Tab key press)", async () => {
+      // Open the tooltip with the Tab Key
+      await button1Ref.focus();
+      await button1Ref.press("Tab");
+      await page.waitForChanges();
+
+      // Focus a different in the DOM
+      await button2Ref.press("Tab");
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeFalsy();
+    });
+
+    it.skip("should not hide the popover when the focused element changes (Tab key press), because the mouse is over the action element", async () => {
+      // Open the tooltip with the Tab Key
+      await button1Ref.focus();
+      await button1Ref.press("Tab");
+      await page.waitForChanges();
+
+      // Focus a different element in the DOM
+      await button2Ref.hover(); // DO NOT CHANGE THE ORDER
+      await button2Ref.press("Tab");
+      await page.waitForChanges();
+      expect(await getPopoverRef()).toBeTruthy();
+    });
+
+    it.todo("should not hide the tooltip when hovering the tooltip content");
+  });
+};
+
+performTest("reference");
+performTest("nested");
+
+// TODO: Add "standalone" case (ch-tooltip without an actionElement)

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -33,15 +33,12 @@
 ch-popover {
   --ch-popover-separation-x: var(--ch-tooltip-separation-x);
   --ch-popover-separation-y: var(--ch-tooltip-separation-y);
+  animation: delay-visibility var(--ch-tooltip-delay) linear;
 
   &:not(.hydrated) {
     display: none;
     opacity: 0;
   }
-}
-
-.visible {
-  animation: delay-visibility var(--ch-tooltip-delay) linear;
 }
 
 @keyframes delay-visibility {

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -188,27 +188,28 @@ export class ChTooltip implements ComponentInterface {
           </button>
         )}
 
-        <ch-popover
-          id={actionInsideShadow ? this.#tooltipId : undefined}
-          role={actionInsideShadow ? "tooltip" : undefined}
-          class={this.visible ? "visible" : undefined}
-          style={{
-            "--ch-tooltip-delay": `${this.delay}ms`
-          }}
-          part="window"
-          // Don't use #actualActionElement. On the first render is not defined
-          actionElement={this.#getActionElement()}
-          blockAlign={this.blockAlign}
-          closeOnClickOutside
-          hidden={!this.visible}
-          inlineAlign={this.inlineAlign}
-          mode="manual"
-          // We need to sync the visible state when the popover is closed by an
-          // user interaction (click outside)
-          onPopoverClosed={this.visible ? this.#handleLeave : undefined}
-        >
-          <slot />
-        </ch-popover>
+        {this.visible && (
+          <ch-popover
+            id={actionInsideShadow ? this.#tooltipId : undefined}
+            role={actionInsideShadow ? "tooltip" : undefined}
+            style={{
+              "--ch-tooltip-delay": `${this.delay}ms`
+            }}
+            part="window"
+            // Don't use #actualActionElement. On the first render is not defined
+            actionElement={this.#getActionElement()}
+            blockAlign={this.blockAlign}
+            closeOnClickOutside
+            hidden={false}
+            inlineAlign={this.inlineAlign}
+            mode="manual"
+            // We need to sync the visible state when the popover is closed by an
+            // user interaction (click outside)
+            onPopoverClosed={this.#handleLeave}
+          >
+            <slot />
+          </ch-popover>
+        )}
       </Host>
     );
   }

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -83,9 +83,13 @@ export class ChTooltip implements ComponentInterface {
   };
 
   #handleLeave = () => {
-    // Only remove the tooltip if the action element is not focused. If focused,
-    // "mouseleave" should not dismiss the tooltip
-    if (focusComposedPath()[0] !== this.#getActionElement()) {
+    const focusedWithFocusVisible =
+      focusComposedPath()[0] === this.#getActionElement() &&
+      this.#actualActionElement.matches(":focus-visible");
+
+    // Only remove the tooltip if the action element is not focused with
+    // "focus-visible". If focused, "mouseleave" should not dismiss the tooltip
+    if (!focusedWithFocusVisible) {
       this.visible = false;
     }
   };


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fix: If the mouse leaves the tooltip, only keep it visible if the focus is "focus-visible".
  Now, if the tooltip is shown by clicking on the actionElement, this fix will hide the tooltip when the mouse leaves the `actionElement`.

   Previously, the tooltip reamined visible until a new element in the UI was focused.

 - Perf: Don't render the `ch-popover` if the tooltip is not displayed.