### PR TITLE
`[ch-combo-box-render]` Add support to customize the placeholder color and the expanded/collapsed chevron

### DIFF
--- a/src/components/combo-box/combo-box.scss
+++ b/src/components/combo-box/combo-box.scss
@@ -65,6 +65,13 @@
   --ch-combo-box__picker-image-size: 100%;
 
   /**
+   * @prop --ch-placeholder-color:
+   * Define the placeholder color when the combo-box does not have a value set.
+   * (currentColor by default)
+   */
+  --ch-combo-box__placeholder-color: currentColor;
+
+  /**
    * @prop --ch-combo-box-item-gap:
    * Specifies the spacing between the images, text and the expandable button
    * on items.
@@ -168,6 +175,11 @@ select {
   &--readonly {
     pointer-events: none;
     text-overflow: ellipsis;
+  }
+
+  // TODO: What should we do for the native select (used in mobile devices)?
+  &::placeholder {
+    color: var(--ch-combo-box__placeholder-color);
   }
 }
 

--- a/src/components/combo-box/combo-box.scss
+++ b/src/components/combo-box/combo-box.scss
@@ -44,6 +44,20 @@
   --ch-combo-box__picker: url('data:image/svg+xml,<svg width="8" height="12" viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg"><path d="M4.16669 0.666626L7.66669 4.66663H0.666687L4.16669 0.666626ZM4.16669 11.3333L0.666687 7.33329H7.66669L4.16669 11.3333Z"/></svg>');
 
   /**
+   * @prop --ch-combo-box__picker-collapsed:
+   * Specifies the image of the combo-box's picker when it is collapsed.
+   * @default var(--ch-combo-box__picker)
+   */
+  --ch-combo-box__picker-collapsed: var(--ch-combo-box__picker);
+
+  /**
+   * @prop --ch-combo-box__picker-expanded:
+   * Specifies the image of the combo-box's picker when it is expanded.
+   * @default var(--ch-combo-box__picker)
+   */
+  --ch-combo-box__picker-expanded: var(--ch-combo-box__picker);
+
+  /**
    * @prop --ch-combo-box__picker-color:
    * Specifies the color of the combo-box's picker.
    * @default currentColor
@@ -112,13 +126,17 @@
     grid-column: 2;
     inline-size: var(--ch-combo-box__picker-size);
     block-size: var(--ch-combo-box__picker-size);
-    -webkit-mask: var(--ch-combo-box__picker) 50% 50% /
+    -webkit-mask: var(--ch-combo-box__picker-collapsed) 50% 50% /
       var(--ch-combo-box__picker-image-size)
       var(--ch-combo-box__picker-image-size) no-repeat;
     margin-inline-start: var(--ch-combo-box-item-gap);
     background-color: var(--ch-combo-box__picker-color);
     pointer-events: none;
   }
+}
+
+:host(.ch-combo-box--expanded)::after {
+  -webkit-mask-image: var(--ch-combo-box__picker-expanded);
 }
 
 :host(.ch-combo-box--normal) {

--- a/src/components/combo-box/combo-box.tsx
+++ b/src/components/combo-box/combo-box.tsx
@@ -12,30 +12,39 @@ import {
   h
 } from "@stencil/core";
 import {
+  analyzeLabelExistence,
+  getElementInternalsLabel
+} from "../../common/analysis/accessibility";
+import {
   AccessibleNameComponent,
   DisableableComponent
 } from "../../common/interfaces";
-import {
-  ComboBoxSuggestOptions,
-  ComboBoxItemModel,
-  ComboBoxItemGroup,
-  ComboBoxSuggestInfo,
-  ComboBoxModel,
-  ComboBoxSelectedIndex,
-  ComboBoxItemModelExtended,
-  ComboBoxItemImagesModel,
-  ComboBoxImagePathCallback
-} from "./types";
-import { focusComposedPath } from "../common/helpers";
+import { getControlRegisterProperty } from "../../common/registry-properties";
 import {
   COMBO_BOX_HOST_PARTS,
   COMBO_BOX_PARTS_DICTIONARY,
   KEY_CODES
 } from "../../common/reserved-names";
+import { GxImageMultiStateStart } from "../../common/types";
 import { isMobileDevice, tokenMap } from "../../common/utils";
-import { ChPopoverAlign } from "../popover/types";
 import { ChPopoverCustomEvent, GxImageMultiState } from "../../components";
+import { focusComposedPath } from "../common/helpers";
+import { ChPopoverAlign } from "../popover/types";
 import { filterSubModel } from "./helpers";
+import { computeComboBoxItemImage, getComboBoxImages } from "./item-images";
+import { findNextSelectedIndex, findSelectedIndex } from "./navigation";
+import { customComboBoxItemRender, nativeItemRender } from "./renders";
+import {
+  ComboBoxImagePathCallback,
+  ComboBoxItemGroup,
+  ComboBoxItemImagesModel,
+  ComboBoxItemModel,
+  ComboBoxItemModelExtended,
+  ComboBoxModel,
+  ComboBoxSelectedIndex,
+  ComboBoxSuggestInfo,
+  ComboBoxSuggestOptions
+} from "./types";
 import {
   comboBoxActiveDescendantIsRendered,
   findComboBoxLargestValue,
@@ -43,15 +52,6 @@ import {
   mapValuesToItemInfo,
   popoverWasClicked
 } from "./utils";
-import { findNextSelectedIndex, findSelectedIndex } from "./navigation";
-import { customComboBoxItemRender, nativeItemRender } from "./renders";
-import { computeComboBoxItemImage, getComboBoxImages } from "./item-images";
-import { getControlRegisterProperty } from "../../common/registry-properties";
-import { GxImageMultiStateStart } from "../../common/types";
-import {
-  analyzeLabelExistence,
-  getElementInternalsLabel
-} from "../../common/analysis/accessibility";
 
 const SELECTED_ITEM_SELECTOR = `button[part*='${COMBO_BOX_PARTS_DICTIONARY.SELECTED}']`;
 const mobileDevice = isMobileDevice();
@@ -910,7 +910,8 @@ export class ChComboBoxRender
         class={{
           "ch-disabled": this.disabled,
           "ch-combo-box--normal": !filtersAreApplied,
-          "ch-combo-box--suggest": filtersAreApplied
+          "ch-combo-box--suggest": filtersAreApplied,
+          "ch-combo-box--expanded": this.expanded
         }}
         // TODO: Add unit tests for this feature, since it breaks custom parts
         // rendered outside of the ch-combo-box-render render() method


### PR DESCRIPTION
Added the following custom vars:
```css
  /**
   * @prop --ch-placeholder-color:
   * Define the placeholder color when the combo-box does not have a value set.
   * (currentColor by default)
   */
  --ch-combo-box__placeholder-color: currentColor;

  /**
   * @prop --ch-combo-box__picker-collapsed:
   * Specifies the image of the combo-box's picker when it is collapsed.
   * @default var(--ch-combo-box__picker)
   */
  --ch-combo-box__picker-collapsed: var(--ch-combo-box__picker);

  /**
   * @prop --ch-combo-box__picker-expanded:
   * Specifies the image of the combo-box's picker when it is expanded.
   * @default var(--ch-combo-box__picker)
   */
  --ch-combo-box__picker-expanded: var(--ch-combo-box__picker);
```