### PR TITLE
`[ch-navigation-list-render][ch-tooltip]` Several improvements for the accessibility

### DIFF
--- a/src/components/navigation-list/internal/navigation-list-item/navigation-list-item.tsx
+++ b/src/components/navigation-list/internal/navigation-list-item/navigation-list-item.tsx
@@ -185,6 +185,7 @@ export class ChNavigationListItem implements ComponentInterface {
         // focusable elements generate issue with the "mouseleave" and
         // "focusout" events
         actionElement={(this.#actionRef as HTMLButtonElement) ?? null}
+        actionElementAccessibleName={this.caption}
         blockAlign="center"
         inlineAlign="outside-end"
         delay={this.tooltipDelay}
@@ -381,6 +382,7 @@ export class ChNavigationListItem implements ComponentInterface {
 
         {this.expandable && (
           <div
+            role="list"
             class={{
               expandable: true,
               "expandable--collapsed": !this.expanded

--- a/src/components/navigation-list/tests/accessibility.e2e.ts
+++ b/src/components/navigation-list/tests/accessibility.e2e.ts
@@ -1,0 +1,74 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import { unanimoShowcase } from "../../../showcase/assets/components/navigation-list/models";
+
+describe("[ch-navigation-list-render][basic]", () => {
+  let page: E2EPage;
+  let navigationListRef: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-navigation-list-render></ch-navigation-list-render>`,
+      failOnConsoleError: true
+    });
+
+    navigationListRef = await page.find("ch-navigation-list-render");
+  });
+
+  it('should have role="list"', () =>
+    expect(navigationListRef).toEqualAttribute("role", "list"));
+
+  it('expandable items should have role="list"', async () => {
+    navigationListRef.setProperty("model", unanimoShowcase);
+    await page.waitForChanges();
+
+    const firstExpandableItemRef = await page.find(
+      "ch-navigation-list-render >>> ch-navigation-list-item >>> div[part*='item__group']"
+    );
+
+    expect(firstExpandableItemRef).toEqualAttribute("role", "list");
+  });
+
+  it('all items should have role="listitem"', async () => {
+    navigationListRef.setProperty("model", unanimoShowcase);
+    await page.waitForChanges();
+
+    const navigationListItems = await page.findAll(
+      "ch-navigation-list-render >>> ch-navigation-list-item"
+    );
+
+    navigationListItems.forEach(item =>
+      expect(item).toEqualAttribute("role", "listitem")
+    );
+  });
+
+  it('when the control is collapsed and showCaptionOnCollapse === "tooltip", all items should set the actionElementAccessibleName property in their ch-tooltip with the value of the caption property', async () => {
+    navigationListRef.setProperty("model", unanimoShowcase);
+    navigationListRef.setProperty("expanded", false);
+    navigationListRef.setProperty("showCaptionOnCollapse", "tooltip");
+    await page.waitForChanges();
+
+    const navigationListItemCaptions = await Promise.all<string>(
+      (
+        await page.findAll(
+          "ch-navigation-list-render >>> ch-navigation-list-item"
+        )
+      ).map(tooltipRef => tooltipRef.getProperty("caption"))
+    );
+
+    const tooltipActionElementAccessibleNames = await Promise.all<string>(
+      (
+        await page.findAll(
+          "ch-navigation-list-render >>> ch-navigation-list-item >>> ch-tooltip"
+        )
+      ).map(tooltipRef => tooltipRef.getProperty("actionElementAccessibleName"))
+    );
+
+    tooltipActionElementAccessibleNames.forEach(
+      (actionElementAccessibleName, index) => {
+        expect(actionElementAccessibleName).toBe(
+          navigationListItemCaptions[index]
+        );
+      }
+    );
+  });
+});

--- a/src/components/navigation-list/tests/basic.e2e.ts
+++ b/src/components/navigation-list/tests/basic.e2e.ts
@@ -1,0 +1,47 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import {
+  testDefaultCssProperties,
+  testDefaultProperties
+} from "../../../testing/utils.e2e";
+
+testDefaultProperties("ch-navigation-list-render", {
+  autoGrow: false,
+  expandableButton: "decorative",
+  expandableButtonPosition: "start",
+  expanded: true,
+  expandSelectedLink: false,
+  getImagePathCallback: undefined,
+  gxImageConstructor: undefined,
+  gxSettings: undefined,
+  model: undefined,
+  selectedLink: {
+    link: { url: undefined }
+  },
+  selectedLinkIndicator: false,
+  showCaptionOnCollapse: "inline",
+  tooltipDelay: 100,
+  useGxRender: false
+});
+
+testDefaultCssProperties("ch-navigation-list-render", {
+  display: "grid"
+  // Add unit tests for the rest of the custom vars
+});
+
+// TODO: Add basic unit tests for the ch-navigation-list-item control
+describe("[ch-navigation-list-render][basic]", () => {
+  let page: E2EPage;
+  let navigationListRef: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-navigation-list-render></ch-navigation-list-render>`,
+      failOnConsoleError: true
+    });
+
+    navigationListRef = await page.find("ch-navigation-list-render");
+  });
+
+  it("should have Shadow DOM", () =>
+    expect(navigationListRef.shadowRoot).toBeTruthy());
+});

--- a/src/components/tooltip/tests/accessibility.e2e.ts
+++ b/src/components/tooltip/tests/accessibility.e2e.ts
@@ -2,7 +2,13 @@ import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 
 const BUTTON_1_SELECTOR = "[id='button-1']";
 const BUTTON_2_SELECTOR = "[id='button-2']";
-// const BUTTON_INSIDE_SELECTOR = "ch-tooltip >>> button";
+const BUTTON_INSIDE_SELECTOR = "ch-tooltip >>> button";
+
+const ACCESSIBLE_NAME_1 = "Hello world";
+const ACCESSIBLE_NAME_2 = "Another string";
+
+const ARIA_LABEL_ATTR = "aria-label";
+const ARIA_DESCRIBED_BY_ATTR = "aria-describedby";
 
 const performTest = (
   actionElementBindingType: "inside-action" | "reference" | "standalone"
@@ -11,7 +17,8 @@ const performTest = (
   let tooltipHTML = "";
 
   if (actionElementBindingType === "inside-action") {
-    description = "ch-tooltip inside the actionElement";
+    description =
+      "ch-tooltip with actionElement === null (inside the actionElement)";
     tooltipHTML = `
       <button id="button-2" type="button">
         Action 2
@@ -32,7 +39,6 @@ const performTest = (
   describe(`[ch-tooltip][accessibility][${description}]`, () => {
     let page: E2EPage;
     let anotherButtonRef: E2EElement;
-    // let actionElementRef: E2EElement;
     let tooltipRef: E2EElement;
 
     beforeEach(async () => {
@@ -42,11 +48,6 @@ const performTest = (
         failOnConsoleError: true
       });
       anotherButtonRef = await page.find(BUTTON_1_SELECTOR);
-      // actionElementRef = await page.find(
-      //   actionElementBindingType === "standalone"
-      //     ? BUTTON_INSIDE_SELECTOR
-      //     : BUTTON_2_SELECTOR
-      // );
       tooltipRef = await page.find("ch-tooltip");
       tooltipRef.setProperty("delay", 0); // Avoid any race condition by removing the delay
 
@@ -77,6 +78,12 @@ const performTest = (
     };
 
     const getPopoverRef = () => page.find("ch-tooltip >>> ch-popover");
+    const getActionElementRef = () =>
+      page.find(
+        actionElementBindingType === "standalone"
+          ? BUTTON_INSIDE_SELECTOR
+          : BUTTON_2_SELECTOR
+      );
 
     if (actionElementBindingType === "standalone") {
       it("should not have an aria-hidden when the popover is not visible", () =>
@@ -131,9 +138,9 @@ const performTest = (
     it(`should ${addOrRemove} the aria-hidden when the popover is dismissed`, async () => {
       await displayPopover();
 
+      // Hide popover
       await anotherButtonRef.focus();
       await page.waitForChanges();
-      // Now is hidden
 
       tooltipRef = await page.find("ch-tooltip");
 
@@ -143,6 +150,131 @@ const performTest = (
         expect(tooltipRef).toHaveAttribute("aria-hidden");
       }
     });
+
+    it("the actionElement should not have an aria-label set by default, since by default actionElementAccessibleName === undefined", async () =>
+      expect(await getActionElementRef()).not.toHaveAttribute(ARIA_LABEL_ATTR));
+
+    it("the actionElement should have an aria-label set if actionElementAccessibleName is defined", async () => {
+      tooltipRef.setProperty("actionElementAccessibleName", ACCESSIBLE_NAME_1);
+      await page.waitForChanges();
+
+      expect(await getActionElementRef()).toEqualAttribute(
+        ARIA_LABEL_ATTR,
+        ACCESSIBLE_NAME_1
+      );
+    });
+
+    it("the actionElementAccessibleName property should be reactive", async () => {
+      tooltipRef.setProperty("actionElementAccessibleName", ACCESSIBLE_NAME_1);
+      await page.waitForChanges();
+
+      tooltipRef.setProperty("actionElementAccessibleName", ACCESSIBLE_NAME_2);
+      await page.waitForChanges();
+
+      expect(await getActionElementRef()).toEqualAttribute(
+        ARIA_LABEL_ATTR,
+        ACCESSIBLE_NAME_2
+      );
+    });
+
+    it("if the actionElementAccessibleName property is removed in runtime, the aria-label should be removed from the actionElement", async () => {
+      tooltipRef.setProperty("actionElementAccessibleName", ACCESSIBLE_NAME_1);
+      await page.waitForChanges();
+
+      tooltipRef.setProperty("actionElementAccessibleName", undefined);
+      await page.waitForChanges();
+
+      expect(await getActionElementRef()).not.toHaveAttribute(ARIA_LABEL_ATTR);
+    });
+
+    it('the actionElement should have an aria-describedby set that matches the ID of the element with role="tooltip"', async () => {
+      let tooltipId = "";
+
+      if (actionElementBindingType === "standalone") {
+        await displayPopover();
+        tooltipId = (await getPopoverRef()).getAttribute("id");
+      } else {
+        tooltipId = tooltipRef.getAttribute("id");
+      }
+
+      expect(await getActionElementRef()).toEqualAttribute(
+        ARIA_DESCRIBED_BY_ATTR,
+        tooltipId
+      );
+    });
+
+    it("should remove the aria-label and aria-describedby from the old actionElement when updating the actionElement property in runtime", async () => {
+      // Add aria-label, otherwise the check will always be valid
+      tooltipRef.setProperty("actionElementAccessibleName", ACCESSIBLE_NAME_1);
+      await page.waitForChanges();
+
+      await page.evaluate((actionElementSelector: string) => {
+        const actionElementRef = document.querySelector(
+          actionElementSelector
+        ) as HTMLButtonElement;
+
+        document.querySelector("ch-tooltip").actionElement = actionElementRef;
+      }, BUTTON_1_SELECTOR);
+      await page.waitForChanges();
+      const actionRef = await getActionElementRef();
+
+      if (actionElementBindingType === "standalone") {
+        // When the "standalone" mode has an actual reference, the inner button
+        // should be destroyed
+        expect(actionRef).toBeFalsy();
+      } else {
+        expect(actionRef).not.toHaveAttribute(ARIA_LABEL_ATTR);
+        expect(actionRef).not.toHaveAttribute(ARIA_DESCRIBED_BY_ATTR);
+      }
+    });
+
+    it("should add the aria-label and aria-describedby in the new actionElement when updating the actionElement property in runtime", async () => {
+      tooltipRef.setProperty("actionElementAccessibleName", ACCESSIBLE_NAME_1);
+
+      await page.evaluate((actionElementSelector: string) => {
+        const actionElementRef = document.querySelector(
+          actionElementSelector
+        ) as HTMLButtonElement;
+
+        document.querySelector("ch-tooltip").actionElement = actionElementRef;
+      }, BUTTON_1_SELECTOR);
+      await page.waitForChanges();
+
+      // Refresh the references
+      anotherButtonRef = await page.find(BUTTON_1_SELECTOR);
+      tooltipRef = await page.find("ch-tooltip");
+
+      const tooltipId = tooltipRef.getAttribute("id");
+
+      expect(anotherButtonRef).toEqualAttribute(
+        ARIA_LABEL_ATTR,
+        ACCESSIBLE_NAME_1
+      );
+      expect(anotherButtonRef).toEqualAttribute(
+        ARIA_DESCRIBED_BY_ATTR,
+        tooltipId
+      );
+    });
+
+    if (actionElementBindingType !== "standalone") {
+      it("should remove the aria-label and aria-describedby from the actionElement when the ch-tooltip is destroyed", async () => {
+        // Add aria-label, otherwise the check will always be valid
+        tooltipRef.setProperty(
+          "actionElementAccessibleName",
+          ACCESSIBLE_NAME_1
+        );
+        await page.waitForChanges();
+
+        await page.evaluate(() =>
+          document.querySelector("ch-tooltip").remove()
+        );
+        await page.waitForChanges();
+
+        const actionRef = await getActionElementRef();
+        expect(actionRef).not.toHaveAttribute(ARIA_LABEL_ATTR);
+        expect(actionRef).not.toHaveAttribute(ARIA_DESCRIBED_BY_ATTR);
+      });
+    }
   });
 };
 

--- a/src/components/tooltip/tests/accessibility.e2e.ts
+++ b/src/components/tooltip/tests/accessibility.e2e.ts
@@ -1,0 +1,119 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+
+const BUTTON_1_SELECTOR = "[id='button-1']";
+const BUTTON_2_SELECTOR = "[id='button-2']";
+// const BUTTON_INSIDE_SELECTOR = "ch-tooltip >>> button";
+
+const performTest = (
+  actionElementBindingType: "inside-action" | "reference" | "standalone"
+) => {
+  let description = "";
+  let tooltipHTML = "";
+
+  if (actionElementBindingType === "inside-action") {
+    description = "ch-tooltip inside the actionElement";
+    tooltipHTML = `
+      <button id="button-2" type="button">
+        Action 2
+        <ch-tooltip></ch-tooltip>
+      </button>`;
+  } else if (actionElementBindingType === "reference") {
+    description = "ch-tooltip with the actionElement ref";
+    tooltipHTML = `
+      <button id="button-2" type="button">
+        Action 2
+      </button>
+      <ch-tooltip></ch-tooltip>`;
+  } else {
+    description = "ch-tooltip with actionElement === undefined";
+    tooltipHTML = `<ch-tooltip></ch-tooltip>`;
+  }
+
+  describe(`[ch-tooltip][accessibility][${description}]`, () => {
+    let page: E2EPage;
+    let anotherButtonRef: E2EElement;
+    // let actionElementRef: E2EElement;
+    let tooltipRef: E2EElement;
+
+    beforeEach(async () => {
+      page = await newE2EPage({
+        html: `<button id="button-1" type="button">Action 1</button>
+              ${tooltipHTML}`,
+        failOnConsoleError: true
+      });
+      anotherButtonRef = await page.find(BUTTON_1_SELECTOR);
+      // actionElementRef = await page.find(
+      //   actionElementBindingType === "standalone"
+      //     ? BUTTON_INSIDE_SELECTOR
+      //     : BUTTON_2_SELECTOR
+      // );
+      tooltipRef = await page.find("ch-tooltip");
+      tooltipRef.setProperty("delay", 0); // Avoid any race condition by removing the delay
+
+      // Set the actionElement binding
+      if (actionElementBindingType === "reference") {
+        await page.evaluate((actionElementSelector: string) => {
+          const actionElementRef = document.querySelector(
+            actionElementSelector
+          ) as HTMLButtonElement;
+
+          document.querySelector("ch-tooltip").actionElement = actionElementRef;
+        }, BUTTON_2_SELECTOR);
+      } else if (actionElementBindingType === "inside-action") {
+        tooltipRef.setProperty("actionElement", null);
+      }
+
+      await page.waitForChanges();
+
+      // We have to refresh the ch-tooltip reference again, since we changed
+      // its properties
+      tooltipRef = await page.find("ch-tooltip");
+    });
+
+    if (actionElementBindingType === "standalone") {
+      it("should not render an aria-hidden when the popover is not visible", async () => {
+        expect(tooltipRef).not.toHaveAttribute("aria-hidden");
+      });
+    } else {
+      it("should render an aria-hidden when the popover is not visible", async () => {
+        expect(tooltipRef).toEqualAttribute("aria-hidden", "true");
+      });
+    }
+
+    it("should not render an aria-hidden when the popover is visible", async () => {
+      await anotherButtonRef.focus();
+      await anotherButtonRef.press("Tab");
+      await page.waitForChanges();
+      tooltipRef = await page.find("ch-tooltip");
+
+      tooltipRef = await page.find("ch-tooltip");
+      expect(tooltipRef).not.toHaveAttribute("aria-hidden");
+    });
+
+    const addOrRemove =
+      actionElementBindingType === "standalone" ? "not add" : "add";
+
+    it(`should ${addOrRemove} the aria-hidden when the popover is dismissed`, async () => {
+      await anotherButtonRef.focus();
+      await anotherButtonRef.press("Tab");
+      await page.waitForChanges();
+      // To this point is visible
+
+      await anotherButtonRef.focus();
+      await page.waitForChanges();
+      // Now is hidden
+
+      tooltipRef = await page.find("ch-tooltip");
+
+      if (actionElementBindingType === "standalone") {
+        expect(tooltipRef).not.toHaveAttribute("aria-hidden");
+      } else {
+        expect(tooltipRef).toHaveAttribute("aria-hidden");
+      }
+    });
+  });
+};
+
+performTest("reference");
+performTest("inside-action");
+performTest("standalone");

--- a/src/components/tooltip/tests/accessibility.e2e.ts
+++ b/src/components/tooltip/tests/accessibility.e2e.ts
@@ -70,20 +70,55 @@ const performTest = (
       tooltipRef = await page.find("ch-tooltip");
     });
 
+    const displayPopover = async () => {
+      await anotherButtonRef.focus();
+      await anotherButtonRef.press("Tab");
+      await page.waitForChanges();
+    };
+
+    const getPopoverRef = () => page.find("ch-tooltip >>> ch-popover");
+
     if (actionElementBindingType === "standalone") {
-      it("should not render an aria-hidden when the popover is not visible", async () => {
-        expect(tooltipRef).not.toHaveAttribute("aria-hidden");
+      it("should not have an aria-hidden when the popover is not visible", () =>
+        expect(tooltipRef).not.toHaveAttribute("aria-hidden"));
+
+      it('should not have role="tooltip"', () =>
+        expect(tooltipRef).not.toHaveAttribute("role"));
+
+      it("should not have an id", () =>
+        expect(tooltipRef).not.toHaveAttribute("id"));
+
+      it('the internal popover should have role="tooltip"', async () => {
+        await displayPopover();
+        expect(await getPopoverRef()).toEqualAttribute("role", "tooltip");
+      });
+
+      it("the internal popover should have an id", async () => {
+        await displayPopover();
+        expect(await getPopoverRef()).toHaveAttribute("id");
       });
     } else {
-      it("should render an aria-hidden when the popover is not visible", async () => {
-        expect(tooltipRef).toEqualAttribute("aria-hidden", "true");
+      it("should have an aria-hidden when the popover is not visible", () =>
+        expect(tooltipRef).toEqualAttribute("aria-hidden", "true"));
+
+      it('should have role="tooltip"', () =>
+        expect(tooltipRef).toEqualAttribute("role", "tooltip"));
+
+      it("should have an id", () => expect(tooltipRef).toHaveAttribute("id"));
+
+      it('the internal popover should not have role="tooltip"', async () => {
+        await displayPopover();
+        expect(await getPopoverRef()).not.toEqualAttribute("role", "tooltip");
+      });
+
+      it("the internal popover should not have an id", async () => {
+        await displayPopover();
+        expect(await getPopoverRef()).not.toHaveAttribute("id");
       });
     }
 
     it("should not render an aria-hidden when the popover is visible", async () => {
-      await anotherButtonRef.focus();
-      await anotherButtonRef.press("Tab");
-      await page.waitForChanges();
+      await displayPopover();
       tooltipRef = await page.find("ch-tooltip");
 
       tooltipRef = await page.find("ch-tooltip");
@@ -94,10 +129,7 @@ const performTest = (
       actionElementBindingType === "standalone" ? "not add" : "add";
 
     it(`should ${addOrRemove} the aria-hidden when the popover is dismissed`, async () => {
-      await anotherButtonRef.focus();
-      await anotherButtonRef.press("Tab");
-      await page.waitForChanges();
-      // To this point is visible
+      await displayPopover();
 
       await anotherButtonRef.focus();
       await page.waitForChanges();

--- a/src/components/tooltip/tests/basic.e2e.ts
+++ b/src/components/tooltip/tests/basic.e2e.ts
@@ -1,5 +1,8 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
-import { testDefaultProperties } from "../../../testing/utils.e2e";
+import {
+  testDefaultCssProperties,
+  testDefaultProperties
+} from "../../../testing/utils.e2e";
 
 testDefaultProperties("ch-tooltip", {
   actionElement: undefined,
@@ -7,6 +10,13 @@ testDefaultProperties("ch-tooltip", {
   blockAlign: "outside-end",
   delay: 100,
   inlineAlign: "center"
+});
+
+testDefaultCssProperties("ch-tooltip", {
+  display: "contents",
+  "--ch-tooltip-separation": "0px",
+  "--ch-tooltip-separation-x": "0px",
+  "--ch-tooltip-separation-y": "0px"
 });
 
 describe("[ch-tooltip][basic]", () => {
@@ -22,29 +32,8 @@ describe("[ch-tooltip][basic]", () => {
     tooltipRef = await page.find("ch-tooltip");
   });
 
-  const getCustomVarValue = (customVar: string) =>
-    page.evaluate(
-      (customVarName: string) =>
-        getComputedStyle(document.querySelector("ch-tooltip")).getPropertyValue(
-          customVarName
-        ),
-      customVar
-    );
-
   it("should have Shadow DOM", () =>
     expect(tooltipRef.shadowRoot).toBeTruthy());
-
-  it('should have "display: contents" by default', async () =>
-    expect((await tooltipRef.getComputedStyle()).display).toBe("contents"));
-
-  it('should have "--ch-tooltip-separation: 0px" by default', async () =>
-    expect(await getCustomVarValue("--ch-tooltip-separation")).toBe("0px"));
-
-  it('should have "--ch-tooltip-separation-x: 0px" by default', async () =>
-    expect(await getCustomVarValue("--ch-tooltip-separation-x")).toBe("0px"));
-
-  it('should have "--ch-tooltip-separation-y: 0px" by default', async () =>
-    expect(await getCustomVarValue("--ch-tooltip-separation-y")).toBe("0px"));
 
   it("should not render the ch-popover by default", async () => {
     const popoverRef = await page.find("ch-tooltip >>> ch-popover");

--- a/src/components/tooltip/tests/basic.e2e.ts
+++ b/src/components/tooltip/tests/basic.e2e.ts
@@ -1,4 +1,13 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import { testDefaultProperties } from "../../../testing/utils.e2e";
+
+testDefaultProperties("ch-tooltip", {
+  actionElement: undefined,
+  actionElementAccessibleName: undefined,
+  blockAlign: "outside-end",
+  delay: 100,
+  inlineAlign: "center"
+});
 
 describe("[ch-tooltip][basic]", () => {
   let page: E2EPage;
@@ -9,21 +18,9 @@ describe("[ch-tooltip][basic]", () => {
       html: `<ch-tooltip></ch-tooltip>`,
       failOnConsoleError: true
     });
+
     tooltipRef = await page.find("ch-tooltip");
   });
-
-  const testDefault = (
-    propertyName: string,
-    propertyValue: any,
-    propertyValueDescription: string
-  ) =>
-    it(`the "${propertyName}" property should be ${
-      typeof propertyValue === "string"
-        ? `"${propertyValueDescription}"`
-        : propertyValueDescription
-    } by default`, async () => {
-      expect(await tooltipRef.getProperty(propertyName)).toBe(propertyValue);
-    });
 
   const getCustomVarValue = (customVar: string) =>
     page.evaluate(
@@ -34,30 +31,20 @@ describe("[ch-tooltip][basic]", () => {
       customVar
     );
 
-  it("should have Shadow DOM", async () => {
-    expect(tooltipRef.shadowRoot).toBeTruthy();
-  });
+  it("should have Shadow DOM", () =>
+    expect(tooltipRef.shadowRoot).toBeTruthy());
 
-  testDefault("actionElement", undefined, "undefined");
-  testDefault("blockAlign", "outside-end", "outside-end");
-  testDefault("delay", 100, "100");
-  testDefault("inlineAlign", "center", "center");
+  it('should have "display: contents" by default', async () =>
+    expect((await tooltipRef.getComputedStyle()).display).toBe("contents"));
 
-  it('should have "display: contents" by default', async () => {
-    expect((await tooltipRef.getComputedStyle()).display).toBe("contents");
-  });
+  it('should have "--ch-tooltip-separation: 0px" by default', async () =>
+    expect(await getCustomVarValue("--ch-tooltip-separation")).toBe("0px"));
 
-  it('should have "--ch-tooltip-separation: 0px" by default', async () => {
-    expect(await getCustomVarValue("--ch-tooltip-separation")).toBe("0px");
-  });
+  it('should have "--ch-tooltip-separation-x: 0px" by default', async () =>
+    expect(await getCustomVarValue("--ch-tooltip-separation-x")).toBe("0px"));
 
-  it('should have "--ch-tooltip-separation-x: 0px" by default', async () => {
-    expect(await getCustomVarValue("--ch-tooltip-separation-x")).toBe("0px");
-  });
-
-  it('should have "--ch-tooltip-separation-y: 0px" by default', async () => {
-    expect(await getCustomVarValue("--ch-tooltip-separation-y")).toBe("0px");
-  });
+  it('should have "--ch-tooltip-separation-y: 0px" by default', async () =>
+    expect(await getCustomVarValue("--ch-tooltip-separation-y")).toBe("0px"));
 
   it("should not render the ch-popover by default", async () => {
     const popoverRef = await page.find("ch-tooltip >>> ch-popover");

--- a/src/showcase/assets/components/navigation-list/models.ts
+++ b/src/showcase/assets/components/navigation-list/models.ts
@@ -4,7 +4,7 @@ export const unanimoShowcase: NavigationListModel = [
   {
     caption: "Controls",
     startImgSrc:
-      "url('https://unpkg.com/@genexus/unanimo@latest/dist/assets/icons/projects.svg')",
+      "url('https://unpkg.com/@genexus/unanimo@0.25.0/dist/assets/icons/projects.svg')",
     startImgType: "mask",
     items: [
       {
@@ -44,7 +44,7 @@ export const unanimoShowcase: NavigationListModel = [
   {
     caption: "Navigation",
     startImgSrc:
-      "url('https://unpkg.com/@genexus/unanimo@latest/dist/assets/icons/send.svg')",
+      "url('https://unpkg.com/@genexus/unanimo@0.25.0/dist/assets/icons/send.svg')",
     startImgType: "mask",
     items: [
       {
@@ -68,7 +68,7 @@ export const unanimoShowcase: NavigationListModel = [
   {
     caption: "Interaction",
     startImgSrc:
-      "url('https://unpkg.com/@genexus/unanimo@latest/dist/assets/icons/profile.svg')",
+      "url('https://unpkg.com/@genexus/unanimo@0.25.0/dist/assets/icons/profile.svg')",
     startImgType: "mask",
     items: [
       {


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fixed accessibility issues with the `ch-navigation-list-render` (missing roles).

 - Now, when the `ch-tooltip` does not displays its popover, it will be hidden to the accessibility tree (added `aria-hidden` in the Host for those cases).

 - Added a new property `actionElementAccessibleName` in the `ch-tooltip` to add an aria-label in the `actionElement`.

 - The `ch-tooltip` will now set the `aria-describedby` value in the `actionElement`, so there is no need to manually set it.