### PR TITLE
Fixed `registerProperty` implementation not working in some frameworks

### DIFF
--- a/src/common/registry-properties.ts
+++ b/src/common/registry-properties.ts
@@ -62,6 +62,14 @@ export const registryControlProperty = <
     throw new Error("Invalid property name");
   }
 
+  if (
+    (controlName as string) === "__proto__" ||
+    (controlName as string) === "constructor" ||
+    (controlName as string) === "prototype"
+  ) {
+    throw new Error("Invalid control name");
+  }
+
   window.chameleonControlsLibrary[propertyName][controlName] = value;
 };
 

--- a/src/common/registry-properties.ts
+++ b/src/common/registry-properties.ts
@@ -1,8 +1,14 @@
-import { ActionListImagePathCallback } from "../components/action-list/types";
-import {
+import type { ActionListImagePathCallback } from "../components/action-list/types";
+import type {
   ChameleonImagePathCallbackControls,
   ChameleonImagePathCallbackControlsTagName
 } from "./types";
+
+declare global {
+  interface Window {
+    getImagePathCallback: Partial<RegistryGetImagePathCallback>;
+  }
+}
 
 export type RegistryGetImagePathCallback = {
   [key in ChameleonImagePathCallbackControlsTagName]: ChameleonImagePathCallbackControls[key]["getImagePathCallback"];
@@ -10,13 +16,13 @@ export type RegistryGetImagePathCallback = {
 
 export type RegisterPropertyName = "getImagePathCallback";
 
-export type RegisterProperty = typeof registerMapping;
-
-const registryGetImagePathCallback: Partial<RegistryGetImagePathCallback> = {};
-
-const registerMapping = {
-  getImagePathCallback: registryGetImagePathCallback
+export type RegisterProperty = {
+  getImagePathCallback: Partial<RegistryGetImagePathCallback>;
 };
+
+if (typeof window !== "undefined") {
+  window.getImagePathCallback ??= {};
+}
 
 export const registryProperty = <
   Prop extends RegisterPropertyName,
@@ -25,7 +31,7 @@ export const registryProperty = <
   propertyName: Prop,
   value: T
 ) => {
-  registerMapping[propertyName] = value;
+  window[propertyName] = value;
 };
 
 export const registryControlProperty = <
@@ -37,7 +43,7 @@ export const registryControlProperty = <
   controlName: Control,
   value: T
 ) => {
-  registerMapping[propertyName][controlName] = value;
+  window[propertyName][controlName] = value;
 };
 
 export const getControlRegisterProperty = <
@@ -47,7 +53,7 @@ export const getControlRegisterProperty = <
   propertyName: PropName,
   controlName: Control
 ): RegisterProperty[PropName][Control] | undefined =>
-  registerMapping[propertyName][controlName];
+  window[propertyName][controlName];
 
 export const DEFAULT_GET_IMAGE_PATH_CALLBACK: ActionListImagePathCallback =
   additionalItem => ({

--- a/src/common/registry-properties.ts
+++ b/src/common/registry-properties.ts
@@ -34,6 +34,14 @@ export const registryProperty = <
   propertyName: Prop,
   value: T
 ) => {
+  if (
+    (propertyName as string) === "__proto__" ||
+    (propertyName as string) === "constructor" ||
+    (propertyName as string) === "prototype"
+  ) {
+    throw new Error("Invalid property name");
+  }
+
   window.chameleonControlsLibrary[propertyName] = value;
 };
 
@@ -46,6 +54,14 @@ export const registryControlProperty = <
   controlName: Control,
   value: T
 ) => {
+  if (
+    (propertyName as string) === "__proto__" ||
+    (propertyName as string) === "constructor" ||
+    (propertyName as string) === "prototype"
+  ) {
+    throw new Error("Invalid property name");
+  }
+
   window.chameleonControlsLibrary[propertyName][controlName] = value;
 };
 

--- a/src/common/registry-properties.ts
+++ b/src/common/registry-properties.ts
@@ -6,7 +6,9 @@ import type {
 
 declare global {
   interface Window {
-    getImagePathCallback: Partial<RegistryGetImagePathCallback>;
+    chameleonControlsLibrary: {
+      getImagePathCallback: Partial<RegistryGetImagePathCallback>;
+    };
   }
 }
 
@@ -21,7 +23,8 @@ export type RegisterProperty = {
 };
 
 if (typeof window !== "undefined") {
-  window.getImagePathCallback ??= {};
+  window.chameleonControlsLibrary ??= { getImagePathCallback: {} };
+  window.chameleonControlsLibrary.getImagePathCallback ??= {};
 }
 
 export const registryProperty = <
@@ -31,7 +34,7 @@ export const registryProperty = <
   propertyName: Prop,
   value: T
 ) => {
-  window[propertyName] = value;
+  window.chameleonControlsLibrary[propertyName] = value;
 };
 
 export const registryControlProperty = <
@@ -43,7 +46,7 @@ export const registryControlProperty = <
   controlName: Control,
   value: T
 ) => {
-  window[propertyName][controlName] = value;
+  window.chameleonControlsLibrary[propertyName][controlName] = value;
 };
 
 export const getControlRegisterProperty = <
@@ -53,7 +56,7 @@ export const getControlRegisterProperty = <
   propertyName: PropName,
   controlName: Control
 ): RegisterProperty[PropName][Control] | undefined =>
-  window[propertyName][controlName];
+  window.chameleonControlsLibrary[propertyName][controlName];
 
 export const DEFAULT_GET_IMAGE_PATH_CALLBACK: ActionListImagePathCallback =
   additionalItem => ({

--- a/src/components/navigation-list/navigation-list-render.tsx
+++ b/src/components/navigation-list/navigation-list-render.tsx
@@ -39,6 +39,10 @@ import { formatImagePath } from "../../common/utils";
 // This callback will be registered by default. If it is used in GeneXus, all
 // tree views will have the same state, so the parameters used of the treeState
 // are "shared" across all tree view instances
+
+// TODO: For some reason, this module import is different when an external
+// library imports the registryControlProperty function. We should de-dup this
+// to fix issues related with double initialization of the registry
 const registerDefaultGetImagePathCallback = (
   navigationListState: ChNavigationListRender
 ) =>


### PR DESCRIPTION
For some reason, in frameworks like Angular or React, the registry utilities we export do not use the same JS file to implement the utilities, which causes the register to not be initialized correctly (because the frameworks use a different storage for the registry than the web components).

We are adding a WA to set up the register using the global window, so at least we can share the same memory for the registry.