### PR TITLE
`[ch-accordion-render]` Add support to customize the position of the expandable button with the `expandableButtonPosition` property

### DIFF
--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -10,21 +10,21 @@
    * Specifies the box size of the chevron.
    * @default #{$default-decorative-image-size}
    */
-  --ch-accordion__chevron-size: #{$default-decorative-image-size};
+  --ch-accordion__chevron-size: #{$default-decorative-image-size}; // TODO: rename "chevron" to "expandable-button"
 
   /**
    * @prop --ch-accordion__chevron-image-size:
    * Specifies the image size of the chevron.
    * @default 100%
    */
-  --ch-accordion__chevron-image-size: 100%;
+  --ch-accordion__chevron-image-size: 100%; // TODO: rename "chevron" to "expandable-button"
 
   /**
    * @prop --ch-accordion__chevron-color:
    * Specifies the color of the chevron.
    * @default 100%
    */
-  --ch-accordion__chevron-color: currentColor;
+  --ch-accordion__chevron-color: currentColor; // TODO: rename "chevron" to "expandable-button"
 
   /**
    * @prop --ch-accordion-expand-collapse-duration
@@ -91,7 +91,6 @@
     content: "";
     inline-size: var(--ch-accordion__chevron-size);
     block-size: var(--ch-accordion__chevron-size);
-    margin-inline-start: auto;
     background-color: var(--ch-accordion__chevron-color);
 
     -webkit-mask: no-repeat center / var(--ch-accordion__chevron-image-size)
@@ -101,8 +100,24 @@
       var(--ch-accordion-expand-collapse-timing-function);
   }
 
-  &--expanded::after {
-    transform: rotate(-180deg); // TODO: Add support for RTL
+  &--expand-button-start {
+    &::after {
+      order: -1;
+    }
+
+    &-collapsed::after {
+      transform: rotate(-90deg); // TODO: Add support for RTL
+    }
+  }
+
+  &--expand-button-end {
+    &::after {
+      margin-inline-start: auto;
+    }
+
+    &-expanded::after {
+      transform: rotate(-180deg); // TODO: Add support for RTL
+    }
   }
 }
 

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -68,6 +68,12 @@ export class ChAccordionRender implements ComponentInterface {
   @Prop() readonly disabled: boolean = false;
 
   /**
+   * Specifies the position of the expandable button in the header of the
+   * panels.
+   */
+  @Prop() readonly expandableButtonPosition: "start" | "end" = "end";
+
+  /**
    * This property specifies a callback that is executed when the path for an
    * startImgSrc needs to be resolved.
    */
