### PR TITLE
`[ch-chat]` Refactor the `ch-chat` interface to improve consistency and extensibility. Add support for uploading and rendering files

### DIFF
--- a/src/common/mime-types.ts
+++ b/src/common/mime-types.ts
@@ -1,0 +1,55 @@
+import type { FilterByPrefix, Prettify } from "./types";
+
+export type ChMimeType =
+  | "audio/aac" // aac
+  | "audio/midi" // mid, midi
+  | "audio/mpeg" // mp3
+  | "audio/ogg" // oga, opus
+  | "audio/wav" // wav
+  | "audio/webm" // weba
+  | "audio/x-midi" // mid, midi
+  | "application/java" // java
+  | "application/javascript" // js
+  | "application/json" // json
+  | "application/msword" // doc
+  | "application/php" // php
+  | "application/pdf" // pdf
+  | "application/typescript" // ts
+  | "application/vnd.openxmlformats-officedocument.presentationml.presentation" // pptx
+  | "application/vnd.openxmlformats-officedocument.wordprocessingml.document" // docx
+  | "application/x-python" // py
+  | "application/x-ruby" // rb
+  | "application/x-shellscript" // sh
+  | "application/x-tex" // tex
+  | "image/gif" // gif
+  | "image/jpeg" // jpg, jpeg
+  | "image/png" // png
+  | "image/svg+xml" // svg
+  | "text/css" // css
+  | "text/html" // html
+  | "text/markdown" // md
+  | "text/plain" // txt
+  | "text/x-c" // c
+  | "text/x-csharp" // cs
+  | "text/x-c++" // cpp
+  | "video/mp4" // mp4
+  | "video/quicktime" // mov
+  | "video/x-msvideo" // avi
+  | "video/x-ms-wmv"; // wmv
+
+export type ChMimeTypeAudio = FilterByPrefix<ChMimeType, "audio">;
+
+export type ChMimeTypeFile = Prettify<
+  FilterByPrefix<ChMimeType, "application"> | FilterByPrefix<ChMimeType, "text">
+>;
+
+export type ChMimeTypeImage = FilterByPrefix<ChMimeType, "image">;
+
+export type ChMimeTypeVideo = FilterByPrefix<ChMimeType, "video">;
+
+export interface ChMimeTypeFormatMap {
+  audio: ChMimeTypeFile;
+  file: ChMimeTypeFile;
+  image: ChMimeTypeImage;
+  video: ChMimeTypeVideo;
+}

--- a/src/common/mimeTypes/mime-types-utils.ts
+++ b/src/common/mimeTypes/mime-types-utils.ts
@@ -1,0 +1,13 @@
+import type { ChMimeType, ChMimeTypeFormatMap } from "./mime-types";
+
+export const getMimeTypeFileFormat = (
+  mimeType: ChMimeType | (string & Record<never, never>)
+): keyof ChMimeTypeFormatMap => {
+  const format = mimeType.substring(0, 5);
+
+  // "image" is the most probable file format, so it is placed first to resolve
+  // the branch faster
+  return format === "image" || format === "video" || format === "audio"
+    ? format
+    : "file";
+};

--- a/src/common/mimeTypes/mime-types.ts
+++ b/src/common/mimeTypes/mime-types.ts
@@ -1,4 +1,4 @@
-import type { FilterByPrefix, Prettify } from "./types";
+import type { FilterByPrefix, Prettify } from "../types";
 
 export type ChMimeType =
   | "audio/aac" // aac

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -27,6 +27,11 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 };
 
