### PR TITLE
Add a CLI to generate React Web Component wrappers

### DIFF
--- a/copy-files.mjs
+++ b/copy-files.mjs
@@ -4,6 +4,14 @@ fs.copyFile(
   "./src/framework-integrations.ts",
   "./dist/collection/framework-integrations.ts",
   err => {
-    if (err) throw err;
+    if (err) {
+      throw err;
+    }
   }
 );
+
+fs.copyFile("./src/copy-react.js", "./dist/react/copy-react.js", err => {
+  if (err) {
+    throw err;
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,15 @@
         "qr-creator": "^1.0.0",
         "stencil-click-outside": "^1.8.0"
       },
+      "bin": {
+        "ch.generate.react": "dist/react/copy-react.mjs",
+        "chameleon.generate.react": "dist/react/copy-react.mjs"
+      },
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",
         "@stencil-community/eslint-plugin": "~0.7.1",
         "@stencil/core": "~4.16.0",
+        "@stencil/react-output-target": "~0.5.3",
         "@stencil/sass": "~3.0.11",
         "@types/hast": "^3.0.4",
         "@types/jest": "~29.5.1",
@@ -1961,6 +1966,15 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.10.0"
+      }
+    },
+    "node_modules/@stencil/react-output-target": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.5.3.tgz",
+      "integrity": "sha512-68jwRp35CjAcwhTJ9yFD/3n+jrHOqvEH2jreVuPVvZK+4tkhPlYlwz0d1E1RlF3jyifUSfdkWUGgXIEy8Fo3yw==",
+      "dev": true,
+      "peerDependencies": {
+        "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
       }
     },
     "node_modules/@stencil/sass": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "npm run build.monaco && npm run build.light && npm run build.extras",
-    "build.light": "stencil build --docs",
+    "build.light": "stencil build --docs --react",
     "build.extras": "tsc --project tsconfig-collection.json && node copy-files.mjs",
     "build.monaco": "vite build",
     "generate": "stencil generate",
@@ -26,7 +26,8 @@
     "lint": "eslint src/**/*{.ts,.tsx} --fix",
     "start": "npm run build.monaco && npm run start.light",
     "start.light": "stencil build --dev --watch --serve",
-    "start.optimized": "stencil build --dev --watch --serve --config stencil.config.optimized-dev.ts",
+    "start.optimized": "stencil build --watch --serve --config stencil.config.optimized-dev.ts",
+    "start.o": "npm run start.optimized",
     "test": "stencil test --spec --e2e --maxWorkers=1",
     "test.spec": "stencil test --spec --coverage --no-cache",
     "test.watch": "npm run test -- --watchAll --config stencil.config.optimized-test-watch.ts",
@@ -34,6 +35,9 @@
     "validate.ci": "npm run lint && npm run build.monaco && npm run test && npm run build.light --debug && npm run build.extras"
   },
   "license": "MIT",
