### PR TITLE
`[ch-code]` Add basic support for GeneXus language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.14.0",
       "license": "MIT",
       "dependencies": {
-        "@genexus/markdown-parser": "~0.2.0",
+        "@genexus/markdown-parser": "~0.3.0",
         "@open-wc/lit-helpers": "0.7.0",
         "html5-qrcode": "^2.3.8",
         "lit": "~3.3.0",
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@genexus/markdown-parser": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@genexus/markdown-parser/-/markdown-parser-0.2.0.tgz",
-      "integrity": "sha512-N20hdOGJzWRWy4s1G5CqqBKcyqVR8rpYT/9HOsJxP6uq25hlXTDwr1gYlQ4aNCk2tl7Rcvde3aVLtm99eZL6cA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@genexus/markdown-parser/-/markdown-parser-0.3.0.tgz",
+      "integrity": "sha512-Qg5eZVNxQ4GXZeKTDcqRe4Ym3zwwPCVgM6l5TBjh7LUjSomwdc2k3mphsIOvbrLtvF5HO2zb3zYh/jbpEjW6/w==",
       "dependencies": {
         "hast-util-from-html": "^2.0.1",
         "hast-util-sanitize": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chameleon-generate-react": "dist/react/copy-react.js"
   },
   "dependencies": {
-    "@genexus/markdown-parser": "~0.2.0",
+    "@genexus/markdown-parser": "~0.3.0",
     "@open-wc/lit-helpers": "0.7.0",
     "html5-qrcode": "^2.3.8",
     "lit": "~3.3.0",


### PR DESCRIPTION
The `ch-code` now supports a common implementation for the GeneXus language. This implementation is based on the language of the Procedure object.

Aliases:
- `genexus`
- `gx`
- `GeneXus`
- `geneXus`