### PR TITLE
`[ch-code]` Improve default property types and add scrollbars when the content overflows the x-axis

### DIFF
--- a/src/components/code/code.scss
+++ b/src/components/code/code.scss
@@ -307,6 +307,7 @@
 
 code {
   font: inherit;
+  contain: inline-size;
 }
 
 .hljs {

--- a/src/components/code/code.tsx
+++ b/src/components/code/code.tsx
@@ -24,14 +24,14 @@ export class ChCode {
   @State() JSXCodeBlock: any;
 
   /**
+   * Specifies the code language to highlight.
+   */
+  @Prop() readonly language?: string | undefined;
+
+  /**
    *
    */
   @Prop() readonly lastNestedChildClass: string = "last-nested-child";
-
-  /**
-   * Specifies the code language to highlight.
-   */
-  @Prop() readonly language: string;
 
   /**
    * Specifies if an indicator is displayed in the last element rendered.
@@ -42,7 +42,7 @@ export class ChCode {
   /**
    * Specifies the code string to highlight.
    */
-  @Prop() readonly value: string;
+  @Prop() readonly value?: string | undefined;
 
   #getLanguageOrDefault = () => this.language || "plaintext";
 

--- a/src/components/code/tests/basic.e2e.ts
+++ b/src/components/code/tests/basic.e2e.ts
@@ -1,0 +1,78 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import {
+  testDefaultCssProperties,
+  testDefaultProperties
+} from "../../../testing/utils.e2e";
+
+testDefaultProperties("ch-code", {
+  language: undefined,
+  lastNestedChildClass: "last-nested-child",
+  showIndicator: false,
+  value: undefined
+});
+
+testDefaultCssProperties("ch-code", {
+  "--ch-code-indicator-color": "currentColor",
+  "--ch-code-inline-size": "1.125ch",
+  "--ch-code-block-size": "1em",
+  "--ch-code__addition": "currentColor",
+  "--ch-code__attr": "currentColor",
+  "--ch-code__attribute": "currentColor",
+  "--ch-code__built-in": "currentColor",
+  "--ch-code__bullet": "currentColor",
+  "--ch-code__class": "currentColor",
+  "--ch-code__code": "currentColor",
+  "--ch-code__comment": "currentColor",
+  "--ch-code__deletion": "currentColor",
+  "--ch-code__doctag": "currentColor",
+  "--ch-code__formula": "currentColor",
+  "--ch-code__function": "currentColor",
+  "--ch-code__function-variable": "currentColor",
+  "--ch-code__keyword": "currentColor",
+  "--ch-code__link": "currentColor",
+  "--ch-code__literal": "currentColor",
+  "--ch-code__meta": "currentColor",
+  "--ch-code__meta__keyword": "currentColor",
+  "--ch-code__meta__string": "currentColor",
+  "--ch-code__name": "currentColor",
+  "--ch-code__number": "currentColor",
+  "--ch-code__operator": "currentColor",
+  "--ch-code__regexp": "currentColor",
+  "--ch-code__quote": "currentColor",
+  "--ch-code__selector-attr": "currentColor",
+  "--ch-code__selector-class": "currentColor",
+  "--ch-code__selector-id": "currentColor",
+  "--ch-code__selector-pseudo": "currentColor",
+  "--ch-code__selector-tag": "currentColor",
+  "--ch-code__string": "currentColor",
+  "--ch-code__subst": "currentColor",
+  "--ch-code__symbol": "currentColor",
+  "--ch-code__tag": "currentColor",
+  "--ch-code__template-tag": "currentColor",
+  "--ch-code__template-variable": "currentColor",
+  "--ch-code__title": "currentColor",
+  "--ch-code__title-class": "currentColor",
+  "--ch-code__title-class-inherited": "currentColor",
+  "--ch-code__title-function": "currentColor",
+  "--ch-code__type": "currentColor",
+  "--ch-code__variable": "currentColor",
+  "--ch-code__variable-language": "currentColor"
+});
+
+describe("[ch-code][basic]", () => {
+  let page: E2EPage;
+  let codeRef: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-code></ch-code>`,
+      failOnConsoleError: true
+    });
+    codeRef = await page.find("ch-code");
+  });
+
+  it("should have Shadow DOM", () => expect(codeRef.shadowRoot).toBeTruthy());
+
+  // it("should render empty by default", () =>
+  //   expect(codeRef.shadowRoot.innerHTML).toBeFalsy());
+});

--- a/src/components/code/tests/code.e2e.ts
+++ b/src/components/code/tests/code.e2e.ts
@@ -72,13 +72,6 @@ describe("[ch-code]", () => {
     expect(codeRef).not.toBeNull();
   });
 
-  it("should have a shadowRoot", async () => {
-    await page.setContent(`<ch-code></ch-code>`);
-    const codeRef = await page.find("ch-code");
-
-    expect(codeRef.shadowRoot).not.toBeNull();
-  });
-
   it("should render an empty <code> when no value is provided", async () => {
     await page.setContent(`<ch-code></ch-code>`);
     const codeRef = await page.find("ch-code");
@@ -95,24 +88,6 @@ describe("[ch-code]", () => {
     expect(codeRef.shadowRoot).toEqualHtml(
       `<code class="hljs language-typescript" part="code language-typescript"></code>`
     );
-  });
-
-  it('should have "white-space: pre" to properly display the content', async () => {
-    await page.setContent(`<ch-code language="typescript"></ch-code>`);
-    const codeRef = await page.find("ch-code");
-
-    const computedStyle = await codeRef.getComputedStyle();
-
-    expect(computedStyle.whiteSpace).toBe("pre");
-  });
-
-  it('should have "overflow: auto" to properly display the content', async () => {
-    await page.setContent(`<ch-code language="typescript"></ch-code>`);
-    const codeRef = await page.find("ch-code");
-
-    const computedStyle = await codeRef.getComputedStyle();
-
-    expect(computedStyle.overflow).toBe("auto");
   });
 
   it("should render a hello world", async () => {

--- a/src/components/code/tests/styles.e2e.ts
+++ b/src/components/code/tests/styles.e2e.ts
@@ -1,0 +1,50 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import { SCROLLABLE_CLASS } from "../../../common/reserved-names";
+
+describe("[ch-code][styles]", () => {
+  let page: E2EPage;
+  let codeRef: E2EElement;
+  let internalCodeRef: E2EElement;
+  let computedStyle: CSSStyleDeclaration;
+  let internalCodeComputedStyle: CSSStyleDeclaration;
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      failOnConsoleError: true,
+      html: `<ch-code language="typescript"></ch-code>`
+    });
+    codeRef = await page.find("ch-code");
+    internalCodeRef = await page.find("ch-code >>> code");
+
+    computedStyle = await codeRef.getComputedStyle();
+    internalCodeComputedStyle = await internalCodeRef.getComputedStyle();
+  });
+
+  it('should have "font-family: monospace" to properly display the content', () =>
+    expect(computedStyle.fontFamily).toBe("monospace"));
+
+  it('should have "white-space: pre" to properly display the content', () =>
+    expect(computedStyle.whiteSpace).toBe("pre"));
+
+  it('should have "overflow: auto" to properly display the content', () =>
+    expect(computedStyle.overflow).toBe("auto"));
+
+  // TODO: This test should be in a generic test file for the scrollbar styles
+  it(`should have the ${SCROLLABLE_CLASS} class to properly style the scrollbars`, () =>
+    expect(codeRef.className).toContain(SCROLLABLE_CLASS));
+
+  it('the internal <code> should inherit the font styles ("font: inherit")', async () => {
+    const cssRules = await page.evaluate(() =>
+      [
+        ...document.querySelector("ch-code").shadowRoot.adoptedStyleSheets[0]
+          .cssRules
+      ].map(rule => rule.cssText)
+    );
+
+    expect(cssRules).toContain("code { font: inherit; contain: inline-size; }");
+    expect(internalCodeComputedStyle.font).toContain("monospace");
+  });
+
+  it('the internal <code> should have "contain: inline-size" to avoid overflowing the x-axis', () =>
+    expect(internalCodeComputedStyle.contain).toBe("inline-size"));
+});


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Improve default property types.
  The type of the `language` and `value` properties now includes `undefined` as an alternative.

 - Add scrollbars when the content overflows the x-axis.
  The `ch-code` will no longer stretch the width of its parent container.