+export type FilterByPrefix<
+  T,
+  Prefix extends string
+> = T extends `${Prefix}${string}` ? T : never;
+
 export type GxImageMultiState = {
   base: string;
   hover?: string;

--- a/src/components/chat/chat.scss
+++ b/src/components/chat/chat.scss
@@ -36,15 +36,33 @@ img {
   align-items: center;
 }
 
-.assistant-files {
-  grid-area: 2 / 2;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-}
+// .assistant-files {
+//   grid-area: 2 / 2;
+//   display: flex;
+//   flex-wrap: wrap;
+//   align-items: center;
+// }
 
+// - - - - - - - - - - - - - - - -
+//              Files
+// - - - - - - - - - - - - - - - -
 .contents {
   display: contents;
+}
+
+.file-container {
+  display: block;
+}
+
+.sources-container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.files-container,
+.sources-container {
+  margin: 0;
+  padding: 0;
 }
 
 // .file-skeleton {
@@ -79,9 +97,9 @@ img {
   position: relative;
   align-items: end;
 
-  &--file-uploading {
-    grid-template: "upload-image input-wrapper send-or-audio" 1fr / max-content 1fr max-content;
-  }
+  // &--file-uploading {
+  //   grid-template: "upload-image input-wrapper send-or-audio" 1fr / max-content 1fr max-content;
+  // }
 }
 
 .send-input-wrapper {

--- a/src/components/chat/chat.scss
+++ b/src/components/chat/chat.scss
@@ -43,6 +43,11 @@ img {
 //   align-items: center;
 // }
 
+::part(code-block__header) {
+  display: grid;
+  grid-template-columns: 1fr max-content;
+}
+
 // - - - - - - - - - - - - - - - -
 //              Files
 // - - - - - - - - - - - - - - - -

--- a/src/components/chat/chat.scss
+++ b/src/components/chat/chat.scss
@@ -19,9 +19,9 @@
   contain: paint;
 }
 
-.message-with-images {
-  display: grid;
-}
+// .message-with-images {
+//   display: grid;
+// }
 
 img {
   display: block;
@@ -43,31 +43,31 @@ img {
   align-items: center;
 }
 
-.file-skeleton {
-  position: relative;
+// .file-skeleton {
+//   position: relative;
 
-  &::before,
-  &::after {
-    content: "";
-    display: inline-flex;
-  }
-}
+//   &::before,
+//   &::after {
+//     content: "";
+//     display: inline-flex;
+//   }
+// }
 
 // - - - - - - - - - - - - - - - -
 //         Send container
 // - - - - - - - - - - - - - - - -
-.stop-generating-answer-button {
-  grid-area: input-wrapper;
-  position: absolute;
-  inset-block-start: 0;
-  justify-self: center;
-  transform: translateY(-100%);
-}
+// .stop-generating-answer-button {
+//   grid-area: input-wrapper;
+//   position: absolute;
+//   inset-block-start: 0;
+//   justify-self: center;
+//   transform: translateY(-100%);
+// }
 
-.images-to-upload {
-  display: flex;
-  flex-wrap: wrap;
-}
+// .images-to-upload {
+//   display: flex;
+//   flex-wrap: wrap;
+// }
 
 .send-container {
   display: grid;

--- a/src/components/chat/chat.scss
+++ b/src/components/chat/chat.scss
@@ -43,6 +43,10 @@ img {
   align-items: center;
 }
 
+.contents {
+  display: contents;
+}
+
 // .file-skeleton {
 //   position: relative;
 

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -355,7 +355,7 @@ export class ChChat {
       this.#cellHasToReserveSpace.add(lastCell.id);
     }
 
-    this.callbacks?.sendChatToLLM(this.items);
+    this.callbacks?.sendChatMessages(this.items);
   };
 
   #sendMessage = async () => {

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -17,7 +17,7 @@ import type {
 } from "../../components";
 import type { ThemeModel } from "../theme/theme-types";
 import type {
-  ChatFiles,
+  ChatMessageFiles,
   ChatInternalCallbacks,
   ChatMessage,
   ChatMessageAssistant,
@@ -33,7 +33,11 @@ import type { ChatTranslations } from "./translations";
 import type { ChMimeType } from "../../common/mimeTypes/mime-types";
 import { adoptCommonThemes } from "../../common/theme";
 import { tokenMap } from "../../common/utils";
-import { getMessageContent, getMessageFiles } from "./utils";
+import {
+  DEFAULT_ASSISTANT_STATUS,
+  getMessageContent,
+  getMessageFiles
+} from "./utils";
 import { renderContentBySections } from "./renders/renders";
 
 const ENTER_KEY = "Enter";
@@ -205,7 +209,7 @@ export class ChChat {
   @Prop() readonly translations: ChatTranslations = {
     accessibleName: {
       clearChat: "Clear chat",
-      copyResponseButton: "Copy assistant response",
+      copyMessageContent: "Copy message content",
       downloadCodeButton: "Download code",
       sendButton: "Send",
       sendInput: "Message",
@@ -215,10 +219,11 @@ export class ChChat {
       sendInput: "Ask me a question..."
     },
     text: {
-      stopGeneratingAnswerButton: "Stop generating answer",
       copyCodeButton: "Copy code",
+      copyMessageContent: "Copy",
       processing: `Processing...`,
-      sourceFiles: "Source files:"
+      sourceFiles: "Source files:",
+      stopGeneratingAnswerButton: "Stop generating answer"
     }
   };
 
@@ -336,7 +341,7 @@ export class ChChat {
         getMessageContent(messageInIndex) + getMessageContent(message);
 
       // Temporal store for the new message files
-      const newMessageFiles: ChatFiles = getMessageFiles(messageInIndex);
+      const newMessageFiles: ChatMessageFiles = getMessageFiles(messageInIndex);
       newMessageFiles.push(...getMessageFiles(message));
 
       // Update the message object, since the current message could not be an
@@ -411,7 +416,7 @@ export class ChChat {
       );
     }
 
-    const chatFiles: ChatFiles = [];
+    const chatFiles: ChatMessageFiles = [];
     userMessageToAdd.content = {
       message: sendInputValue,
       files: chatFiles
@@ -608,7 +613,8 @@ export class ChChat {
     const parts = tokenMap({
       [`message ${message.role} ${message.id}`]: true,
       [message.parts]: !!message.parts,
-      [(message as ChatMessageByRole<"assistant">).status]: isAssistantMessage
+      [(message as ChatMessageByRole<"assistant">).status ??
+      DEFAULT_ASSISTANT_STATUS]: isAssistantMessage
     });
 
     const renderedContent = this.#getMessageRenderedContent(message);

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -91,11 +91,6 @@ export class ChChat {
    */
   @Prop() readonly generatingResponse?: boolean = false;
 
-  /**
-   * Specifies if the chat is used in a mobile device.
-   */
-  @Prop() readonly isMobile?: boolean = false;
-
   // TODO: Add support for undefined messages.
   /**
    * Specifies the items that the chat will display.

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -223,11 +223,12 @@ export class ChChat {
   };
 
   /**
-   * Fired when a new user message is added in the chat by an user interaction.
+   * Fired when a new user message is added in the chat via user interaction.
    *
-   * This callback is useful for cleaning up the files for any custom render of
-   * the files or even blocking user interactions before the sendChatMessages
-   * callback is executed.
+   * Since developers can define their own render for file attachment, this
+   * event serves to synchronize the cleanup of the `send-input` with the
+   * cleanup of the custom file attachment, or or even blocking user
+   * interactions before the `sendChatMessages` callback is executed.
    */
   @Event() userMessageAdded: EventEmitter<ChatMessageByRole<"user">>;
 
@@ -452,10 +453,6 @@ export class ChChat {
             this.#sendChat();
           }
         });
-    }
-
-    if (callbacks.clearChatMessageFiles) {
-      callbacks.clearChatMessageFiles();
     }
   };
 

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -593,7 +593,7 @@ export class ChChat {
     const isAssistantMessage = message.role === "assistant";
 
     const parts = tokenMap({
-      [`cell message ${message.role}`]: true,
+      [`cell message ${message.role} ${message.id}`]: true,
       [message.parts]: !!message.parts,
       [(message as ChatMessageByRole<"assistant">).status]: isAssistantMessage
     });

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -1,6 +1,8 @@
 import {
   Component,
   Element,
+  Event,
+  EventEmitter,
   Host,
   Method,
   Prop,
@@ -219,6 +221,15 @@ export class ChChat {
       sourceFiles: "Source files:"
     }
   };
+
+  /**
+   * Fired when a new user message is added in the chat by an user interaction.
+   *
+   * This callback is useful for cleaning up the files for any custom render of
+   * the files or even blocking user interactions before the sendChatMessages
+   * callback is executed.
+   */
+  @Event() userMessageAdded: EventEmitter<ChatMessageByRole<"user">>;
 
   /**
    * Add a new message at the end of the record, performing a re-render.

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -18,7 +18,7 @@ import type {
 import type { ThemeModel } from "../theme/theme-types";
 import type {
   ChatMessageFiles,
-  ChatInternalCallbacks,
+  ChatCallbacks,
   ChatMessage,
   ChatMessageAssistant,
   ChatMessageByRole,
@@ -98,7 +98,7 @@ export class ChChat {
   /**
    * Specifies the callbacks required in the control.
    */
-  @Prop() readonly callbacks?: ChatInternalCallbacks | undefined;
+  @Prop() readonly callbacks?: ChatCallbacks | undefined;
 
   /**
    * Specifies if all interactions are disabled

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -181,8 +181,6 @@ export class ChChat {
       clearChat: "Clear chat",
       copyResponseButton: "Copy assistant response",
       downloadCodeButton: "Download code",
-      imagePicker: "Select images",
-      removeUploadedImage: "Remove uploaded image",
       sendButton: "Send",
       sendInput: "Message",
       stopGeneratingAnswerButton: "Stop generating answer"

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -606,7 +606,7 @@ export class ChChat {
     const isAssistantMessage = message.role === "assistant";
 
     const parts = tokenMap({
-      [`cell message ${message.role} ${message.id}`]: true,
+      [`message ${message.role} ${message.id}`]: true,
       [message.parts]: !!message.parts,
       [(message as ChatMessageByRole<"assistant">).status]: isAssistantMessage
     });

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -92,13 +92,6 @@ export class ChChat {
   @Prop() readonly generatingResponse?: boolean = false;
 
   /**
-   * Specifies an object containing an HTMLAnchorElement reference. Use this
-   * property to render a button to download the code when displaying a code
-   * block.
-   */
-  @Prop() readonly hyperlinkToDownloadFile?: { anchor: HTMLAnchorElement };
-
-  /**
    * Specifies if the chat is used in a mobile device.
    */
   @Prop() readonly isMobile?: boolean = false;

--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -319,6 +319,7 @@ export class ChChat {
     this.items[messageIndex] = Object.assign({ id: messageId }, message);
   };
 
+  // TODO: This should be a property
   #sendMessageKeyboard = (event: KeyboardEvent) => {
     if (event.key !== ENTER_KEY || event.shiftKey) {
       return;
@@ -556,8 +557,7 @@ export class ChChat {
         {this.theme && <ch-theme model={this.theme}></ch-theme>}
 
         {this.loadingState === "initial" ? (
-          // TODO: Improve this slot name
-          <div class="loading-chat" slot="empty-chat"></div>
+          <slot name="loading-chat"></slot>
         ) : (
           this.#renderChatOrEmpty()
         )}

--- a/src/components/chat/default-chat-render.tsx
+++ b/src/components/chat/default-chat-render.tsx
@@ -1,9 +1,5 @@
 import { h } from "@stencil/core";
-import {
-  ChatAssistantContentFiles,
-  ChatContentImage,
-  ChatMessageByRole
-} from "./types";
+import { ChatContentFiles, ChatContentImage, ChatMessageByRole } from "./types";
 import { ChatTranslations } from "./translations";
 import { copyToTheClipboard } from "../../common/utils";
 import {
@@ -131,8 +127,7 @@ const renderDefaultAssistantMessage = (
       ? messageModel.content
       : messageModel.content.message;
 
-  const files =
-    (messageModel.content as ChatAssistantContentFiles).files ?? null;
+  const files = (messageModel.content as ChatContentFiles).files ?? null;
 
   const translations = chatRef.translations;
 

--- a/src/components/chat/default-chat-render.tsx
+++ b/src/components/chat/default-chat-render.tsx
@@ -1,5 +1,5 @@
 import { h } from "@stencil/core";
-import { ChatContentFiles, ChatContentImage, ChatMessageByRole } from "./types";
+import { ChatContentFiles, ChatMessageByRole } from "./types";
 import { ChatTranslations } from "./translations";
 import { copyToTheClipboard } from "../../common/utils";
 import {
@@ -56,18 +56,18 @@ const defaultCodeRender =
             part="code-block__header-actions"
           >
             <button
-              aria-label={
-                chatRef.isMobile ? translations.text.copyCodeButton : undefined
-              }
+              // aria-label={
+              //   chatRef.isMobile ? translations.text.copyCodeButton : undefined
+              // }
               class="code-block__copy-code-button"
               part="code-block__copy-code-button"
               type="button"
               onClick={copy(options.plainText)}
             >
-              {!chatRef.isMobile && translations.text.copyCodeButton}
+              {translations.text.copyCodeButton}
             </button>
 
-            {chatRef.hyperlinkToDownloadFile && (
+            {/* {chatRef.hyperlinkToDownloadFile && (
               <button
                 aria-label={translations.accessibleName.downloadCodeButton}
                 title={translations.accessibleName.downloadCodeButton}
@@ -75,7 +75,7 @@ const defaultCodeRender =
                 part="code-block__download-code-button"
                 onClick={downloadCode(options, chatRef.hyperlinkToDownloadFile)}
               ></button>
-            )}
+            )} */}
           </div>
         </div>
 
@@ -98,7 +98,7 @@ const renderUserMessage = (userMessage: ChatMessageByRole<"user">) => {
         {userMessage.content[0].text}
       </span>
 
-      {(userMessage.content.slice(1) as ChatContentImage[]).map(
+      {/* {(userMessage.content.slice(1) as ChatContentImage[]).map(
         imageContent => (
           <img
             aria-hidden="true"
@@ -113,7 +113,7 @@ const renderUserMessage = (userMessage: ChatMessageByRole<"user">) => {
             loading="lazy"
           ></img>
         )
-      )}
+      )} */}
     </div>
   );
 };
@@ -193,7 +193,8 @@ const renderErrorMessage = (
       chatRef.renderCode ?? defaultCodeRender(chatRef, chatRef.translations)
     }
     theme={chatRef.markdownTheme}
-    value={messageModel.content}
+    // TODO: Fix this
+    value={messageModel.content as string}
   ></ch-markdown-viewer>
 );
 

--- a/src/components/chat/default-chat-render.tsx
+++ b/src/components/chat/default-chat-render.tsx
@@ -1,211 +1,46 @@
-import { h } from "@stencil/core";
-import { ChatContentFiles, ChatMessageByRole } from "./types";
-import { ChatTranslations } from "./translations";
-import { copyToTheClipboard } from "../../common/utils";
-import {
-  MarkdownViewerCodeRender,
-  MarkdownViewerCodeRenderOptions
-} from "../markdown-viewer/parsers/types";
+// import { h } from "@stencil/core";
+// import type {
+//   ChatContentFiles,
+//   ChatMessageByRole,
+//   ChatMessageRenderBySections
+// } from "./types";
+// import type { ChatTranslations } from "./translations";
+// import { copyToTheClipboard } from "../../common/utils";
+// import type {
+//   MarkdownViewerCodeRender,
+//   MarkdownViewerCodeRenderOptions
+// } from "../markdown-viewer/parsers/types";
 
-const copy = (text: string) => () => copyToTheClipboard(text);
+// const downloadCode =
+//   (
+//     options: MarkdownViewerCodeRenderOptions,
+//     hyperlinkRef: { anchor: HTMLAnchorElement }
+//   ) =>
+//   () => {
+//     // Create the blob variable on the click event
+//     const blob = new Blob([options.plainText], { type: "text/plain" });
 
-const getAriaBusyValue = (
-  status?: "complete" | "waiting" | "streaming" | undefined
-): "true" | "false" =>
-  status === "complete" || status === undefined ? "false" : "true";
+//     // Create blob object
+//     const url = window.URL.createObjectURL(blob);
 
-const getAssistantParts = (
-  status?: "complete" | "waiting" | "streaming" | undefined
-) => (status ? `assistant-content ${status}` : "assistant-content");
+//     hyperlinkRef.anchor.href = url;
+//     hyperlinkRef.anchor.download = "Answer.txt";
+//     hyperlinkRef.anchor.click(); // Download the blob
 
-const downloadCode =
-  (
-    options: MarkdownViewerCodeRenderOptions,
-    hyperlinkRef: { anchor: HTMLAnchorElement }
-  ) =>
-  () => {
-    // Create the blob variable on the click event
-    const blob = new Blob([options.plainText], { type: "text/plain" });
+//     // Remove the blob object to free the memory
+//     setTimeout(() => {
+//       window.URL.revokeObjectURL(url);
+//     });
+//   };
 
-    // Create blob object
-    const url = window.URL.createObjectURL(blob);
+// export const defaultChatRender =
+//   (chatRef: HTMLChChatElement) =>
+//   (messageModel: ChatMessageByRole<"assistant" | "error" | "user">) => {
+//     if (messageModel.role === "assistant") {
+//       return renderDefaultAssistantMessage(chatRef, messageModel);
+//     }
 
-    hyperlinkRef.anchor.href = url;
-    hyperlinkRef.anchor.download = "Answer.txt";
-    hyperlinkRef.anchor.click(); // Download the blob
-
-    // Remove the blob object to free the memory
-    setTimeout(() => {
-      window.URL.revokeObjectURL(url);
-    });
-  };
-
-const defaultCodeRender =
-  (
-    chatRef: HTMLChChatElement,
-    translations: ChatTranslations
-  ): MarkdownViewerCodeRender =>
-  (options: MarkdownViewerCodeRenderOptions): any =>
-    (
-      <div>
-        <div class="code-block__header" part="code-block__header">
-          {options.language}
-
-          <div
-            class="code-block__header-actions"
-            part="code-block__header-actions"
-          >
-            <button
-              // aria-label={
-              //   chatRef.isMobile ? translations.text.copyCodeButton : undefined
-              // }
-              class="code-block__copy-code-button"
-              part="code-block__copy-code-button"
-              type="button"
-              onClick={copy(options.plainText)}
-            >
-              {translations.text.copyCodeButton}
-            </button>
-
-            {/* {chatRef.hyperlinkToDownloadFile && (
-              <button
-                aria-label={translations.accessibleName.downloadCodeButton}
-                title={translations.accessibleName.downloadCodeButton}
-                class="code-block__download-code-button"
-                part="code-block__download-code-button"
-                onClick={downloadCode(options, chatRef.hyperlinkToDownloadFile)}
-              ></button>
-            )} */}
-          </div>
-        </div>
-
-        <ch-code
-          class="code-block__content"
-          language={options.language}
-          lastNestedChildClass={options.lastNestedChildClass}
-          showIndicator={options.showIndicator}
-          value={options.plainText}
-        ></ch-code>
-      </div>
-    );
-
-const renderUserMessage = (userMessage: ChatMessageByRole<"user">) => {
-  return typeof userMessage.content === "string" ? (
-    userMessage.content
-  ) : (
-    <div class="message-with-images" part="message-with-images">
-      <span part="message-with-images__text">
-        {userMessage.content[0].text}
-      </span>
-
-      {/* {(userMessage.content.slice(1) as ChatContentImage[]).map(
-        imageContent => (
-          <img
-            aria-hidden="true"
-            class={!imageContent.image_url.url ? "file-skeleton" : undefined}
-            part={
-              imageContent.image_url.url
-                ? "message-with-images__image"
-                : "message-with-images__image file-skeleton"
-            }
-            src={imageContent.image_url.url}
-            alt=""
-            loading="lazy"
-          ></img>
-        )
-      )} */}
-    </div>
-  );
-};
-
-const renderDefaultAssistantMessage = (
-  chatRef: HTMLChChatElement,
-  messageModel: ChatMessageByRole<"assistant">
-) => {
-  const messageContent =
-    typeof messageModel.content === "string"
-      ? messageModel.content
-      : messageModel.content.message;
-
-  const files = (messageModel.content as ChatContentFiles).files ?? null;
-
-  const translations = chatRef.translations;
-
-  return (
-    <div
-      // Improve accessibility by announcing live changes
-      aria-live="polite"
-      // Wait until all changes are made to prevents assistive
-      // technologies from announcing changes before updates are done
-      aria-busy={getAriaBusyValue(messageModel.status)}
-      class="assistant-content"
-      part={getAssistantParts(messageModel.status)}
-    >
-      {messageModel.status === "waiting" ? (
-        <div class="assistant-loading" part="assistant-loading">
-          {/* {spinner()} */}
-          {messageContent}
-        </div>
-      ) : (
-        [
-          <ch-markdown-viewer
-            renderCode={
-              chatRef.renderCode ?? defaultCodeRender(chatRef, translations)
-            }
-            showIndicator={messageModel.status === "streaming"}
-            theme={chatRef.markdownTheme}
-            value={messageContent}
-          ></ch-markdown-viewer>,
-
-          files && (
-            <div class="assistant-files" part="assistant-files">
-              {translations.text.sourceFiles}
-
-              {files.map(file => (
-                <a href={file.url} target="_blank" part="assistant-file">
-                  {file.caption}
-                </a>
-              ))}
-            </div>
-          )
-        ]
-      )}
-
-      {(messageModel.status === "complete" || !messageModel.status) && (
-        <button
-          aria-label={translations.accessibleName.copyResponseButton}
-          title={translations.accessibleName.copyResponseButton}
-          part="copy-response-button"
-          type="button"
-          onClick={copy(messageContent)}
-        ></button>
-      )}
-    </div>
-  );
-};
-
-const renderErrorMessage = (
-  chatRef: HTMLChChatElement,
-  messageModel: ChatMessageByRole<"error">
-) => (
-  <ch-markdown-viewer
-    renderCode={
-      chatRef.renderCode ?? defaultCodeRender(chatRef, chatRef.translations)
-    }
-    theme={chatRef.markdownTheme}
-    // TODO: Fix this
-    value={messageModel.content as string}
-  ></ch-markdown-viewer>
-);
-
-export const defaultChatRender =
-  (chatRef: HTMLChChatElement) =>
-  (messageModel: ChatMessageByRole<"assistant" | "error" | "user">) => {
-    if (messageModel.role === "assistant") {
-      return renderDefaultAssistantMessage(chatRef, messageModel);
-    }
-
-    return messageModel.role === "user"
-      ? renderUserMessage(messageModel)
-      : renderErrorMessage(chatRef, messageModel);
-  };
+//     return messageModel.role === "user"
+//       ? renderUserMessage(messageModel)
+//       : renderErrorMessage(chatRef, messageModel);
+//   };

--- a/src/components/chat/renders/actions.tsx
+++ b/src/components/chat/renders/actions.tsx
@@ -1,0 +1,29 @@
+import { h } from "@stencil/core";
+import type { ChatActionsRender, ChatMessage } from "../types";
+import { tokenMap } from "../../../common/utils";
+import { copy, getMessageSerializedContentAll } from "../utils";
+
+export const defaultActionsRender: ChatActionsRender = (
+  message: ChatMessage,
+  chatRef: HTMLChChatElement
+): any => {
+  const { accessibleName, text } = chatRef.translations;
+
+  return (
+    message.role === "assistant" &&
+    (message.status === "complete" || !message.status) && (
+      <button
+        aria-label={accessibleName.copyMessageContent}
+        part={tokenMap({
+          [`assistant copy-message-content ${message.id}`]: true,
+          [message.parts]: !!message.parts
+        })}
+        type="button"
+        // We use the whole message to support copying the files and/or sources
+        onClick={copy(getMessageSerializedContentAll(message))}
+      >
+        {text.copyMessageContent}
+      </button>
+    )
+  );
+};

--- a/src/components/chat/renders/actions.tsx
+++ b/src/components/chat/renders/actions.tsx
@@ -13,6 +13,7 @@ export const defaultActionsRender: ChatActionsRender = (
     message.role === "assistant" &&
     (message.status === "complete" || !message.status) && (
       <button
+        // TODO: Don't set aria-label if it equals to the caption
         aria-label={accessibleName.copyMessageContent}
         part={tokenMap({
           [`assistant copy-message-content ${message.id}`]: true,

--- a/src/components/chat/renders/code-block.tsx
+++ b/src/components/chat/renders/code-block.tsx
@@ -19,18 +19,12 @@ export const defaultCodeBlockRender: ChatCodeBlockRender =
 
     return (
       <div part="code-block">
-        <div class="code-block__header" part="code-block__header">
-          {options.language}
+        <div part="code-block__header">
+          <span part="code-block__header-caption">{options.language}</span>
 
-          <div
-            class="code-block__header-actions"
-            part="code-block__header-actions"
-          >
+          <div part="code-block__header-actions">
             <button
-              // aria-label={
-              //   chatRef.isMobile ? translations.text.copyCodeButton : undefined
-              // }
-              class="code-block__copy-code-button"
+              aria-label={text.copyCodeButton}
               part="code-block__copy-code-button"
               type="button"
               onClick={copy(options.plainText)}
@@ -58,9 +52,9 @@ export const defaultCodeBlockRender: ChatCodeBlockRender =
         </div>
 
         <ch-code
-          class="code-block__content"
           language={options.language}
           lastNestedChildClass={options.lastNestedChildClass}
+          part="code-block__content"
           showIndicator={options.showIndicator}
           value={options.plainText}
         ></ch-code>

--- a/src/components/chat/renders/code-block.tsx
+++ b/src/components/chat/renders/code-block.tsx
@@ -1,12 +1,23 @@
 import { h } from "@stencil/core";
 import type { MarkdownViewerCodeRenderOptions } from "../../markdown-viewer/parsers/types";
-import type { ChatCodeBlockRender } from "../types";
+import type { ChatCodeBlockRender, ChatInternalCallbacks } from "../types";
 import { copy } from "../utils";
+
+const downloadCodeBlockCallback =
+  (
+    plainText: string,
+    language: string,
+    downloadCodeBlock: ChatInternalCallbacks["downloadCodeBlock"]
+  ) =>
+  () =>
+    downloadCodeBlock(plainText, language);
 
 export const defaultCodeBlockRender: ChatCodeBlockRender =
   (chatRef: HTMLChChatElement) =>
-  (options: MarkdownViewerCodeRenderOptions): any =>
-    (
+  (options: MarkdownViewerCodeRenderOptions): any => {
+    const { accessibleName, text } = chatRef.translations;
+
+    return (
       <div part="code-block">
         <div class="code-block__header" part="code-block__header">
           {options.language}
@@ -24,18 +35,25 @@ export const defaultCodeBlockRender: ChatCodeBlockRender =
               type="button"
               onClick={copy(options.plainText)}
             >
-              {chatRef.translations.text.copyCodeButton}
+              {text.copyCodeButton}
             </button>
 
-            {/* {chatRef.hyperlinkToDownloadFile && (
+            {chatRef.callbacks?.downloadCodeBlock && (
               <button
-                aria-label={translations.accessibleName.downloadCodeButton}
-                title={translations.accessibleName.downloadCodeButton}
-                class="code-block__download-code-button"
+                // TODO: Don't set aria-label if it equals to the caption
+                aria-label={accessibleName.downloadCodeButton}
+                // title={accessibleName.downloadCodeButton}
+                // class="code-block__download-code-button"
                 part="code-block__download-code-button"
-                onClick={downloadCode(options, chatRef.hyperlinkToDownloadFile)}
-              ></button>
-            )} */}
+                onClick={downloadCodeBlockCallback(
+                  options.plainText,
+                  options.language,
+                  chatRef.callbacks.downloadCodeBlock
+                )}
+              >
+                {text.downloadCodeButton}
+              </button>
+            )}
           </div>
         </div>
 
@@ -48,3 +66,4 @@ export const defaultCodeBlockRender: ChatCodeBlockRender =
         ></ch-code>
       </div>
     );
+  };

--- a/src/components/chat/renders/code-block.tsx
+++ b/src/components/chat/renders/code-block.tsx
@@ -1,13 +1,13 @@
 import { h } from "@stencil/core";
 import type { MarkdownViewerCodeRenderOptions } from "../../markdown-viewer/parsers/types";
-import type { ChatCodeBlockRender, ChatInternalCallbacks } from "../types";
+import type { ChatCodeBlockRender, ChatCallbacks } from "../types";
 import { copy } from "../utils";
 
 const downloadCodeBlockCallback =
   (
     plainText: string,
     language: string,
-    downloadCodeBlock: ChatInternalCallbacks["downloadCodeBlock"]
+    downloadCodeBlock: ChatCallbacks["downloadCodeBlock"]
   ) =>
   () =>
     downloadCodeBlock(plainText, language);

--- a/src/components/chat/renders/code-block.tsx
+++ b/src/components/chat/renders/code-block.tsx
@@ -1,0 +1,54 @@
+import { h } from "@stencil/core";
+import { copyToTheClipboard } from "../../../common/utils";
+import type {
+  MarkdownViewerCodeRender,
+  MarkdownViewerCodeRenderOptions
+} from "../../markdown-viewer/parsers/types";
+
+const copy = (text: string) => () => copyToTheClipboard(text);
+
+export const defaultCodeBlockRender =
+  (chatRef: HTMLChChatElement): MarkdownViewerCodeRender =>
+  (options: MarkdownViewerCodeRenderOptions): any =>
+    (
+      <div part="code-block">
+        <div class="code-block__header" part="code-block__header">
+          {options.language}
+
+          <div
+            class="code-block__header-actions"
+            part="code-block__header-actions"
+          >
+            <button
+              // aria-label={
+              //   chatRef.isMobile ? translations.text.copyCodeButton : undefined
+              // }
+              class="code-block__copy-code-button"
+              part="code-block__copy-code-button"
+              type="button"
+              onClick={copy(options.plainText)}
+            >
+              {chatRef.translations.text.copyCodeButton}
+            </button>
+
+            {/* {chatRef.hyperlinkToDownloadFile && (
+              <button
+                aria-label={translations.accessibleName.downloadCodeButton}
+                title={translations.accessibleName.downloadCodeButton}
+                class="code-block__download-code-button"
+                part="code-block__download-code-button"
+                onClick={downloadCode(options, chatRef.hyperlinkToDownloadFile)}
+              ></button>
+            )} */}
+          </div>
+        </div>
+
+        <ch-code
+          class="code-block__content"
+          language={options.language}
+          lastNestedChildClass={options.lastNestedChildClass}
+          showIndicator={options.showIndicator}
+          value={options.plainText}
+        ></ch-code>
+      </div>
+    );

--- a/src/components/chat/renders/code-block.tsx
+++ b/src/components/chat/renders/code-block.tsx
@@ -1,14 +1,12 @@
 import { h } from "@stencil/core";
 import { copyToTheClipboard } from "../../../common/utils";
-import type {
-  MarkdownViewerCodeRender,
-  MarkdownViewerCodeRenderOptions
-} from "../../markdown-viewer/parsers/types";
+import type { MarkdownViewerCodeRenderOptions } from "../../markdown-viewer/parsers/types";
+import type { ChatCodeBlockRender } from "../types";
 
 const copy = (text: string) => () => copyToTheClipboard(text);
 
-export const defaultCodeBlockRender =
-  (chatRef: HTMLChChatElement): MarkdownViewerCodeRender =>
+export const defaultCodeBlockRender: ChatCodeBlockRender =
+  (chatRef: HTMLChChatElement) =>
   (options: MarkdownViewerCodeRenderOptions): any =>
     (
       <div part="code-block">

--- a/src/components/chat/renders/code-block.tsx
+++ b/src/components/chat/renders/code-block.tsx
@@ -1,9 +1,7 @@
 import { h } from "@stencil/core";
-import { copyToTheClipboard } from "../../../common/utils";
 import type { MarkdownViewerCodeRenderOptions } from "../../markdown-viewer/parsers/types";
 import type { ChatCodeBlockRender } from "../types";
-
-const copy = (text: string) => () => copyToTheClipboard(text);
+import { copy } from "../utils";
 
 export const defaultCodeBlockRender: ChatCodeBlockRender =
   (chatRef: HTMLChChatElement) =>

--- a/src/components/chat/renders/content.tsx
+++ b/src/components/chat/renders/content.tsx
@@ -1,0 +1,146 @@
+import { h } from "@stencil/core";
+import type {
+  ChatCodeBlockRender,
+  ChatContentRender,
+  ChatMessage,
+  ChatMessageByRole,
+  ChatMessageRole
+} from "../types";
+import { DEFAULT_ASSISTANT_STATUS, getMessageContent } from "../utils";
+import { tokenMap } from "../../../common/utils";
+
+// const renderDefaultAssistantMessage = (
+//   chatRef: HTMLChChatElement,
+//   messageModel: ChatMessageByRole<"assistant">
+// ) => {
+//   const messageContent = getMessageContent(messageModel);
+
+//   const translations = chatRef.translations;
+
+//   return (
+//     <div
+//       // Improve accessibility by announcing live changes
+//       aria-live="polite"
+//       // Wait until all changes are made to prevents assistive
+//       // technologies from announcing changes before updates are done
+//       aria-busy={getAriaBusyValue(messageModel.status)}
+//       class="assistant-content"
+//       part={getAssistantParts(messageModel.status)}
+//     >
+//       {messageModel.status === "waiting" ? (
+//         <div class="assistant-loading" part="assistant-loading">
+//           {/* {spinner()} */}
+//           {messageContent}
+//         </div>
+//       ) : (
+//         [
+//           <ch-markdown-viewer
+//             renderCode={
+//               chatRef.renderCode ?? defaultCodeRender(chatRef, translations)
+//             }
+//             showIndicator={messageModel.status === "streaming"}
+//             theme={chatRef.markdownTheme}
+//             value={messageContent}
+//           ></ch-markdown-viewer>,
+
+//           files && (
+//             <div class="assistant-files" part="assistant-files">
+//               {translations.text.sourceFiles}
+
+//               {files.map(file => (
+//                 <a href={file.url} target="_blank" part="assistant-file">
+//                   {file.caption}
+//                 </a>
+//               ))}
+//             </div>
+//           )
+//         ]
+//       )}
+
+//       {/* {(messageModel.status === "complete" || !messageModel.status) && (
+//         <button
+//           aria-label={translations.accessibleName.copyResponseButton}
+//           title={translations.accessibleName.copyResponseButton}
+//           part="copy-response-button"
+//           type="button"
+//           onClick={copy(messageContent)}
+//         ></button>
+//       )} */}
+//     </div>
+//   );
+// };
+
+const defaultAssistantContentRender: ChatContentRender = (
+  messageModel: ChatMessageByRole<"assistant">,
+  chatRef: HTMLChChatElement,
+  codeBlockRender: ChatCodeBlockRender
+) => {
+  const messageContent = getMessageContent(messageModel);
+
+  return messageModel.status === "waiting" ? (
+    <div
+      class="assistant-loading"
+      part={tokenMap({
+        "assistant content waiting": true,
+        [messageModel.parts]: !!messageModel.parts
+      })}
+    >
+      {/* {spinner()} */}
+      {messageContent}
+    </div>
+  ) : (
+    messageContent && (
+      <ch-markdown-viewer
+        part={tokenMap({
+          [`assistant content ${
+            messageModel.status ?? DEFAULT_ASSISTANT_STATUS
+          }`]: true,
+          [messageModel.parts]: !!messageModel.parts
+        })}
+        // TODO: Fix the way to optimize this re-render
+        renderCode={codeBlockRender(chatRef)}
+        showIndicator={messageModel.status === "streaming"}
+        theme={chatRef.markdownTheme}
+        value={messageContent}
+      ></ch-markdown-viewer>
+    )
+  );
+};
+
+const defaultErrorContentRender: ChatContentRender = (
+  messageModel: ChatMessageByRole<"error">,
+  chatRef: HTMLChChatElement,
+  codeBlockRender
+) => {
+  const errorContent = getMessageContent(messageModel);
+
+  return (
+    errorContent && (
+      <ch-markdown-viewer
+        part="error content"
+        renderCode={codeBlockRender(chatRef)}
+        theme={chatRef.markdownTheme}
+        value={errorContent}
+      ></ch-markdown-viewer>
+    )
+  );
+};
+
+const defaultUserContentRender: ChatContentRender = (
+  messageModel: ChatMessageByRole<"error">
+) => getMessageContent(messageModel);
+
+const defaultSystemContentRender: ChatContentRender = () => null;
+
+const contentRenderByRole = {
+  assistant: defaultAssistantContentRender,
+  error: defaultErrorContentRender,
+  system: defaultSystemContentRender,
+  user: defaultUserContentRender
+} as const satisfies { [key in ChatMessageRole]: ChatContentRender };
+
+export const defaultContentRender: ChatContentRender = (
+  message: ChatMessage,
+  chatRef: HTMLChChatElement,
+  codeBlockRender: ChatCodeBlockRender
+) => contentRenderByRole[message.role](message, chatRef, codeBlockRender);

--- a/src/components/chat/renders/content.tsx
+++ b/src/components/chat/renders/content.tsx
@@ -9,67 +9,6 @@ import type {
 import { DEFAULT_ASSISTANT_STATUS, getMessageContent } from "../utils";
 import { tokenMap } from "../../../common/utils";
 
-// const renderDefaultAssistantMessage = (
-//   chatRef: HTMLChChatElement,
-//   messageModel: ChatMessageByRole<"assistant">
-// ) => {
-//   const messageContent = getMessageContent(messageModel);
-
-//   const translations = chatRef.translations;
-
-//   return (
-//     <div
-//       // Improve accessibility by announcing live changes
-//       aria-live="polite"
-//       // Wait until all changes are made to prevents assistive
-//       // technologies from announcing changes before updates are done
-//       aria-busy={getAriaBusyValue(messageModel.status)}
-//       class="assistant-content"
-//       part={getAssistantParts(messageModel.status)}
-//     >
-//       {messageModel.status === "waiting" ? (
-//         <div class="assistant-loading" part="assistant-loading">
-//           {/* {spinner()} */}
-//           {messageContent}
-//         </div>
-//       ) : (
-//         [
-//           <ch-markdown-viewer
-//             renderCode={
-//               chatRef.renderCode ?? defaultCodeRender(chatRef, translations)
-//             }
-//             showIndicator={messageModel.status === "streaming"}
-//             theme={chatRef.markdownTheme}
-//             value={messageContent}
-//           ></ch-markdown-viewer>,
-
-//           files && (
-//             <div class="assistant-files" part="assistant-files">
-//               {translations.text.sourceFiles}
-
-//               {files.map(file => (
-//                 <a href={file.url} target="_blank" part="assistant-file">
-//                   {file.caption}
-//                 </a>
-//               ))}
-//             </div>
-//           )
-//         ]
-//       )}
-
-//       {/* {(messageModel.status === "complete" || !messageModel.status) && (
-//         <button
-//           aria-label={translations.accessibleName.copyResponseButton}
-//           title={translations.accessibleName.copyResponseButton}
-//           part="copy-response-button"
-//           type="button"
-//           onClick={copy(messageContent)}
-//         ></button>
-//       )} */}
-//     </div>
-//   );
-// };
-
 const defaultAssistantContentRender: ChatContentRender = (
   message: ChatMessageByRole<"assistant">,
   chatRef: HTMLChChatElement,

--- a/src/components/chat/renders/content.tsx
+++ b/src/components/chat/renders/content.tsx
@@ -71,18 +71,18 @@ import { tokenMap } from "../../../common/utils";
 // };
 
 const defaultAssistantContentRender: ChatContentRender = (
-  messageModel: ChatMessageByRole<"assistant">,
+  message: ChatMessageByRole<"assistant">,
   chatRef: HTMLChChatElement,
   codeBlockRender: ChatCodeBlockRender
 ) => {
-  const messageContent = getMessageContent(messageModel);
+  const messageContent = getMessageContent(message);
 
-  return messageModel.status === "waiting" ? (
+  return message.status === "waiting" ? (
     <div
       class="assistant-loading"
       part={tokenMap({
-        "assistant content waiting": true,
-        [messageModel.parts]: !!messageModel.parts
+        [`assistant content waiting ${message.id}`]: true,
+        [message.parts]: !!message.parts
       })}
     >
       {/* {spinner()} */}
@@ -92,14 +92,14 @@ const defaultAssistantContentRender: ChatContentRender = (
     messageContent && (
       <ch-markdown-viewer
         part={tokenMap({
-          [`assistant content ${
-            messageModel.status ?? DEFAULT_ASSISTANT_STATUS
+          [`assistant content ${message.id} ${
+            message.status ?? DEFAULT_ASSISTANT_STATUS
           }`]: true,
-          [messageModel.parts]: !!messageModel.parts
+          [message.parts]: !!message.parts
         })}
         // TODO: Fix the way to optimize this re-render
         renderCode={codeBlockRender(chatRef)}
-        showIndicator={messageModel.status === "streaming"}
+        showIndicator={message.status === "streaming"}
         theme={chatRef.markdownTheme}
         value={messageContent}
       ></ch-markdown-viewer>
@@ -108,16 +108,19 @@ const defaultAssistantContentRender: ChatContentRender = (
 };
 
 const defaultErrorContentRender: ChatContentRender = (
-  messageModel: ChatMessageByRole<"error">,
+  message: ChatMessageByRole<"error">,
   chatRef: HTMLChChatElement,
   codeBlockRender
 ) => {
-  const errorContent = getMessageContent(messageModel);
+  const errorContent = getMessageContent(message);
 
   return (
     errorContent && (
       <ch-markdown-viewer
-        part="error content"
+        part={tokenMap({
+          [`error content ${message.id}`]: true,
+          [message.parts]: !!message.parts
+        })}
         renderCode={codeBlockRender(chatRef)}
         theme={chatRef.markdownTheme}
         value={errorContent}

--- a/src/components/chat/renders/file.tsx
+++ b/src/components/chat/renders/file.tsx
@@ -55,7 +55,7 @@ const getFileParts = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
 // uploading
 export const defaultFileRender: ChatFileRender = {
   audio: (file: ChatFile) => (
-    <div part={getFileContainerParts(file, "audio")}>
+    <li class="contents" part={getFileContainerParts(file, "audio")}>
       <audio
         aria-label={file.accessibleName}
         part={getFileParts(file, "audio")}
@@ -64,10 +64,10 @@ export const defaultFileRender: ChatFileRender = {
       ></audio>
 
       {fileSkeleton(file, "audio")}
-    </div>
+    </li>
   ),
   video: (file: ChatFile) => (
-    <div part={getFileContainerParts(file, "video")}>
+    <li class="contents" part={getFileContainerParts(file, "video")}>
       <video
         aria-label={file.accessibleName}
         part={getFileParts(file, "video")}
@@ -76,11 +76,11 @@ export const defaultFileRender: ChatFileRender = {
       ></video>
 
       {fileSkeleton(file, "video")}
-    </div>
+    </li>
   ),
 
   image: (file: ChatFile) => (
-    <div part={getFileContainerParts(file, "image")}>
+    <li class="contents" part={getFileContainerParts(file, "image")}>
       <img
         aria-label={file.accessibleName}
         part={getFileParts(file, "image")}
@@ -91,14 +91,14 @@ export const defaultFileRender: ChatFileRender = {
       ></img>
 
       {fileSkeleton(file, "image")}
-    </div>
+    </li>
   ),
 
   file: (file: ChatFile) => {
     const disabledWhileUploading = file.uploadState === "in-progress";
 
     return (
-      <div part={getFileContainerParts(file, "file")}>
+      <li class="contents" part={getFileContainerParts(file, "file")}>
         <a
           aria-label={file.accessibleName}
           role={disabledWhileUploading ? "link" : undefined}
@@ -130,7 +130,7 @@ export const defaultFileRender: ChatFileRender = {
         </a>
 
         {fileSkeleton(file, "file")}
-      </div>
+      </li>
     );
   }
 };

--- a/src/components/chat/renders/file.tsx
+++ b/src/components/chat/renders/file.tsx
@@ -1,10 +1,13 @@
 import { h } from "@stencil/core";
-import type { ChatFile, ChatFileRender } from "../types";
+import type { ChatMessageFile, ChatFileRender } from "../types";
 import type { ChMimeTypeFormatMap } from "../../../common/mimeTypes/mime-types";
 import { DEFAULT_FILE_UPLOAD_STATE } from "../utils";
 import { tokenMap } from "../../../common/utils";
 
-const fileSkeleton = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
+const fileSkeleton = (
+  file: ChatMessageFile,
+  fileFormat: keyof ChMimeTypeFormatMap
+) =>
   file.uploadState === "in-progress" && (
     <div
       part={tokenMap({
@@ -31,7 +34,7 @@ const fileSkeleton = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
 //   );
 
 const getFileContainerParts = (
-  file: ChatFile,
+  file: ChatMessageFile,
   fileFormat: keyof ChMimeTypeFormatMap
 ) =>
   tokenMap({
@@ -42,7 +45,10 @@ const getFileContainerParts = (
     [file.parts]: !!file.parts
   });
 
-const getFileParts = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
+const getFileParts = (
+  file: ChatMessageFile,
+  fileFormat: keyof ChMimeTypeFormatMap
+) =>
   tokenMap({
     [`file format-${fileFormat} ${file.mimeType} ${
       file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
@@ -54,8 +60,8 @@ const getFileParts = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
 // TODO: Improve accessibility by exposing progress or spin states while
 // uploading
 export const defaultFileRender: ChatFileRender = {
-  audio: (file: ChatFile) => (
-    <li class="contents" part={getFileContainerParts(file, "audio")}>
+  audio: (file: ChatMessageFile) => (
+    <li class="file-container" part={getFileContainerParts(file, "audio")}>
       <audio
         aria-label={file.accessibleName}
         part={getFileParts(file, "audio")}
@@ -66,8 +72,8 @@ export const defaultFileRender: ChatFileRender = {
       {fileSkeleton(file, "audio")}
     </li>
   ),
-  video: (file: ChatFile) => (
-    <li class="contents" part={getFileContainerParts(file, "video")}>
+  video: (file: ChatMessageFile) => (
+    <li class="file-container" part={getFileContainerParts(file, "video")}>
       <video
         aria-label={file.accessibleName}
         part={getFileParts(file, "video")}
@@ -79,8 +85,8 @@ export const defaultFileRender: ChatFileRender = {
     </li>
   ),
 
-  image: (file: ChatFile) => (
-    <li class="contents" part={getFileContainerParts(file, "image")}>
+  image: (file: ChatMessageFile) => (
+    <li class="file-container" part={getFileContainerParts(file, "image")}>
       <img
         aria-label={file.accessibleName}
         part={getFileParts(file, "image")}
@@ -94,11 +100,11 @@ export const defaultFileRender: ChatFileRender = {
     </li>
   ),
 
-  file: (file: ChatFile) => {
+  file: (file: ChatMessageFile) => {
     const disabledWhileUploading = file.uploadState === "in-progress";
 
     return (
-      <li class="contents" part={getFileContainerParts(file, "file")}>
+      <li class="file-container" part={getFileContainerParts(file, "file")}>
         <a
           aria-label={file.accessibleName}
           role={disabledWhileUploading ? "link" : undefined}

--- a/src/components/chat/renders/file.tsx
+++ b/src/components/chat/renders/file.tsx
@@ -1,14 +1,19 @@
 import { h } from "@stencil/core";
-import type { ChatFile, ChatFilesRender } from "../types";
+import type { ChatFile, ChatFileRender } from "../types";
 import type { ChMimeTypeFormatMap } from "../../../common/mimeTypes/mime-types";
 import { DEFAULT_FILE_UPLOAD_STATE } from "../utils";
+import { tokenMap } from "../../../common/utils";
 
 const fileSkeleton = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
   file.uploadState === "in-progress" && (
     <div
-      part={`file-skeleton format-${fileFormat} ${
-        file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
-      }${file.extension ? " " + file.extension : ""}`}
+      part={tokenMap({
+        [`file-skeleton format-${fileFormat} ${file.mimeType} ${
+          file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+        }`]: true,
+        [file.extension]: !!file.extension,
+        [file.parts]: !!file.parts
+      })}
     ></div>
   );
 
@@ -29,18 +34,26 @@ const getFileContainerParts = (
   file: ChatFile,
   fileFormat: keyof ChMimeTypeFormatMap
 ) =>
-  `file-container format-${fileFormat} ${file.mimeType} ${
-    file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
-  }${file.extension ? " " + file.extension : ""}` as const;
+  tokenMap({
+    [`file-container format-${fileFormat} ${file.mimeType} ${
+      file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+    }`]: true,
+    [file.extension]: !!file.extension,
+    [file.parts]: !!file.parts
+  });
 
 const getFileParts = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
-  `file format-${fileFormat} ${file.mimeType} ${
-    file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
-  }${file.extension ? " " + file.extension : ""}` as const;
+  tokenMap({
+    [`file format-${fileFormat} ${file.mimeType} ${
+      file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+    }`]: true,
+    [file.extension]: !!file.extension,
+    [file.parts]: !!file.parts
+  });
 
 // TODO: Improve accessibility by exposing progress or spin states while
 // uploading
-export const defaultFilesRender: ChatFilesRender = {
+export const defaultFileRender: ChatFileRender = {
   audio: (file: ChatFile) => (
     <div part={getFileContainerParts(file, "audio")}>
       <audio

--- a/src/components/chat/renders/files.tsx
+++ b/src/components/chat/renders/files.tsx
@@ -29,7 +29,7 @@ const getFileContainerParts = (
   file: ChatFile,
   fileFormat: keyof ChMimeTypeFormatMap
 ) =>
-  `file format-${fileFormat} ${file.mimeType} ${
+  `file-container format-${fileFormat} ${file.mimeType} ${
     file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
   }${file.extension ? " " + file.extension : ""}` as const;
 

--- a/src/components/chat/renders/files.tsx
+++ b/src/components/chat/renders/files.tsx
@@ -1,0 +1,123 @@
+import { h } from "@stencil/core";
+import type { ChatFile, ChatFilesRender } from "../types";
+import type { ChMimeTypeFormatMap } from "../../../common/mimeTypes/mime-types";
+import { DEFAULT_FILE_UPLOAD_STATE } from "../utils";
+
+const fileSkeleton = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
+  file.uploadState === "in-progress" && (
+    <div
+      part={`file-skeleton format-${fileFormat} ${
+        file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+      }${file.extension ? " " + file.extension : ""}`}
+    ></div>
+  );
+
+// const retryFileUpload = (
+//   file: ChatFile,
+//   fileFormat: keyof ChMimeTypeFormatMap,
+//   chatRef: HTMLChChatElement
+// ) =>
+//   file.uploadState === "failed" && (
+//     <button
+//       part={`file-retry-upload format-${fileFormat} ${
+//         file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+//       }${file.extension ? " " + file.extension : ""}`}
+//     ></button>
+//   );
+
+const getFileContainerParts = (
+  file: ChatFile,
+  fileFormat: keyof ChMimeTypeFormatMap
+) =>
+  `file format-${fileFormat} ${file.mimeType} ${
+    file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+  }${file.extension ? " " + file.extension : ""}` as const;
+
+const getFileParts = (file: ChatFile, fileFormat: keyof ChMimeTypeFormatMap) =>
+  `file format-${fileFormat} ${file.mimeType} ${
+    file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+  }${file.extension ? " " + file.extension : ""}` as const;
+
+// TODO: Improve accessibility by exposing progress or spin states while
+// uploading
+export const defaultFilesRender: ChatFilesRender = {
+  audio: (file: ChatFile) => (
+    <div part={getFileContainerParts(file, "audio")}>
+      <audio
+        aria-label={file.accessibleName}
+        part={getFileParts(file, "audio")}
+        src={file.uploadState === "in-progress" ? undefined : file.url}
+        controls
+      ></audio>
+
+      {fileSkeleton(file, "audio")}
+    </div>
+  ),
+  video: (file: ChatFile) => (
+    <div part={getFileContainerParts(file, "video")}>
+      <video
+        aria-label={file.accessibleName}
+        part={getFileParts(file, "video")}
+        src={file.uploadState === "in-progress" ? undefined : file.url}
+        controls
+      ></video>
+
+      {fileSkeleton(file, "video")}
+    </div>
+  ),
+
+  image: (file: ChatFile) => (
+    <div part={getFileContainerParts(file, "image")}>
+      <img
+        aria-label={file.accessibleName}
+        part={getFileParts(file, "image")}
+        src={file.url}
+        // TODO: Should we add a default alt attr?
+        alt={file.alternativeText ?? file.accessibleName ?? ""}
+        loading="lazy"
+      ></img>
+
+      {fileSkeleton(file, "image")}
+    </div>
+  ),
+
+  file: (file: ChatFile) => {
+    const disabledWhileUploading = file.uploadState === "in-progress";
+
+    return (
+      <div part={getFileContainerParts(file, "file")}>
+        <a
+          aria-label={file.accessibleName}
+          role={disabledWhileUploading ? "link" : undefined}
+          aria-disabled={disabledWhileUploading ? "true" : undefined}
+          // class={file.url ? "file-render" : "file-render skeleton"}
+          part={getFileParts(file, "file")}
+          href={disabledWhileUploading ? undefined : file.url}
+          target="_blank"
+        >
+          {file.caption && (
+            <span
+              part={`file-caption format-file ${file.mimeType} ${
+                file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+              }`}
+            >
+              {file.caption}
+            </span>
+          )}
+
+          {file.caption && file.extension && (
+            <span
+              part={`file-extension format-file ${file.mimeType} ${
+                file.uploadState ?? DEFAULT_FILE_UPLOAD_STATE
+              }`}
+            >
+              {file.extension}
+            </span>
+          )}
+        </a>
+
+        {fileSkeleton(file, "file")}
+      </div>
+    );
+  }
+};

--- a/src/components/chat/renders/renders.tsx
+++ b/src/components/chat/renders/renders.tsx
@@ -1,0 +1,20 @@
+import { ChatMessage, ChatMessageRenderBySections } from "../types";
+import { defaultCodeBlockRender } from "./code-block";
+import { defaultContentRender } from "./content";
+import { defaultFilesRender } from "./files";
+import { defaultMessageStructureRender } from "./structure";
+
+export const renderContentBySections = (
+  message: ChatMessage,
+  chatRef: HTMLChChatElement,
+  rendersBySections: ChatMessageRenderBySections
+) =>
+  (rendersBySections.messageStructure ?? defaultMessageStructureRender)(
+    message,
+    chatRef,
+    {
+      codeBlock: rendersBySections.codeBlock ?? defaultCodeBlockRender,
+      content: rendersBySections.content ?? defaultContentRender,
+      files: rendersBySections.files ?? defaultFilesRender
+    }
+  );

--- a/src/components/chat/renders/renders.tsx
+++ b/src/components/chat/renders/renders.tsx
@@ -1,7 +1,8 @@
 import { ChatMessage, ChatMessageRenderBySections } from "../types";
 import { defaultCodeBlockRender } from "./code-block";
 import { defaultContentRender } from "./content";
-import { defaultFilesRender } from "./files";
+import { defaultFileRender } from "./file";
+import { defaultSourceRender } from "./source";
 import { defaultMessageStructureRender } from "./structure";
 
 export const renderContentBySections = (
@@ -15,6 +16,12 @@ export const renderContentBySections = (
     {
       codeBlock: rendersBySections.codeBlock ?? defaultCodeBlockRender,
       content: rendersBySections.content ?? defaultContentRender,
-      files: rendersBySections.files ?? defaultFilesRender
+      file: {
+        audio: rendersBySections.file?.audio ?? defaultFileRender.audio,
+        file: rendersBySections.file?.file ?? defaultFileRender.file,
+        image: rendersBySections.file?.image ?? defaultFileRender.image,
+        video: rendersBySections.file?.video ?? defaultFileRender.video
+      },
+      source: rendersBySections.source ?? defaultSourceRender
     }
   );

--- a/src/components/chat/renders/renders.tsx
+++ b/src/components/chat/renders/renders.tsx
@@ -1,4 +1,5 @@
 import { ChatMessage, ChatMessageRenderBySections } from "../types";
+import { defaultActionsRender } from "./actions";
 import { defaultCodeBlockRender } from "./code-block";
 import { defaultContentRender } from "./content";
 import { defaultFileRender } from "./file";
@@ -14,6 +15,7 @@ export const renderContentBySections = (
     message,
     chatRef,
     {
+      actions: rendersBySections.actions ?? defaultActionsRender,
       codeBlock: rendersBySections.codeBlock ?? defaultCodeBlockRender,
       content: rendersBySections.content ?? defaultContentRender,
       file: {

--- a/src/components/chat/renders/source.tsx
+++ b/src/components/chat/renders/source.tsx
@@ -1,0 +1,28 @@
+import { h } from "@stencil/core";
+import { ChatMessageSource, ChatSourceRender } from "../types";
+import { tokenMap } from "../../../common/utils";
+
+export const defaultSourceRender: ChatSourceRender = (
+  source: ChatMessageSource
+): any => (
+  <a
+    aria-label={source.accessibleName}
+    part={tokenMap({
+      source: true,
+      [source.parts]: !!source.parts
+    })}
+    href={source.url}
+    target="_blank"
+  >
+    {source.caption && (
+      <span
+        part={tokenMap({
+          "source-caption": true,
+          [source.parts]: !!source.parts
+        })}
+      >
+        {source.caption}
+      </span>
+    )}
+  </a>
+);

--- a/src/components/chat/renders/source.tsx
+++ b/src/components/chat/renders/source.tsx
@@ -5,24 +5,26 @@ import { tokenMap } from "../../../common/utils";
 export const defaultSourceRender: ChatSourceRender = (
   source: ChatMessageSource
 ): any => (
-  <a
-    aria-label={source.accessibleName}
-    part={tokenMap({
-      source: true,
-      [source.parts]: !!source.parts
-    })}
-    href={source.url}
-    target="_blank"
-  >
-    {source.caption && (
-      <span
-        part={tokenMap({
-          "source-caption": true,
-          [source.parts]: !!source.parts
-        })}
-      >
-        {source.caption}
-      </span>
-    )}
-  </a>
+  <li class="contents">
+    <a
+      aria-label={source.accessibleName}
+      part={tokenMap({
+        source: true,
+        [source.parts]: !!source.parts
+      })}
+      href={source.url}
+      target="_blank"
+    >
+      {source.caption && (
+        <span
+          part={tokenMap({
+            "source-caption": true,
+            [source.parts]: !!source.parts
+          })}
+        >
+          {source.caption}
+        </span>
+      )}
+    </a>
+  </li>
 );

--- a/src/components/chat/renders/source.tsx
+++ b/src/components/chat/renders/source.tsx
@@ -1,5 +1,5 @@
 import { h } from "@stencil/core";
-import { ChatMessageSource, ChatSourceRender } from "../types";
+import type { ChatMessageSource, ChatSourceRender } from "../types";
 import { tokenMap } from "../../../common/utils";
 
 export const defaultSourceRender: ChatSourceRender = (

--- a/src/components/chat/renders/structure.tsx
+++ b/src/components/chat/renders/structure.tsx
@@ -41,7 +41,7 @@ export const defaultMessageStructureRender: ChatMessageStructureRender = (
   return (
     <div
       part={tokenMap({
-        [`content-container ${message.role}`]: true,
+        [`content-container ${message.role} ${message.id}`]: true,
         [assistantStatus]: !!assistantStatus,
         [message.parts]: !!message.parts
       })}
@@ -51,7 +51,7 @@ export const defaultMessageStructureRender: ChatMessageStructureRender = (
       {chatFiles.length !== 0 && (
         <div
           part={tokenMap({
-            [`files-container ${message.role}`]: true,
+            [`files-container ${message.role} ${message.id}`]: true,
             [assistantStatus]: !!assistantStatus,
             [message.parts]: !!message.parts
           })}

--- a/src/components/chat/renders/structure.tsx
+++ b/src/components/chat/renders/structure.tsx
@@ -40,6 +40,7 @@ export const defaultMessageStructureRender: ChatMessageStructureRender = (
 
   const messageFiles = getMessageFiles(message);
   const messageSources = message.sources ?? [];
+  const { sourceFiles } = chatRef.translations.text;
 
   return (
     <div
@@ -54,7 +55,7 @@ export const defaultMessageStructureRender: ChatMessageStructureRender = (
       {
         // Files
         messageFiles.length !== 0 && (
-          <div
+          <ul
             part={tokenMap({
               [`files-container ${message.role} ${message.id}`]: true,
               [assistantStatus]: !!assistantStatus,
@@ -64,22 +65,35 @@ export const defaultMessageStructureRender: ChatMessageStructureRender = (
             {messageFiles.map(file =>
               applyFileRenders(file, chatRef, renders.file)
             )}
-          </div>
+          </ul>
         )
       }
 
       {
         // Sources
         messageSources.length !== 0 && (
-          <div
+          <ul
             part={tokenMap({
               [`sources-container ${message.role} ${message.id}`]: true,
               [assistantStatus]: !!assistantStatus,
               [message.parts]: !!message.parts
             })}
           >
+            {sourceFiles && (
+              // TODO: Test the accessibility of this span
+              <span
+                part={tokenMap({
+                  [`sources-caption ${message.role} ${message.id}`]: true,
+                  [assistantStatus]: !!assistantStatus,
+                  [message.parts]: !!message.parts
+                })}
+              >
+                {sourceFiles}
+              </span>
+            )}
+
             {messageSources.map(source => renders.source(source, chatRef))}
-          </div>
+          </ul>
         )
       }
     </div>

--- a/src/components/chat/renders/structure.tsx
+++ b/src/components/chat/renders/structure.tsx
@@ -1,0 +1,66 @@
+import { h } from "@stencil/core";
+import type {
+  ChatCodeBlockRender,
+  ChatContentRender,
+  ChatFile,
+  ChatFilesRender,
+  ChatMessageByRole,
+  ChatMessageRole,
+  ChatMessageStructureRender
+} from "../types";
+import { tokenMap } from "../../../common/utils";
+import { DEFAULT_ASSISTANT_STATUS, getMessageFiles } from "../utils";
+import { getMimeTypeFileFormat } from "../../../common/mimeTypes/mime-types-utils";
+
+type ChatMessageNoSystem = ChatMessageByRole<
+  Exclude<ChatMessageRole, "system">
+>;
+
+const applyFileRenders = (
+  file: ChatFile,
+  chatRef: HTMLChChatElement,
+  renders: ChatFilesRender
+) => renders[getMimeTypeFileFormat(file.mimeType)](file, chatRef);
+
+export const defaultMessageStructureRender: ChatMessageStructureRender = (
+  message: ChatMessageNoSystem,
+  chatRef: HTMLChChatElement,
+  renders: {
+    codeBlock: ChatCodeBlockRender;
+    content: ChatContentRender;
+    files: ChatFilesRender;
+  }
+) => {
+  const assistantStatus =
+    message.role === "assistant"
+      ? message.status ?? DEFAULT_ASSISTANT_STATUS
+      : undefined;
+
+  const chatFiles = getMessageFiles(message);
+
+  return (
+    <div
+      part={tokenMap({
+        [`content-container ${message.role}`]: true,
+        [assistantStatus]: !!assistantStatus,
+        [message.parts]: !!message.parts
+      })}
+    >
+      {renders.content(message, chatRef, renders.codeBlock)}
+
+      {chatFiles.length !== 0 && (
+        <div
+          part={tokenMap({
+            [`files-container ${message.role}`]: true,
+            [assistantStatus]: !!assistantStatus,
+            [message.parts]: !!message.parts
+          })}
+        >
+          {chatFiles.map(file =>
+            applyFileRenders(file, chatRef, renders.files)
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/chat/tests/basic.e2e.ts
+++ b/src/components/chat/tests/basic.e2e.ts
@@ -6,15 +6,11 @@ testDefaultProperties("ch-chat", {
   callbacks: undefined,
   disabled: false,
   generatingResponse: false,
-  hyperlinkToDownloadFile: undefined,
-  imageUpload: false,
-  isMobile: false,
   items: [],
   loadingState: "initial",
   markdownTheme: "ch-markdown-viewer",
   newUserMessageAlignment: "end",
   newUserMessageScrollBehavior: "instant",
-  renderCode: undefined,
   showAdditionalContent: false,
   theme: undefined,
   translations: {
@@ -30,10 +26,10 @@ testDefaultProperties("ch-chat", {
       sendInput: "Ask me a question..."
     },
     text: {
-      stopGeneratingAnswerButton: "Stop generating answer",
       copyCodeButton: "Copy code",
       processing: `Processing...`,
-      sourceFiles: "Source files:"
+      sourceFiles: "Source files:",
+      stopGeneratingAnswerButton: "Stop generating answer"
     }
   }
 });

--- a/src/components/chat/tests/basic.e2e.ts
+++ b/src/components/chat/tests/basic.e2e.ts
@@ -22,8 +22,6 @@ testDefaultProperties("ch-chat", {
       clearChat: "Clear chat",
       copyResponseButton: "Copy assistant response",
       downloadCodeButton: "Download code",
-      imagePicker: "Select images",
-      removeUploadedImage: "Remove uploaded image",
       sendButton: "Send",
       sendInput: "Message",
       stopGeneratingAnswerButton: "Stop generating answer"

--- a/src/components/chat/tests/basic.e2e.ts
+++ b/src/components/chat/tests/basic.e2e.ts
@@ -16,7 +16,7 @@ testDefaultProperties("ch-chat", {
   translations: {
     accessibleName: {
       clearChat: "Clear chat",
-      copyResponseButton: "Copy assistant response",
+      copyMessageContent: "Copy assistant response",
       downloadCodeButton: "Download code",
       sendButton: "Send",
       sendInput: "Message",

--- a/src/components/chat/tests/basic.e2e.ts
+++ b/src/components/chat/tests/basic.e2e.ts
@@ -16,7 +16,7 @@ testDefaultProperties("ch-chat", {
   translations: {
     accessibleName: {
       clearChat: "Clear chat",
-      copyMessageContent: "Copy assistant response",
+      copyMessageContent: "Copy message content",
       downloadCodeButton: "Download code",
       sendButton: "Send",
       sendInput: "Message",
@@ -27,6 +27,7 @@ testDefaultProperties("ch-chat", {
     },
     text: {
       copyCodeButton: "Copy code",
+      copyMessageContent: "Copy",
       processing: `Processing...`,
       sourceFiles: "Source files:",
       stopGeneratingAnswerButton: "Stop generating answer"

--- a/src/components/chat/tests/callbacks/validateSendChatMessage.e2e.ts
+++ b/src/components/chat/tests/callbacks/validateSendChatMessage.e2e.ts
@@ -32,7 +32,7 @@ describe("[ch-chat][callbacks]", () => {
             clear: () => Promise.resolve(),
             validateSendChatMessage: (chat: ChatMessage) =>
               chat.content !== "error",
-            sendChatToLLM: () => {},
+            sendChatMessages: () => {},
             uploadImage: () => Promise.resolve("")
           } satisfies HTMLChChatElement["callbacks"];
         });
@@ -40,7 +40,7 @@ describe("[ch-chat][callbacks]", () => {
         await page.evaluate(() => {
           document.querySelector("ch-chat").callbacks = {
             clear: () => Promise.resolve(),
-            sendChatToLLM: () => {},
+            sendChatMessages: () => {},
             uploadImage: () => Promise.resolve("")
           } satisfies HTMLChChatElement["callbacks"];
         });

--- a/src/components/chat/tests/items-reactivity.e2e.ts
+++ b/src/components/chat/tests/items-reactivity.e2e.ts
@@ -2,7 +2,7 @@ import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { ChatMessage } from "../types";
 
 const INITIAL_LOAD_RENDERED_CONTENT =
-  '<div class="loading-chat" slot="empty-chat"></div><div class="send-container" part="send-container"><div class="send-input-wrapper" part="send-input-wrapper"><ch-edit class="ch-edit--cursor-text ch-edit--multiline hydrated" part="ch-edit--empty-value send-input" data-text-align=""></ch-edit></div><button aria-label="Send" title="Send" class="send-or-audio-button" part="send-button" type="button"></button></div>';
+  '<slot name="loading-chat"></slot><div class="send-container" part="send-container"><div class="send-input-wrapper" part="send-input-wrapper"><ch-edit class="ch-edit--cursor-text ch-edit--multiline hydrated" part="ch-edit--empty-value send-input" data-text-align=""></ch-edit></div><button aria-label="Send" title="Send" class="send-or-audio-button" part="send-button" type="button"></button></div>';
 
 const EMPTY_RENDERED_CONTENT =
   '<slot name="empty-chat"></slot><div class="send-container" part="send-container"><div class="send-input-wrapper" part="send-input-wrapper"><ch-edit class="ch-edit--cursor-text ch-edit--multiline hydrated" part="ch-edit--empty-value send-input" data-text-align=""></ch-edit></div><button aria-label="Send" title="Send" class="send-or-audio-button" part="send-button" type="button"></button></div>';

--- a/src/components/chat/tests/items-reactivity.e2e.ts
+++ b/src/components/chat/tests/items-reactivity.e2e.ts
@@ -1,5 +1,5 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
-import { ChatMessage } from "../types";
+import { ChatMessage, ChatMessageByRole } from "../types";
 
 const INITIAL_LOAD_RENDERED_CONTENT =
   '<slot name="loading-chat"></slot><div class="send-container" part="send-container"><div class="send-input-wrapper" part="send-input-wrapper"><ch-edit class="ch-edit--cursor-text ch-edit--multiline hydrated" part="ch-edit--empty-value send-input" data-text-align=""></ch-edit></div><button aria-label="Send" title="Send" class="send-or-audio-button" part="send-button" type="button"></button></div>';
@@ -44,10 +44,13 @@ const chatModel2: ChatMessage[] = [
 ];
 
 const USER_CELL = <I extends string, T extends string>(id: I, content: T) =>
-  `<ch-smart-grid-cell part="message user" role="gridcell" cell-id="${id}" class="hydrated" data-did-load="true">${content}</ch-smart-grid-cell>`;
+  `<ch-smart-grid-cell part="message user ${id}" role="gridcell" cell-id="${id}" class="hydrated" data-did-load="true">${content}</ch-smart-grid-cell>`;
 
-const ASSISTANT_CELL = <I extends string>(id: I) =>
-  `<ch-smart-grid-cell part="message assistant undefined" role="gridcell" cell-id="${id}" class="hydrated" data-did-load="true"><div aria-live="polite" aria-busy="false" class="assistant-content" part="assistant-content"><ch-markdown-viewer class="hydrated"></ch-markdown-viewer><button aria-label="Copy assistant response" title="Copy assistant response" part="copy-response-button" type="button"></button></div></ch-smart-grid-cell>`;
+const ASSISTANT_CELL = <I extends string>(
+  id: I,
+  assistantState: ChatMessageByRole<"assistant">["status"]
+) =>
+  `<ch-smart-grid-cell aria-live="polite" aria-busy="false" part="message assistant ${id} ${assistantState}" role="gridcell" cell-id="${id}" class="hydrated" data-did-load="true"><div class="assistant-content" part="assistant-content"><ch-markdown-viewer class="hydrated" part="assistant content ${id} ${assistantState}"></ch-markdown-viewer><button aria-label="Copy assistant response" title="Copy assistant response" part="copy-response-button" type="button"></button></div></ch-smart-grid-cell>`;
 
 describe("[ch-chat][items reactivity]", () => {
   let page: E2EPage;
@@ -110,7 +113,7 @@ describe("[ch-chat][items reactivity]", () => {
 
     expect(await getChatRenderedItems()).toEqual(
       USER_CELL("1", "Something") +
-        ASSISTANT_CELL("2") +
+        ASSISTANT_CELL("2", "complete") +
         USER_CELL("3", "Something 3")
     );
   });
@@ -125,7 +128,7 @@ describe("[ch-chat][items reactivity]", () => {
 
     expect(await getChatRenderedItems()).toEqual(
       USER_CELL("1", "Something") +
-        ASSISTANT_CELL("2") +
+        ASSISTANT_CELL("2", "complete") +
         USER_CELL("3", "Something 3")
     );
 
@@ -134,7 +137,7 @@ describe("[ch-chat][items reactivity]", () => {
 
     expect(await getChatRenderedItems()).toEqual(
       USER_CELL("1", "A different text") +
-        ASSISTANT_CELL("2") +
+        ASSISTANT_CELL("2", "complete") +
         USER_CELL("3", "A different text 3")
     );
   });

--- a/src/components/chat/tests/items-reactivity.e2e.ts
+++ b/src/components/chat/tests/items-reactivity.e2e.ts
@@ -44,13 +44,13 @@ const chatModel2: ChatMessage[] = [
 ];
 
 const USER_CELL = <I extends string, T extends string>(id: I, content: T) =>
-  `<ch-smart-grid-cell part="message user ${id}" role="gridcell" cell-id="${id}" class="hydrated" data-did-load="true">${content}</ch-smart-grid-cell>`;
+  `<ch-smart-grid-cell part="message user ${id}" role="gridcell" cell-id="${id}" class="hydrated" data-did-load="true"><div part="content-container user ${id}">${content}</div></ch-smart-grid-cell>`;
 
 const ASSISTANT_CELL = <I extends string>(
   id: I,
   assistantState: ChatMessageByRole<"assistant">["status"]
 ) =>
-  `<ch-smart-grid-cell aria-live="polite" aria-busy="false" part="message assistant ${id} ${assistantState}" role="gridcell" cell-id="${id}" class="hydrated" data-did-load="true"><div class="assistant-content" part="assistant-content"><ch-markdown-viewer class="hydrated" part="assistant content ${id} ${assistantState}"></ch-markdown-viewer><button aria-label="Copy assistant response" title="Copy assistant response" part="copy-response-button" type="button"></button></div></ch-smart-grid-cell>`;
+  `<ch-smart-grid-cell aria-live="polite" aria-busy="false" part="message assistant ${id} ${assistantState}" role="gridcell" cell-id="${id}" class="hydrated" data-did-load="true"><div part="content-container assistant ${id} ${assistantState}"><ch-markdown-viewer part="assistant content ${id} ${assistantState}" class="hydrated"></ch-markdown-viewer><button aria-label="Copy message content" part="assistant copy-message-content ${id}" type="button">Copy</button></div></ch-smart-grid-cell>`;
 
 describe("[ch-chat][items reactivity]", () => {
   let page: E2EPage;

--- a/src/components/chat/tests/smart-grid.e2e.ts
+++ b/src/components/chat/tests/smart-grid.e2e.ts
@@ -9,7 +9,7 @@ import {
 } from "./utils.e2e";
 
 const EMPTY_CHAT_SELECTOR = 'ch-chat >>> slot[name="empty-chat"]';
-const LOADING_SELECTOR = 'ch-chat >>> [slot="empty-chat"]';
+const LOADING_SELECTOR = 'ch-chat >>> slot[name="loading-chat"]';
 const INFINITE_SCROLLER_SELECTOR =
   "ch-chat >>> ch-smart-grid > ch-virtual-scroller";
 const SMART_GRID_SELECTOR = "ch-chat >>> ch-smart-grid";

--- a/src/components/chat/translations.ts
+++ b/src/components/chat/translations.ts
@@ -1,7 +1,7 @@
 export type ChatTranslations = {
   accessibleName: {
     clearChat: string;
-    copyResponseButton: string;
+    copyMessageContent?: string;
     downloadCodeButton: string;
     // retryAudioUpload?: string;
     // retryFileUpload?: string;
@@ -9,19 +9,20 @@ export type ChatTranslations = {
     // retryVideoUpload?: string;
     sendButton: string;
     sendInput: string;
-    stopGeneratingAnswerButton: string;
+    stopGeneratingAnswerButton?: string;
   };
   placeholder: {
     sendInput: string;
   };
   text: {
     copyCodeButton: string;
-    processing: string;
+    copyMessageContent?: string;
+    processing?: string;
     // retryAudioUpload?: string;
     // retryFileUpload?: string;
     // retryImageUpload?: string;
     // retryVideoUpload?: string;
-    sourceFiles: string;
-    stopGeneratingAnswerButton: string;
+    sourceFiles?: string;
+    stopGeneratingAnswerButton?: string;
   };
 };

--- a/src/components/chat/translations.ts
+++ b/src/components/chat/translations.ts
@@ -3,8 +3,6 @@ export type ChatTranslations = {
     clearChat: string;
     copyResponseButton: string;
     downloadCodeButton: string;
-    imagePicker: string;
-    removeUploadedImage: string;
     sendButton: string;
     sendInput: string;
     stopGeneratingAnswerButton: string;

--- a/src/components/chat/translations.ts
+++ b/src/components/chat/translations.ts
@@ -3,6 +3,10 @@ export type ChatTranslations = {
     clearChat: string;
     copyResponseButton: string;
     downloadCodeButton: string;
+    // retryAudioUpload?: string;
+    // retryFileUpload?: string;
+    // retryImageUpload?: string;
+    // retryVideoUpload?: string;
     sendButton: string;
     sendInput: string;
     stopGeneratingAnswerButton: string;
@@ -11,9 +15,13 @@ export type ChatTranslations = {
     sendInput: string;
   };
   text: {
-    stopGeneratingAnswerButton: string;
     copyCodeButton: string;
     processing: string;
+    // retryAudioUpload?: string;
+    // retryFileUpload?: string;
+    // retryImageUpload?: string;
+    // retryVideoUpload?: string;
     sourceFiles: string;
+    stopGeneratingAnswerButton: string;
   };
 };

--- a/src/components/chat/translations.ts
+++ b/src/components/chat/translations.ts
@@ -2,7 +2,7 @@ export type ChatTranslations = {
   accessibleName: {
     clearChat: string;
     copyMessageContent?: string;
-    downloadCodeButton: string;
+    downloadCodeButton?: string;
     // retryAudioUpload?: string;
     // retryFileUpload?: string;
     // retryImageUpload?: string;
@@ -17,6 +17,7 @@ export type ChatTranslations = {
   text: {
     copyCodeButton: string;
     copyMessageContent?: string;
+    downloadCodeButton?: string;
     processing?: string;
     // retryAudioUpload?: string;
     // retryFileUpload?: string;

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -75,27 +75,30 @@ export type ChatMessageByRoleNoId<T extends ChatMessageRole> =
 export type ChatMessageSystem = {
   id: string;
   role: "system";
-  metadata?: string;
+  metadata?: any;
   content: ChatContent;
+  sources?: ChatMessageSources;
 };
 
 export type ChatMessageUser = {
   id: string;
   role: "user";
   content: ChatContent;
-  metadata?: string;
+  metadata?: any;
 
   /**
    * Added to the parts of the cell.
    */
   parts?: string;
+
+  sources?: ChatMessageSources;
 };
 
 export type ChatMessageAssistant = {
   id: string;
   role: "assistant";
   content?: ChatContent;
-  metadata?: string;
+  metadata?: any;
 
   /**
    * Added to the parts of the cell.
@@ -107,18 +110,22 @@ export type ChatMessageAssistant = {
    * to `"complete"`
    */
   status?: "complete" | "waiting" | "streaming";
+
+  sources?: ChatMessageSources;
 };
 
 export type ChatMessageError = {
   id: string;
   role: "error";
   content: ChatContent;
-  metadata?: string;
+  metadata?: any;
 
   /**
    * Added to the parts of the cell.
    */
   parts?: string;
+
+  sources?: ChatMessageSources;
 };
 
 export type ChatContent = string | ChatContentFiles;
@@ -139,7 +146,7 @@ export type ChatFile = {
 
   // The (string & Record<never, never>) is necessary to allow any string as
   // the mimeType without removing the VSCode suggestions
-  mimeType: ChMimeType | (string & Record<never, never>); // TODO: Which is the mimeType for hrefs?
+  mimeType: ChMimeType | (string & Record<never, never>);
 
   /**
    * Specifies the uploading state of the files.
@@ -152,6 +159,15 @@ export type ChatFile = {
 };
 
 export type ChatFileUploadState = "failed" | "in-progress" | "uploaded";
+
+export type ChatMessageSources = ChatMessageSource[];
+
+export type ChatMessageSource = {
+  accessibleName?: string;
+  caption?: string;
+  url: string;
+  parts?: string;
+};
 
 export type ChatInternalCallbacks = {
   /**
@@ -196,8 +212,8 @@ export type ChatInternalCallbacks = {
   ) => boolean | Promise<boolean>;
 
   /**
-   * Upload a chat file returning a `ChatFile` type object containing the
-   * public URL where the file is stored.
+   * Upload a file returning a `ChatFile` type object containing the public URL
+   * where the file is stored.
    *
    * When the promise resolve, the `ch-chat` will ensure the returned `ChatFile`
    * has `uploadedState === "uploaded"`. If the promise is reject, the `ch-chat`
@@ -244,6 +260,13 @@ export type ChatMessageRenderBySections = {
    * If `undefined`, a default structure render will be used.
    */
   messageStructure?: ChatMessageStructureRender;
+
+  /**
+   * Render for the sources of the message.
+   *
+   * If `undefined`, a default render for the sources will be used.
+   */
+  sources?: ChatSourcesRender;
 };
 
 export type ChatCodeBlockRender = (
@@ -270,5 +293,11 @@ export type ChatMessageStructureRender = (
     codeBlock: ChatCodeBlockRender;
     content: ChatContentRender;
     files: ChatFilesRender;
+    sources: ChatSourcesRender;
   }
+) => any;
+
+export type ChatSourcesRender = (
+  message: ChatMessage,
+  chatRef: HTMLChChatElement
 ) => any;

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -240,7 +240,7 @@ export type ChatMessageSource = {
   url: string;
 };
 
-export type ChatInternalCallbacks = {
+export type ChatCallbacks = {
   /**
    * Specifies a callback that is executed when the user wants to download the
    * code block as a file.

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -1,4 +1,10 @@
-import type { ChMimeType } from "../../common/mime-types";
+import type {
+  ChMimeType,
+  ChMimeTypeFormatMap
+} from "../../common/mimeTypes/mime-types";
+import type { MarkdownViewerCodeRender } from "../markdown-viewer/parsers/types";
+
+export type ChatMessageRole = "assistant" | "error" | "system" | "user";
 
 /**
  * Valid examples:
@@ -115,8 +121,6 @@ export type ChatMessageError = {
   parts?: string;
 };
 
-export type ChatMessageRole = "system" | "user" | "assistant" | "error";
-
 export type ChatContent = string | ChatContentFiles;
 
 export type ChatContentFiles = {
@@ -130,6 +134,8 @@ export type ChatFile = {
   accessibleName?: string;
   alternativeText?: string;
   caption?: string;
+
+  extension?: string;
 
   // The (string & Record<never, never>) is necessary to allow any string as
   // the mimeType without removing the VSCode suggestions
@@ -199,3 +205,70 @@ export type ChatInternalCallbacks = {
    */
   uploadFile?: (file: File) => Promise<ChatFile>;
 };
+
+export type ChatMessageRenderByItem = (
+  messageModel: ChatMessageByRole<"assistant" | "error" | "user">
+) => any;
+
+export type ChatMessageRenderBySections = {
+  /**
+   * Render for code blocks.
+   *
+   * If `undefined`, a default code block render will be used.
+   */
+  codeBlock?: ChatCodeBlockRender;
+
+  /**
+   * Render for the content of the message.
+   *
+   * If `undefined`, a default content render will be used.
+   */
+  content?: ChatContentRender;
+
+  /**
+   * Renders for each file type of the message
+   *
+   * If `undefined`, a default render for the files will be used.
+   */
+  files?: ChatFilesRender;
+
+  /**
+   * Render for the general structure of the message.
+   *
+   * This render is useful for adding extra elements and widgets for
+   * customizing the message structure and content. This render has direct
+   * access for all sub-renders of the message (`codeBlock`, `content`, and
+   * `files`) for allowing to relocate those render according to the developer
+   * needs.
+   *
+   * If `undefined`, a default structure render will be used.
+   */
+  messageStructure?: ChatMessageStructureRender;
+};
+
+export type ChatCodeBlockRender = (
+  chatRef: HTMLChChatElement
+) => MarkdownViewerCodeRender;
+
+export type ChatContentRender = (
+  message: ChatMessage,
+  chatRef: HTMLChChatElement,
+  codeBlockRender: ChatCodeBlockRender
+) => any;
+
+export type ChatFilesRender = {
+  [key in keyof ChMimeTypeFormatMap]: (
+    file: ChatFile,
+    chatRef: HTMLChChatElement
+  ) => any;
+};
+
+export type ChatMessageStructureRender = (
+  message: ChatMessage,
+  chatRef: HTMLChChatElement,
+  renders: {
+    codeBlock: ChatCodeBlockRender;
+    content: ChatContentRender;
+    files: ChatFilesRender;
+  }
+) => any;

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -134,10 +134,40 @@ export type ChatFile = {
   // The (string & Record<never, never>) is necessary to allow any string as
   // the mimeType without removing the VSCode suggestions
   mimeType: ChMimeType | (string & Record<never, never>); // TODO: Which is the mimeType for hrefs?
+
+  /**
+   * Specifies the uploading state of the files.
+   *
+   * By default is `"uploaded"`.
+   */
+  uploadState?: ChatFileUploadState;
+
   url: string;
 };
 
+export type ChatFileUploadState = "failed" | "in-progress" | "uploaded";
+
 export type ChatInternalCallbacks = {
+  /**
+   * Specifies a callback that is executed after the user adds a new message to
+   * the chat.
+   *
+   * Since developers can define their own render for file attachment, this
+   * callback serves to synchronize the cleanup of the send-input with the
+   * cleanup of the custom file attachment.
+   */
+  clearChatMessageFiles?: () => void;
+
+  /**
+   * Specifies a callback to execute before the user adds a new message in the
+   * chat. This callbacks is intended to get retrieve the files that the user
+   * wants to add in the message.
+   *
+   * This callback allows developers to implement any custom rendering for
+   * attaching files.
+   */
+  getChatMessageFiles?: () => File[] | Promise<File[]>;
+
   /**
    * Specifies a callback to execute when the user adds a new message to the
    * chat and waits a response.
@@ -154,5 +184,18 @@ export type ChatInternalCallbacks = {
    * Specifies a callback to validate if the current chat message of the user
    * can be send. If `false`, the `sendChatMessages` won't be executed.
    */
-  validateSendChatMessage?: (chat: ChatMessage) => boolean | Promise<boolean>;
+  validateSendChatMessage?: (
+    chat: ChatMessage,
+    files: File[]
+  ) => boolean | Promise<boolean>;
+
+  /**
+   * Upload a chat file returning a `ChatFile` type object containing the
+   * public URL where the file is stored.
+   *
+   * When the promise resolve, the `ch-chat` will ensure the returned `ChatFile`
+   * has `uploadedState === "uploaded"`. If the promise is reject, the `ch-chat`
+   * will set `uploadedState === "failed"` in the returned `ChatFile`.
+   */
+  uploadFile?: (file: File) => Promise<ChatFile>;
 };

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -75,7 +75,15 @@ export type ChatMessageByRoleNoId<T extends ChatMessageRole> =
 export type ChatMessageSystem = {
   id: string;
   role: "system";
+
+  /**
+   * A field for adding any extra information that must be stored for the
+   * message.
+   *
+   * The `metadata` field can be used for any purpose.
+   */
   metadata?: any;
+
   content: ChatContent;
   sources?: ChatMessageSources;
 };
@@ -84,6 +92,14 @@ export type ChatMessageUser = {
   id: string;
   role: "user";
   content: ChatContent;
+
+  /**
+   * A field for adding any extra information that must be stored for the
+   * message.
+   *
+   * The `metadata` field can be used for any purpose, for example, adding more
+   * information to customize the render.
+   */
   metadata?: any;
 
   /**
@@ -101,6 +117,14 @@ export type ChatMessageAssistant = {
   id: string;
   role: "assistant";
   content?: ChatContent;
+
+  /**
+   * A field for adding any extra information that must be stored for the
+   * message.
+   *
+   * The `metadata` field can be used for any purpose, for example, adding more
+   * information to customize the render.
+   */
   metadata?: any;
 
   /**
@@ -124,6 +148,14 @@ export type ChatMessageError = {
   id: string;
   role: "error";
   content: ChatContent;
+
+  /**
+   * A field for adding any extra information that must be stored for the
+   * message.
+   *
+   * The `metadata` field can be used for any purpose, for example, adding more
+   * information to customize the render.
+   */
   metadata?: any;
 
   /**
@@ -153,6 +185,15 @@ export type ChatFile = {
 
   extension?: string;
 
+  /**
+   * A field for adding any extra information that must be stored for the
+   * file.
+   *
+   * The `metadata` field can be used for any purpose, for example, adding more
+   * information to customize the render.
+   */
+  metadata?: any;
+
   // The (string & Record<never, never>) is necessary to allow any string as
   // the mimeType without removing the VSCode suggestions
   mimeType: ChMimeType | (string & Record<never, never>);
@@ -179,6 +220,15 @@ export type ChatMessageSources = ChatMessageSource[];
 export type ChatMessageSource = {
   accessibleName?: string;
   caption?: string;
+
+  /**
+   * A field for adding any extra information that must be stored for the
+   * source.
+   *
+   * The `metadata` field can be used for any purpose, for example, adding more
+   * information to customize the render.
+   */
+  metadata?: any;
 
   /**
    * Parts for the source.

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -242,6 +242,19 @@ export type ChatMessageSource = {
 
 export type ChatInternalCallbacks = {
   /**
+   * Specifies a callback that is executed when the user wants to download the
+   * code block as a file.
+   *
+   * This callback is useful to implement any custom render to manage this
+   * action. For example, displaying a dialog to customize the file name that
+   * contains the code block to download.
+   *
+   * If specified, in the default code block render a "download code" button will
+   * be displayed in the `code-block__header-actions`.
+   */
+  downloadCodeBlock?: (plainText: string, language: string) => void;
+
+  /**
    * Specifies a callback to execute before the user adds a new message in the
    * chat. This callbacks is intended to get retrieve the files that the user
    * wants to add in the message.

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -190,16 +190,6 @@ export type ChatMessageSource = {
 
 export type ChatInternalCallbacks = {
   /**
-   * Specifies a callback that is executed after the user adds a new message to
-   * the chat.
-   *
-   * Since developers can define their own render for file attachment, this
-   * callback serves to synchronize the cleanup of the send-input with the
-   * cleanup of the custom file attachment.
-   */
-  clearChatMessageFiles?: () => void;
-
-  /**
    * Specifies a callback to execute before the user adds a new message in the
    * chat. This callbacks is intended to get retrieve the files that the user
    * wants to add in the message.

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -84,14 +84,21 @@ export type ChatMessageSystem = {
    */
   metadata?: any;
 
-  content: ChatContent;
-  sources?: ChatMessageSources;
+  content: ChatMessageContent;
+
+  /**
+   * Parts for the cell, message content, `files-container` and
+   * `sources-container`.
+   *
+   * It is not added to the parts of the files and sources.
+   */
+  parts?: string;
 };
 
 export type ChatMessageUser = {
   id: string;
   role: "user";
-  content: ChatContent;
+  content: ChatMessageContent;
 
   /**
    * A field for adding any extra information that must be stored for the
@@ -109,14 +116,12 @@ export type ChatMessageUser = {
    * It is not added to the parts of the files and sources.
    */
   parts?: string;
-
-  sources?: ChatMessageSources;
 };
 
 export type ChatMessageAssistant = {
   id: string;
   role: "assistant";
-  content?: ChatContent;
+  content: ChatMessageContent;
 
   /**
    * A field for adding any extra information that must be stored for the
@@ -140,14 +145,12 @@ export type ChatMessageAssistant = {
    * to `"complete"`
    */
   status?: "complete" | "waiting" | "streaming";
-
-  sources?: ChatMessageSources;
 };
 
 export type ChatMessageError = {
   id: string;
   role: "error";
-  content: ChatContent;
+  content: ChatMessageContent;
 
   /**
    * A field for adding any extra information that must be stored for the
@@ -165,20 +168,19 @@ export type ChatMessageError = {
    * It is not added to the parts of the files and sources.
    */
   parts?: string;
+};
 
+export type ChatMessageContent = string | ChatMessageContentFilesAndSources;
+
+export type ChatMessageContentFilesAndSources = {
+  message: string;
+  files?: ChatMessageFiles;
   sources?: ChatMessageSources;
 };
 
-export type ChatContent = string | ChatContentFiles;
+export type ChatMessageFiles = ChatMessageFile[];
 
-export type ChatContentFiles = {
-  message: string;
-  files?: ChatFiles;
-};
-
-export type ChatFiles = ChatFile[];
-
-export type ChatFile = {
+export type ChatMessageFile = {
   accessibleName?: string;
   alternativeText?: string;
   caption?: string;
@@ -278,7 +280,7 @@ export type ChatInternalCallbacks = {
    * has `uploadedState === "uploaded"`. If the promise is reject, the `ch-chat`
    * will set `uploadedState === "failed"` in the returned `ChatFile`.
    */
-  uploadFile?: (file: File) => Promise<ChatFile>;
+  uploadFile?: (file: File) => Promise<ChatMessageFile>;
 };
 
 export type ChatMessageRenderByItem = (
@@ -286,6 +288,13 @@ export type ChatMessageRenderByItem = (
 ) => any;
 
 export type ChatMessageRenderBySections = {
+  /**
+   * Render for additional actions of the message.
+   *
+   * If `undefined`, a default render for the additional actions will be used.
+   */
+  actions?: ChatActionsRender;
+
   /**
    * Render for code blocks.
    *
@@ -328,6 +337,11 @@ export type ChatMessageRenderBySections = {
   source?: ChatSourceRender;
 };
 
+export type ChatActionsRender = (
+  message: ChatMessage,
+  chatRef: HTMLChChatElement
+) => any;
+
 export type ChatCodeBlockRender = (
   chatRef: HTMLChChatElement
 ) => MarkdownViewerCodeRender;
@@ -340,7 +354,7 @@ export type ChatContentRender = (
 
 export type ChatFileRender = {
   [key in keyof ChMimeTypeFormatMap]?: (
-    file: ChatFile,
+    file: ChatMessageFile,
     chatRef: HTMLChChatElement
   ) => any;
 };
@@ -348,15 +362,10 @@ export type ChatFileRender = {
 export type ChatMessageStructureRender = (
   message: ChatMessage,
   chatRef: HTMLChChatElement,
-  renders: {
-    codeBlock: ChatCodeBlockRender;
-    content: ChatContentRender;
-    file: ChatFileRender;
-    source: ChatSourceRender;
-  }
+  renders: Required<Omit<ChatMessageRenderBySections, "messageStructure">>
 ) => any;
 
 export type ChatSourceRender = (
-  sources: ChatMessageSource,
+  source: ChatMessageSource,
   chatRef: HTMLChChatElement
 ) => any;

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -131,7 +131,7 @@ export type ChatInternalCallbacks = {
    * Specifies a callback to execute when the user adds a new message to the
    * chat and waits a response.
    */
-  sendChatToLLM: (chat: ChatMessage[]) => void;
+  sendChatMessages: (chat: ChatMessage[]) => void;
 
   /**
    * Specifies a callback to execute when clicking the stop-generate-answer
@@ -141,7 +141,7 @@ export type ChatInternalCallbacks = {
 
   /**
    * Specifies a callback to validate if the current chat message of the user
-   * can be send. If `false`, the `sendChatToLLM` won't be executed.
+   * can be send. If `false`, the `sendChatMessages` won't be executed.
    */
   validateSendChatMessage?: (chat: ChatMessage) => boolean | Promise<boolean>;
 };

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -127,8 +127,6 @@ export type ChatContentImage = {
 };
 
 export type ChatInternalCallbacks = {
-  clear: () => Promise<void>;
-
   /**
    * Specifies a callback to execute when the user adds a new message to the
    * chat and waits a response.

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -104,7 +104,7 @@ export type ChatMessageAssistant = {
 
   /**
    * Specifies the status of the message. If not defined, it will default
-   * to "complete"
+   * to `"complete"`
    */
   status?: "complete" | "waiting" | "streaming";
 };

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -1,29 +1,49 @@
+import type { ChMimeType } from "../../common/mime-types";
+
 /**
  * Valid examples:
  * @example
- *   const systemMessage: GxEAIChatMessage = {
+ *   const systemMessage: ChatMessage = {
  *     role: "system",
  *     content: "A useful assistant."
  *   };
  *
- *   const assistantMessage: GxEAIChatMessage = {
+ *   const assistantMessage: ChatMessage = {
  *     role: "assistant",
- *     content: "Processing with Chat with LLMs",
+ *     content: "How can I help you?",
  *     status: "waiting"
  *   };
  *
- *   const userMessage: GxEAIChatMessage = {
+ *   const assistantMessageWithFiles: ChatMessage = {
+ *     role: "assistant",
+ *     content: {
+ *       message: "How can I help you?",
+ *       files: [
+ *         { url: "...", mimeType: "audio/mpeg", accessibleName: "..." },
+ *         { url: "...", mimeType: "image/png", alternativeText: "..." },
+ *         { url: "...", mimeType: "video/mp4", accessibleName: "..." },
+ *         { url: "...", mimeType: "any string" }
+ *       ]
+ *     },
+ *     status: "waiting"
+ *   };
+ *
+ *   const userMessage: ChatMessage = {
  *     role: "user",
  *     content: "Hello world!"
  *   };
  *
- *   const userMessageWithImage: GxEAIChatMessage = {
+ *   const userMessageWithFiles: ChatMessage = {
  *     role: "user",
- *     content: [
- *       { type: "text", text: "Hello world!" },
- *       { type: "image_url", image_url: { url: "..." } },
- *       { type: "image_url", image_url: { url: "..." } },
- *     ]
+ *     content: {
+ *       message: "Hello world!",
+ *       files: [
+ *         { url: "...", mimeType: "audio/mpeg", accessibleName: "..." },
+ *         { url: "...", mimeType: "image/png", alternativeText: "..." },
+ *         { url: "...", mimeType: "video/mp4", accessibleName: "..." },
+ *         { url: "...", mimeType: "any string" }
+ *       ]
+ *     }
  *   };
  */
 export type ChatMessage = ChatMessageByRole<ChatMessageRole>;
@@ -50,13 +70,13 @@ export type ChatMessageSystem = {
   id: string;
   role: "system";
   metadata?: string;
-  content: string;
+  content: ChatContent;
 };
 
 export type ChatMessageUser = {
   id: string;
   role: "user";
-  content: ChatUserContent;
+  content: ChatContent;
   metadata?: string;
 
   /**
@@ -68,7 +88,7 @@ export type ChatMessageUser = {
 export type ChatMessageAssistant = {
   id: string;
   role: "assistant";
-  content?: ChatAssistantContent;
+  content?: ChatContent;
   metadata?: string;
 
   /**
@@ -86,7 +106,7 @@ export type ChatMessageAssistant = {
 export type ChatMessageError = {
   id: string;
   role: "error";
-  content: string;
+  content: ChatContent;
   metadata?: string;
 
   /**
@@ -97,33 +117,24 @@ export type ChatMessageError = {
 
 export type ChatMessageRole = "system" | "user" | "assistant" | "error";
 
-export type ChatAssistantContent = string | ChatAssistantContentFiles;
+export type ChatContent = string | ChatContentFiles;
 
-export type ChatAssistantContentFiles = {
+export type ChatContentFiles = {
   message: string;
-  files?: ChatAssistantContentFilesFile[];
+  files?: ChatFiles;
 };
 
-export type ChatAssistantContentFilesFile = {
+export type ChatFiles = ChatFile[];
+
+export type ChatFile = {
+  accessibleName?: string;
+  alternativeText?: string;
+  caption?: string;
+
+  // The (string & Record<never, never>) is necessary to allow any string as
+  // the mimeType without removing the VSCode suggestions
+  mimeType: ChMimeType | (string & Record<never, never>); // TODO: Which is the mimeType for hrefs?
   url: string;
-  caption: string;
-};
-
-export type ChatUserContent = string | ChatContentImages;
-
-export type ChatContentImages = [
-  {
-    type: "text";
-    text: string;
-  },
-  ...ChatContentImage[]
-];
-
-export type ChatContentImage = {
-  type: "image_url";
-  image_url: {
-    url: string;
-  };
 };
 
 export type ChatInternalCallbacks = {

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -142,12 +142,6 @@ export type ChatInternalCallbacks = {
   stopGeneratingAnswer?: () => Promise<void>;
 
   /**
-   * Given the image file, it uploads the image to the server and returns the
-   * URL of the public image that will be used in the user chat message.
-   */
-  uploadImage: (imageFile: File) => Promise<string>;
-
-  /**
    * Specifies a callback to validate if the current chat message of the user
    * can be send. If `false`, the `sendChatToLLM` won't be executed.
    */

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -87,7 +87,10 @@ export type ChatMessageUser = {
   metadata?: any;
 
   /**
-   * Added to the parts of the cell.
+   * Parts for the cell, message content, `files-container` and
+   * `sources-container`.
+   *
+   * It is not added to the parts of the files and sources.
    */
   parts?: string;
 
@@ -101,7 +104,10 @@ export type ChatMessageAssistant = {
   metadata?: any;
 
   /**
-   * Added to the parts of the cell.
+   * Parts for the cell, message content, `files-container` and
+   * `sources-container`.
+   *
+   * It is not added to the parts of the files and sources.
    */
   parts?: string;
 
@@ -121,7 +127,10 @@ export type ChatMessageError = {
   metadata?: any;
 
   /**
-   * Added to the parts of the cell.
+   * Parts for the cell, message content, `files-container` and
+   * `sources-container`.
+   *
+   * It is not added to the parts of the files and sources.
    */
   parts?: string;
 
@@ -149,6 +158,11 @@ export type ChatFile = {
   mimeType: ChMimeType | (string & Record<never, never>);
 
   /**
+   * Parts for the file.
+   */
+  parts?: string;
+
+  /**
    * Specifies the uploading state of the files.
    *
    * By default is `"uploaded"`.
@@ -165,8 +179,13 @@ export type ChatMessageSources = ChatMessageSource[];
 export type ChatMessageSource = {
   accessibleName?: string;
   caption?: string;
-  url: string;
+
+  /**
+   * Parts for the source.
+   */
   parts?: string;
+
+  url: string;
 };
 
 export type ChatInternalCallbacks = {
@@ -246,7 +265,7 @@ export type ChatMessageRenderBySections = {
    *
    * If `undefined`, a default render for the files will be used.
    */
-  files?: ChatFilesRender;
+  file?: ChatFileRender;
 
   /**
    * Render for the general structure of the message.
@@ -262,11 +281,11 @@ export type ChatMessageRenderBySections = {
   messageStructure?: ChatMessageStructureRender;
 
   /**
-   * Render for the sources of the message.
+   * Render for each source of the message.
    *
    * If `undefined`, a default render for the sources will be used.
    */
-  sources?: ChatSourcesRender;
+  source?: ChatSourceRender;
 };
 
 export type ChatCodeBlockRender = (
@@ -279,8 +298,8 @@ export type ChatContentRender = (
   codeBlockRender: ChatCodeBlockRender
 ) => any;
 
-export type ChatFilesRender = {
-  [key in keyof ChMimeTypeFormatMap]: (
+export type ChatFileRender = {
+  [key in keyof ChMimeTypeFormatMap]?: (
     file: ChatFile,
     chatRef: HTMLChChatElement
   ) => any;
@@ -292,12 +311,12 @@ export type ChatMessageStructureRender = (
   renders: {
     codeBlock: ChatCodeBlockRender;
     content: ChatContentRender;
-    files: ChatFilesRender;
-    sources: ChatSourcesRender;
+    file: ChatFileRender;
+    source: ChatSourceRender;
   }
 ) => any;
 
-export type ChatSourcesRender = (
-  message: ChatMessage,
+export type ChatSourceRender = (
+  sources: ChatMessageSource,
   chatRef: HTMLChChatElement
 ) => any;

--- a/src/components/chat/utils.ts
+++ b/src/components/chat/utils.ts
@@ -1,8 +1,10 @@
+import { copyToTheClipboard } from "../../common/utils";
 import type {
-  ChatFiles,
+  ChatMessageFiles,
   ChatFileUploadState,
   ChatMessageAssistant,
-  ChatMessageNoId
+  ChatMessageNoId,
+  ChatMessageSources
 } from "./types";
 
 export const getMessageContent = (message: ChatMessageNoId) =>
@@ -10,11 +12,33 @@ export const getMessageContent = (message: ChatMessageNoId) =>
     ? message.content
     : message.content.message;
 
-export const getMessageFiles = (message: ChatMessageNoId): ChatFiles =>
+export const getMessageSerializedContentAll = (message: ChatMessageNoId) =>
+  typeof message.content === "string"
+    ? message.content
+    : JSON.stringify(message.content, undefined, 2);
+
+export const getMessageFiles = (message: ChatMessageNoId): ChatMessageFiles =>
   typeof message.content === "object" ? message.content.files ?? [] : [];
+
+export const getMessageSources = (
+  message: ChatMessageNoId
+): ChatMessageSources =>
+  typeof message.content === "object" ? message.content.sources ?? [] : [];
+
+export const getMessageFilesAndSources = (
+  message: ChatMessageNoId
+): { files: ChatMessageFiles; sources: ChatMessageSources } =>
+  typeof message.content === "object"
+    ? {
+        files: message.content.files ?? [],
+        sources: message.content.sources ?? []
+      }
+    : { files: [], sources: [] };
 
 export const DEFAULT_ASSISTANT_STATUS =
   "complete" satisfies ChatMessageAssistant["status"];
 
 export const DEFAULT_FILE_UPLOAD_STATE =
   "uploaded" satisfies ChatFileUploadState;
+
+export const copy = (text: string) => () => copyToTheClipboard(text);

--- a/src/components/chat/utils.ts
+++ b/src/components/chat/utils.ts
@@ -1,0 +1,20 @@
+import type {
+  ChatFiles,
+  ChatFileUploadState,
+  ChatMessageAssistant,
+  ChatMessageNoId
+} from "./types";
+
+export const getMessageContent = (message: ChatMessageNoId) =>
+  typeof message.content === "string"
+    ? message.content
+    : message.content.message;
+
+export const getMessageFiles = (message: ChatMessageNoId): ChatFiles =>
+  typeof message.content === "object" ? message.content.files ?? [] : [];
+
+export const DEFAULT_ASSISTANT_STATUS =
+  "complete" satisfies ChatMessageAssistant["status"];
+
+export const DEFAULT_FILE_UPLOAD_STATE =
+  "uploaded" satisfies ChatFileUploadState;

--- a/src/showcase/assets/components/chat/callbacks.ts
+++ b/src/showcase/assets/components/chat/callbacks.ts
@@ -174,8 +174,6 @@ export const chatTranslations: ChatTranslations = {
     clearChat: "Clear chat",
     copyResponseButton: "Copy assistant response",
     downloadCodeButton: "Download code",
-    imagePicker: "Select images",
-    removeUploadedImage: "Remove uploaded image",
     sendButton: "Send",
     sendInput: "Message",
     stopGeneratingAnswerButton: "Stop generating answer"

--- a/src/showcase/assets/components/chat/callbacks.ts
+++ b/src/showcase/assets/components/chat/callbacks.ts
@@ -73,7 +73,7 @@ To create code blocks, you’ll use three backticks (\` \`\`\` \`) or three tild
 \`\`\`
 `;
 
-const sendChatToLLM = () => {
+const sendChatMessages = () => {
   // This is a WA to get the chat reference
   const chatRef = document
     .querySelector("ch-flexible-layout-render")!
@@ -149,9 +149,7 @@ function dummyStreaming(
 }
 
 export const chatCallbacks: ChatInternalCallbacks = {
-  clear: () => new Promise(resolve => resolve()),
-  sendChatToLLM: sendChatToLLM,
-  uploadImage: () => new Promise(resolve => resolve("")),
+  sendChatMessages,
   stopGeneratingAnswer: () => {
     clearTimeout(timeOut);
 

--- a/src/showcase/assets/components/chat/callbacks.ts
+++ b/src/showcase/assets/components/chat/callbacks.ts
@@ -148,7 +148,14 @@ function dummyStreaming(
   );
 }
 
+// let returnFiles = true;
+
 export const chatCallbacks: ChatInternalCallbacks = {
+  // getChatMessageFiles: () => {
+  //   returnFiles = !returnFiles;
+
+  //   return returnFiles ? [] : [];
+  // },
   sendChatMessages,
   stopGeneratingAnswer: () => {
     clearTimeout(timeOut);
@@ -172,7 +179,7 @@ export const chatCallbacks: ChatInternalCallbacks = {
 export const chatTranslations: ChatTranslations = {
   accessibleName: {
     clearChat: "Clear chat",
-    copyResponseButton: "Copy assistant response",
+    copyMessageContent: "Copy message content",
     downloadCodeButton: "Download code",
     sendButton: "Send",
     sendInput: "Message",
@@ -182,10 +189,11 @@ export const chatTranslations: ChatTranslations = {
     sendInput: "Ask me a question..."
   },
   text: {
-    stopGeneratingAnswerButton: "Stop generating answer",
     copyCodeButton: "Copy code",
+    copyMessageContent: "Copy",
     processing: `Processing with ${PROCESSING_PLACEHOLDER}`,
-    sourceFiles: "Source files:"
+    sourceFiles: "Source files:",
+    stopGeneratingAnswerButton: "Stop generating answer"
   }
 };
 
@@ -314,6 +322,17 @@ export const codeFixerRecord: ChatMessage[] = [
           caption: "Chameleon",
           mimeType: "text/plain",
           url: "https://github.com/genexuslabs/chameleon-controls-library"
+        }
+      ],
+      sources: [
+        {
+          caption: "Chameleon",
+          url: "https://github.com/genexuslabs/chameleon-controls-library"
+        },
+        {
+          caption: "GeneXus",
+          url: "www.genexus.com",
+          parts: "genexus"
         }
       ]
     }

--- a/src/showcase/assets/components/chat/callbacks.ts
+++ b/src/showcase/assets/components/chat/callbacks.ts
@@ -1,7 +1,4 @@
-import {
-  ChatInternalCallbacks,
-  ChatMessage
-} from "../../../../components/chat/types";
+import { ChatCallbacks, ChatMessage } from "../../../../components/chat/types";
 import { ChatTranslations } from "../../../../components/chat/translations";
 
 const PROCESSING_PLACEHOLDER = "{{ASSISTANT_NAME}}";
@@ -150,7 +147,7 @@ function dummyStreaming(
 
 // let returnFiles = true;
 
-export const chatCallbacks: ChatInternalCallbacks = {
+export const chatCallbacks: ChatCallbacks = {
   // getChatMessageFiles: () => {
   //   returnFiles = !returnFiles;
 

--- a/src/showcase/assets/components/chat/callbacks.ts
+++ b/src/showcase/assets/components/chat/callbacks.ts
@@ -295,6 +295,27 @@ export const codeFixerRecord: ChatMessage[] = [
     id: "9",
     role: "assistant",
     status: "complete",
-    content: ASSISTANT_RESPONSE_SHORT_MARKDOWN
+    content: {
+      message: ASSISTANT_RESPONSE_SHORT_MARKDOWN,
+      files: [
+        {
+          mimeType: "image/png",
+          url: "https://www.genexus.com/media/images/logo_genexus_desktop_2024.png?timestamp=20241113105731"
+        },
+        {
+          mimeType: "video/mp4",
+          url: "https://www.w3schools.com/tags/movie.mp4"
+        },
+        {
+          mimeType: "audio/mpeg",
+          url: "https://www.w3schools.com/html/horse.ogg"
+        },
+        {
+          caption: "Chameleon",
+          mimeType: "text/plain",
+          url: "https://github.com/genexuslabs/chameleon-controls-library"
+        }
+      ]
+    }
   }
 ];

--- a/src/showcase/assets/components/chat/callbacks.ts
+++ b/src/showcase/assets/components/chat/callbacks.ts
@@ -191,6 +191,7 @@ export const chatTranslations: ChatTranslations = {
   text: {
     copyCodeButton: "Copy code",
     copyMessageContent: "Copy",
+    downloadCodeButton: "Download",
     processing: `Processing with ${PROCESSING_PLACEHOLDER}`,
     sourceFiles: "Source files:",
     stopGeneratingAnswerButton: "Stop generating answer"

--- a/src/showcase/assets/components/chat/chat.showcase.tsx
+++ b/src/showcase/assets/components/chat/chat.showcase.tsx
@@ -35,7 +35,6 @@ const render: ShowcaseRender = designSystem => (
         ? undefined
         : mercuryChatMessageRender("mercury/markdown-viewer")
     }
-    isMobile={false}
     items={state.items}
     showAdditionalContent={state.showAdditionalContent}
     translations={chatTranslations}

--- a/src/showcase/assets/components/chat/mercury-code-render.tsx
+++ b/src/showcase/assets/components/chat/mercury-code-render.tsx
@@ -3,7 +3,7 @@ import {
   MarkdownViewerCodeRender,
   MarkdownViewerCodeRenderOptions
 } from "../../../../components/markdown-viewer/parsers/types";
-import { ChatMessageByRole } from "../../../../components";
+import { ChatMessageByRole } from "../../../../components/chat/types";
 
 const copy = (text: string) => () => navigator.clipboard.writeText(text);
 


### PR DESCRIPTION
**Changes we propose in this PR**:

 - The `ch-chat` interface has been refactored to remove some inconsistent and unused properties/callbacks. This refactoring also comes in handy for improving some names and extending the implementation of the `ch-chat`.

 - Removed the following properties:
   | Removed properties | Migration |
   | -- | -- |
   | `hyperlinkToDownloadFile` | This property is no longer being used, since now we provide a callback for downloading block codes. |
   | `imageUpload` | This property was not being used, so there is no need to change anything. |
   | `isMobile` | If you want to customize the render of messages depending on the platform/viewport, you can create your own custom render for the messages by implementing the `renderItem` property. |
   | `renderCode` | This property was removed, but you can still customize the render of block codes by using the new variant of the `renderItem` property, which allows to pass an object instead of a function to customize the render of specific sections of the `ch-chat`. |

 - Removed the following translations (`translations` property):
   | Removed translation| Migration |
   | -- | -- |
   | `accessibleName.imagePicker` | This translation was not being used, so there is no need to change anything. |
   | `accessibleName.removeUploadedImage` | This translation was not being used, so there is no need to change anything. |