### PR TITLE
`[ch-tree-view-render]` Fixes for interactions with the checkbox and filters with `filterType="list"`

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -19,7 +19,8 @@ import {
   DisableableComponent,
   FormComponent
 } from "../../common/interfaces";
-import {
+import type {
+  ChameleonControlsTagName,
   GxImageMultiState,
   GxImageMultiStateStart,
   ImageRender
@@ -225,7 +226,19 @@ export class ChCheckBox
     // When the internal label is clicked it provokes a click in the input with
     // event.detail === 0
     if (event.composedPath()[0] !== this.#getInputRef()) {
-      this.#updateCheckedValueAndEmitEvent(!this.#getInputRef().checked);
+      return this.#updateCheckedValueAndEmitEvent(!this.#getInputRef().checked);
+    }
+
+    const rootNode = this.el.getRootNode();
+
+    // TODO: This is a WA to make work again the ch-checkbox inside the
+    // ch-tree-view-item, because the Space key is not working
+    if (
+      rootNode instanceof ShadowRoot &&
+      rootNode.host.tagName.toLowerCase() ===
+        ("ch-tree-view-item" as ChameleonControlsTagName)
+    ) {
+      this.#updateCheckedValueAndEmitEvent(this.#getInputRef().checked);
     }
   };
 

--- a/src/components/tree-view/tests/events/checkedItemsChange.e2e.ts
+++ b/src/components/tree-view/tests/events/checkedItemsChange.e2e.ts
@@ -1,0 +1,106 @@
+import {
+  E2EElement,
+  E2EPage,
+  EventSpy,
+  newE2EPage
+} from "@stencil/core/testing";
+import { testTreeViewModel } from "../utils.e2e";
+// import { TREE_VIEW_NODE_RENDER } from "../utils.e2e";
+
+const DEV_NODE_ID = "dev";
+
+describe("[ch-tree-view-render][events][checkedItemsChange]", () => {
+  let page: E2EPage;
+  let treeViewRef: E2EElement;
+  let checkedItemsChangeSpy: EventSpy;
+
+  // const getTreeViewRenderedContent = () =>
+  //   page.evaluate(() =>
+  //     document
+  //       .querySelector("ch-tree-view-render")
+  //       .shadowRoot.innerHTML.toString()
+  //   );
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: `<ch-tree-view-render></ch-tree-view-render>`,
+      failOnConsoleError: true
+    });
+    treeViewRef = await page.find("ch-tree-view-render");
+    treeViewRef.setProperty("model", testTreeViewModel);
+    treeViewRef.setProperty("filterDebounce", 0);
+    checkedItemsChangeSpy = await treeViewRef.spyOnEvent("checkedItemsChange");
+
+    await page.waitForChanges();
+  });
+
+  const clickOnCheckbox = async (treeViewId: string) => {
+    const checkboxRef = await page.find(
+      `ch-tree-view-render >>> ch-tree-view-item[id='${treeViewId}'] >>> ch-checkbox`
+    );
+
+    return checkboxRef.press("Space");
+  };
+
+  // TODO: This is hard to implement, because we have to observe the event by
+  // getting a reference for the element, but the element must be created with
+  // the model, without triggering any extra re-render by updating the property
+  // after the initial render.
+  // We should probably check this event in a parent node and create the
+  // element using page.evaluate
+  it.todo("should not emit the checkedItemsChange event on the initial load");
+
+  // TODO: Fix this
+  it.skip("should not emit the event if the checked property, but no node has checkbox = true", async () => {
+    treeViewRef.setProperty("checked", true);
+    await page.waitForChanges();
+
+    expect(checkedItemsChangeSpy).toHaveReceivedEventTimes(0);
+  });
+
+  it("should emit the event if the checked property is updated and checkbox = true", async () => {
+    treeViewRef.setProperty("checkbox", true);
+    treeViewRef.setProperty("checked", true);
+    await page.waitForChanges();
+
+    expect(checkedItemsChangeSpy).toHaveReceivedEventTimes(2);
+
+    // TODO: Puppeteer doesn't know how to deserialize a Map...
+    expect(checkedItemsChangeSpy).toHaveNthReceivedEventDetail(0, {});
+    expect(checkedItemsChangeSpy).toHaveReceivedEventDetail({
+      /* Add all items */
+    });
+  });
+
+  it("should emit the event with empty checked items if checkbox = true and all items are unchecked", async () => {
+    treeViewRef.setProperty("checkbox", true);
+    await page.waitForChanges();
+
+    expect(checkedItemsChangeSpy).toHaveReceivedEventTimes(2);
+
+    // TODO: Puppeteer doesn't know how to deserialize a Map...
+    expect(checkedItemsChangeSpy).toHaveNthReceivedEventDetail(0, {});
+    expect(checkedItemsChangeSpy).toHaveNthReceivedEventDetail(1, {});
+  });
+
+  it("should emit the event the event with the checked items when the user updates the checkbox", async () => {
+    treeViewRef.setProperty("checkbox", true);
+    await page.waitForChanges();
+
+    expect(checkedItemsChangeSpy).toHaveReceivedEventTimes(2);
+
+    // TODO: Puppeteer doesn't know how to deserialize a Map...
+    expect(checkedItemsChangeSpy).toHaveNthReceivedEventDetail(0, {});
+    expect(checkedItemsChangeSpy).toHaveNthReceivedEventDetail(1, {});
+
+    await clickOnCheckbox(DEV_NODE_ID);
+    await page.waitForChanges();
+
+    expect(checkedItemsChangeSpy).toHaveReceivedEventTimes(3);
+
+    // TODO: Puppeteer doesn't know how to deserialize a Map...
+    expect(checkedItemsChangeSpy).toHaveNthReceivedEventDetail(2, {
+      /* Add all items */
+    });
+  });
+});

