### PR TITLE
`[ch-combo-box-render]` Fix emitting the value with debounce, even when the selection is confirmed with no strict filters

### DIFF
--- a/src/components/combo-box/combo-box.tsx
+++ b/src/components/combo-box/combo-box.tsx
@@ -568,7 +568,16 @@ export class ChComboBoxRender
 
     // No item was selected and the suggest is not strict
     if (!this.suggestOptions?.strict) {
-      // TODO: Should we update the #lastConfirmedValue?
+      // TODO: Add a unit test: filters, no strict, value confirmation with
+      // Enter or Tab. Expected: The value update should not be debounced
+      // TODO: Avoid emitting duplicated input events if the value did not
+      // changed
+
+      // Clear last debounce and update the value right away, because the value
+      // selection was confirmed
+      clearTimeout(this.#queuedInputValueUpdate);
+      this.value = this.#inputRef.value;
+      this.input.emit(this.value);
 
       // TODO: Add a unit test for this
       this.#emitChangeEvent();


### PR DESCRIPTION
When the `ch-combo-box-render` had no strict filters applied, the user would typed a new value and immediately confirm the new value by pressing Enter or Tab keys, the value event was debounced, even though the selection was confirmed.

Now, we are no longer debouncing the input event emission for this case.