### PR TITLE
`[ch-action-list-render]` Fix `ch-action-list-render` not working with Angular SSR in some edge cases

### DIFF
--- a/src/components/action-list/action-list-render.tsx
+++ b/src/components/action-list/action-list-render.tsx
@@ -871,7 +871,11 @@ export class ChActionListRender {
     this.el.setAttribute("role", "list");
   }
 
-  componentWillUpdate() {
+  // Don't turn it into the componentWillUpdate lifecycle method.
+  // For some reason, the componentWillUpdate lifecycle method is not
+  // dispatched when an Angular page (with SSR) is served from the server, but
+  // when navigating in the SPA, the componentWillUpdate method works
+  componentWillRender() {
     if (this.#shouldUpdateModelAndSelection) {
       this.#shouldUpdateModelAndSelection = false;
 


### PR DESCRIPTION
For some reason, the `componentWillUpdate` lifecycle method is not dispatched when the Angular page is served from the server, but when navigating in the SPA, the `componentWillUpdate` method works in the `ch-action-list-render`.