+  "bin": {
+    "chameleon-generate-react": "dist/react/copy-react.js"
+  },
   "dependencies": {
     "@genexus/markdown-parser": "~0.1.1",
     "html5-qrcode": "^2.3.8",
@@ -46,6 +50,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@stencil-community/eslint-plugin": "~0.7.1",
     "@stencil/core": "~4.16.0",
+    "@stencil/react-output-target": "~0.5.3",
     "@stencil/sass": "~3.0.11",
     "@types/hast": "^3.0.4",
     "@types/jest": "~29.5.1",

--- a/src/copy-react.js
+++ b/src/copy-react.js
@@ -5,8 +5,8 @@ import path from "node:path";
 import { styleText } from "node:util";
 import { fileURLToPath } from "url";
 
-const DEFAULT_OUT_DIR = "./src";
 const FOLDER_NAME_FOR_WRAPPERS = "chameleon-components";
+const DEFAULT_OUT_DIR = path.join("src", FOLDER_NAME_FOR_WRAPPERS);
 
 const ensureDirectoryItsClear = dirPath => {
   if (fs.existsSync(dirPath)) {
@@ -29,7 +29,7 @@ if (!args || !args[0]) {
   console.log(
     styleText(
       "yellow",
-      "  [warning]: Missing output directory for chameleon components. The directory "
+      "[warning]: Missing output directory for chameleon components. The directory "
     ) +
       styleText("cyan", `'${DEFAULT_OUT_DIR}'`) +
       styleText("yellow", " will be used as default.")
@@ -44,8 +44,7 @@ const chameleonWrappersDirectory = path.join(
 );
 const pathToCopyChameleonWrappers = path.join(
   directoryWhereTheScriptIsRunning,
-  outDir,
-  FOLDER_NAME_FOR_WRAPPERS
+  outDir
 );
 
 ensureDirectoryItsClear(pathToCopyChameleonWrappers);

--- a/src/copy-react.js
+++ b/src/copy-react.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { styleText } from "node:util";
+import { fileURLToPath } from "url";
+
+const DEFAULT_OUT_DIR = "./src";
+const FOLDER_NAME_FOR_WRAPPERS = "chameleon-components";
+
+const ensureDirectoryItsClear = dirPath => {
+  if (fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true });
+  }
+};
+
+// This is a WA to have __dirname in ES modules
+const __filename = fileURLToPath(import.meta.url);
+
+// Directory name where the script is located (<path from root to node_modules/@genexus/chameleon-controls-library>/dist/react/)
+const __dirname = path.dirname(__filename);
+const directoryWhereTheScriptIsRunning = process.cwd();
+
+const [, , ...args] = process.argv;
+
+let outDir = DEFAULT_OUT_DIR;
+
+if (!args || !args[0]) {
+  console.log(
+    styleText(
+      "yellow",
+      "  [warning]: Missing output directory for chameleon components. The directory "
+    ) +
+      styleText("cyan", `'${DEFAULT_OUT_DIR}'`) +
+      styleText("yellow", " will be used as default.")
+  );
+} else {
+  outDir = args[0];
+}
+
+const chameleonWrappersDirectory = path.join(
+  __dirname,
+  FOLDER_NAME_FOR_WRAPPERS
+);
+const pathToCopyChameleonWrappers = path.join(
+  directoryWhereTheScriptIsRunning,
+  outDir,
+  FOLDER_NAME_FOR_WRAPPERS
+);
+
+ensureDirectoryItsClear(pathToCopyChameleonWrappers);
+
+fs.cpSync(chameleonWrappersDirectory, pathToCopyChameleonWrappers, {
+  recursive: true
+});

--- a/stencil.config.optimized-dev.ts
+++ b/stencil.config.optimized-dev.ts
@@ -2,10 +2,13 @@ import { Config } from "@stencil/core";
 import { sass } from "@stencil/sass";
 import { config as defaultConfig } from "./stencil.config.ts";
 
+const argv = process.argv;
+const buildReact = argv.includes("--react");
+
 export const config: Config = {
   namespace: defaultConfig.namespace,
   outputTargets: defaultConfig.outputTargets!.filter(
-    output => output.type === "www"
+    output => output.type === "www" || buildReact
   ),
   plugins: [sass()],
   testing: defaultConfig.testing,

--- a/stencil.config.optimized-test-watch.ts
+++ b/stencil.config.optimized-test-watch.ts
@@ -2,10 +2,13 @@ import { Config } from "@stencil/core";
 import { sass } from "@stencil/sass";
 import { config as defaultConfig } from "./stencil.config.ts";
 
+const argv = process.argv;
+const buildReact = argv.includes("--react");
+
 export const config: Config = {
   namespace: defaultConfig.namespace,
   outputTargets: defaultConfig.outputTargets!.filter(
-    output => output.type === "www"
+    output => output.type === "www" || buildReact
   ),
   plugins: [sass()],
   testing: defaultConfig.testing,

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,26 +1,45 @@
 import { Config } from "@stencil/core";
+import { OutputTarget } from "@stencil/core/internal";
 import { sass } from "@stencil/sass";
+import { reactOutputTarget } from "@stencil/react-output-target";
+
+import { reactOutputExcludedComponents } from "./src/framework-integrations.ts";
+
+const outputTargets: OutputTarget[] = [
+  {
+    type: "dist",
+    esmLoaderPath: "../loader",
+    copy: [{ src: "common/monaco/output/assets", dest: "assets" }]
+  },
+  // dist-custom-elements output target is required for the React output target.
+  // It generates the dist/components folder
+  { type: "dist-custom-elements" },
+  {
+    type: "www",
+    serviceWorker: null,
+    copy: [
+      { src: "common/monaco/output/assets", dest: "assets" },
+      { src: "showcase" }
+    ]
+  },
+  reactOutputTarget({
+    componentCorePackage: "@genexus/chameleon-controls-library",
+    proxiesFile: "dist/react/chameleon-components/index.ts",
+
+    // All Web Components will automatically be registered with the Custom
+    // Elements Registry. This can only be used when lazy loading Web
+    // Components and will not work when includeImportCustomElements is true.
+    includeDefineCustomElements: true,
+    loaderDir: "loader",
+
+    excludeComponents: reactOutputExcludedComponents,
+    customElementsDir: "dist/components"
+  })
+];
 
 export const config: Config = {
   namespace: "chameleon",
-  outputTargets: [
-    {
-      type: "dist",
-      esmLoaderPath: "../loader",
-      copy: [{ src: "common/monaco/output/assets", dest: "assets" }]
-    },
-    // dist-custom-elements output target is required for the React output target.
-    // It generates the dist/components folder
-    { type: "dist-custom-elements" },
-    {
-      type: "www",
-      serviceWorker: null,
-      copy: [
-        { src: "common/monaco/output/assets", dest: "assets" },
-        { src: "showcase" }
-      ]
-    }
-  ],
+  outputTargets,
   plugins: [sass()],
   extras: {
     // Enabling this flag will allow downstream projects that consume a Stencil


### PR DESCRIPTION
Chameleon now exports a CLI to create React Web Component wrappers. To create the wrappers, run the following command:
```bash
chameleon-generate-react <output dir (optional)>
```

For example:
```bash
chameleon-generate-react ./src/chameleon-components
```