--- a/src/components/tree-view/tests/filters-filterType-list.e2e.ts
+++ b/src/components/tree-view/tests/filters-filterType-list.e2e.ts
@@ -109,6 +109,39 @@ describe('[ch-tree-view-render][filters][filterType="list"]', () => {
     );
   });
 
+  it("should work filtering items on the initial load", async () => {
+    await page.setContent("");
+    await page.waitForChanges();
+
+    // This is a WA to create the element and assign the properties before it's
+    // connected to the DOM. Otherwise, we would trigger an extra render
+    await page.evaluate(
+      (model, filterList) => {
+        const treeView = document.createElement("ch-tree-view-render");
+        treeView.filterType = "list";
+        treeView.filterList = filterList;
+        treeView.filterDebounce = 0;
+        treeView.model = model;
+
+        document.body.appendChild(treeView);
+      },
+      kbExplorerModel,
+      ["root"]
+    );
+
+    treeViewRef = await page.find("ch-tree-view-render");
+    await page.waitForChanges();
+
+    const filteredHTML = await getTreeViewRenderedContent();
+
+    expect(filteredHTML).toEqual(
+      TREE_VIEW_NODE(
+        `<ch-tree-view-item id="root" role="treeitem" aria-level="1" exportparts="${ITEM_EXPORT_PARTS}" class="hydrated" part="item" style="--level: 0;"></ch-tree-view-item>`
+      )
+    );
+  });
+
+  // TODO: We should add all this test for the initial load too
   it("should render two items if the filterList only contains a direct descendant of the root", async () => {
     treeViewRef.setProperty("filterType", "list");
     treeViewRef.setProperty("filterList", ["Main_Programs"]);

--- a/src/components/tree-view/tests/utils.e2e.ts
+++ b/src/components/tree-view/tests/utils.e2e.ts
@@ -1,3 +1,5 @@
+import type { TreeViewModel } from "../types";
+
 type TreeViewNodeTest =
   | {
       id: string;
@@ -28,3 +30,172 @@ const TREE_VIEW_ITEM_NODE = (options: TreeViewNodeTest, level: number) => {
 
 export const TREE_VIEW_NODE_RENDER = (children: TreeViewNodeTest[]) =>
   TREE_VIEW_NODE(children.map(node => TREE_VIEW_ITEM_NODE(node, 1)).join(""));
+
+export const testTreeViewModel: TreeViewModel = [
+  {
+    id: "root",
+    caption: "/",
+    editable: false,
+    expanded: true,
+    dragDisabled: true,
+    dropDisabled: true,
+    items: [
+      {
+        id: "dev",
+        caption: "dev",
+        editable: false,
+        dragDisabled: true,
+        dropDisabled: true,
+        leaf: true
+      },
+      {
+        id: "etc",
+        caption: "etc",
+        editable: false,
+        dragDisabled: true,
+        dropDisabled: true,
+        items: [
+          {
+            id: "cups",
+            caption: "cups",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          },
+          {
+            id: "httpd",
+            caption: "httpd",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          },
+          {
+            id: "init",
+            caption: "init.d",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          }
+        ]
+      },
+      {
+        id: "sbin",
+        caption: "sbin",
+        editable: false,
+        dragDisabled: true,
+        dropDisabled: true,
+        leaf: true
+      },
+      {
+        id: "tmp",
+        caption: "tmp",
+        editable: false,
+        dragDisabled: true,
+        dropDisabled: true,
+        leaf: true
+      },
+      {
+        id: "Users",
+        caption: "Users",
+        editable: false,
+        dragDisabled: true,
+        dropDisabled: true,
+        items: [
+          {
+            id: "jdoe",
+            caption: "jdoe",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          },
+          {
+            id: "jmiller",
+            caption: "jmiller",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          },
+          {
+            id: "mysql",
+            caption: "mysql",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          }
+        ]
+      },
+      {
+        id: "usr",
+        caption: "usr",
+        editable: false,
+        dragDisabled: true,
+        dropDisabled: true,
+        items: [
+          {
+            id: "bin",
+            caption: "bin",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          },
+          {
+            id: "lib",
+            caption: "lib",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          },
+          {
+            id: "local",
+            caption: "local",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          }
+        ]
+      },
+      {
+        id: "var",
+        caption: "var",
+        editable: false,
+        dragDisabled: true,
+        dropDisabled: true,
+        items: [
+          {
+            id: "log",
+            caption: "log",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          },
+          {
+            id: "spool",
+            caption: "spool",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          },
+          {
+            id: "yp",
+            caption: "yp",
+            editable: false,
+            dragDisabled: true,
+            dropDisabled: true,
+            leaf: true
+          }
+        ]
+      }
+    ]
+  }
+];

--- a/src/components/tree-view/tree-view-render.tsx
+++ b/src/components/tree-view/tree-view-render.tsx
@@ -1572,7 +1572,8 @@ export class ChTreeViewRender {
         new Map();
 
       if (this.filterType === "list") {
-        this.#filterListAsSet ??= new Set();
+        // TODO: Add unit tests for this case (?? [])
+        this.#filterListAsSet ??= new Set(this.filterList ?? []);
       }
 
       this.#filterSubModel(

--- a/src/components/tree-view/tree-view-render.tsx
+++ b/src/components/tree-view/tree-view-render.tsx
@@ -356,6 +356,11 @@ export class ChTreeViewRender {
    * Set this attribute if you want display a checkbox in all items by default.
    */
   @Prop() readonly checkbox: boolean = false;
+  @Watch("checkbox")
+  checkboxChange() {
+    this.#scheduleCheckedItemsChange();
+    this.#scheduleFilterProcessing();
+  }
 
   /**
    * Set this attribute if you want the checkbox to be checked in all items by
@@ -363,6 +368,11 @@ export class ChTreeViewRender {
    * Only works if `checkbox = true`
    */
   @Prop() readonly checked: boolean = false;
+  @Watch("checked")
+  checkedChange() {
+    this.#scheduleCheckedItemsChange();
+    this.#scheduleFilterProcessing();
+  }
 
   /**
    * Callback that is executed when an element tries to drop in another item of


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fix Space key not working when the `ch-checkbox` is used inside the Tree View.

 - Fix `checkedItemsChange` event not being emitted when updating the `checkbox` or `checked` properties.

 - Fix `filterType = "list"` not working on the initial load.