@@ -241,8 +247,12 @@ export class ChAccordionRender implements ComponentInterface {
           aria-expanded={item.expanded ? "true" : "false"}
           class={{
             header: true,
+            [`header--expand-button-${this.expandableButtonPosition}`]: true,
+            [`header--expand-button-${this.expandableButtonPosition}-collapsed`]:
+              !item.expanded,
+            [`header--expand-button-${this.expandableButtonPosition}-expanded`]:
+              item.expanded,
             [DISABLED_CLASS]: isDisabled,
-            "header--expanded": item.expanded,
             [`start-img-type--${
               item.startImgType ?? "background"
             } pseudo-img--start`]: !!startImage,

--- a/src/components/accordion/readme.md
+++ b/src/components/accordion/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property               | Attribute              | Description                                                                                                                                                                    | Type                                      | Default     |
-| ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- | ----------- |
-| `disabled`             | `disabled`             | This attribute lets you specify if all accordions are disabled. If disabled,accordions will not fire any user interaction related event (for example, `expandedChange` event). | `boolean`                                 | `false`     |
-| `getImagePathCallback` | --                     | This property specifies a callback that is executed when the path for an startImgSrc needs to be resolved.                                                                     | `(imageSrc: string) => GxImageMultiState` | `undefined` |
-| `model`                | --                     | Specifies the items of the control.                                                                                                                                            | `AccordionItemModel[]`                    | `undefined` |
-| `singleItemExpanded`   | `single-item-expanded` | If `true` only one item will be expanded at the same time.                                                                                                                     | `boolean`                                 | `false`     |
+| Property                   | Attribute                    | Description                                                                                                                                                                    | Type                                      | Default     |
+| -------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- | ----------- |
+| `disabled`                 | `disabled`                   | This attribute lets you specify if all accordions are disabled. If disabled,accordions will not fire any user interaction related event (for example, `expandedChange` event). | `boolean`                                 | `false`     |
+| `expandableButtonPosition` | `expandable-button-position` | Specifies the position of the expandable button in the header of the panels.                                                                                                   | `"end" \| "start"`                        | `"end"`     |
+| `getImagePathCallback`     | --                           | This property specifies a callback that is executed when the path for an startImgSrc needs to be resolved.                                                                     | `(imageSrc: string) => GxImageMultiState` | `undefined` |
+| `model`                    | --                           | Specifies the items of the control.                                                                                                                                            | `AccordionItemModel[]`                    | `undefined` |
+| `singleItemExpanded`       | `single-item-expanded`       | If `true` only one item will be expanded at the same time.                                                                                                                     | `boolean`                                 | `false`     |
 
 
 ## Events

--- a/src/showcase/assets/components/accordion/accordion.showcase.tsx
+++ b/src/showcase/assets/components/accordion/accordion.showcase.tsx
@@ -40,18 +40,21 @@ const expandedItemChangeHandler = (
 
 const render = () => (
   <ch-accordion-render
-    class="accordion-filled"
+    class="accordion-filled elevation-2"
     disabled={state.disabled}
+    expandableButtonPosition={state.expandableButtonPosition}
     model={state.model}
     singleItemExpanded={state.singleItemExpanded}
     onExpandedChange={expandedItemChangeHandler}
   >
     {renderedItems.has("item 1") && (
-      <div slot="item 1">Content of the item 1</div>
+      <div slot="item 1" class="spacing-body">
+        Content of the item 1
+      </div>
     )}
 
     {renderedItems.has("item 2") && (
-      <div slot="item 2">
+      <div slot="item 2" class="spacing-body">
         Content of the item 2
         <button class="button-primary" type="button">
           Some action
@@ -72,7 +75,7 @@ const render = () => (
     )}
 
     {renderedItems.has("item 3") && (
-      <div slot="item 3">
+      <div slot="item 3" class="spacing-body">
         Content of the item 3
         <button class="button-secondary" type="button">
           Some action
@@ -97,7 +100,7 @@ const render = () => (
     </div>
 
     {renderedItems.has("item 4") && (
-      <div slot="item 4">
+      <div slot="item 4" class="spacing-body">
         Content of the item 4
         <button class="button-tertiary" type="button">
           Some action
@@ -131,6 +134,17 @@ const showcaseRenderProperties: ShowcaseRenderProperties<HTMLChAccordionRenderEl
           caption: "Single Item Expanded",
           type: "boolean",
           value: false
+        },
+        {
+          id: "expandableButtonPosition",
+          caption: "Expandable Button Position",
+          type: "enum",
+          value: "end",
+          values: [
+            { caption: "Start", value: "start" },
+            { caption: "End", value: "end" }
+          ],
+          render: "radio-group"
         },
         {
           id: "disabled",
@@ -256,8 +270,9 @@ const lightDOMMarkupStencil = insertSpacesAtTheBeginningExceptForTheFirstLine(
 
 const showcasePropertiesInfo: ShowcaseTemplatePropertyInfo<HTMLChAccordionRenderElement>[] =
   [
-    { name: "class", fixed: true, value: "accordion", type: "string" },
+    { name: "class", fixed: true, value: "accordion-filled", type: "string" },
     { name: "disabled", defaultValue: false, type: "boolean" },
+    { name: "expandableButtonPosition", defaultValue: "end", type: "string" },
     {
       name: "getImagePathCallback",
       fixed: true,


### PR DESCRIPTION
Added the property `expandableButtonPosition: "start" | "end"` which specifies the position of the expandable button in the header of the panels.