### PR TITLE
`[ch-chat]` Rename `ch-virtual-scroller` part from `content` to `messages-container`

### DIFF
--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -760,7 +760,7 @@ export class ChChat {
           role="row"
           slot="grid-content"
           class="grid-content"
-          part="content"
+          part="messages-container"
           inverseLoading
           // mode="lazy-render"
           items={this.items}


### PR DESCRIPTION
### Changes we propose in this PR:

## Breaking Changes

Rename the `ch-virtual-scroller` part from `content` to `messages-container` so it does not matches with `ch-markdown-viewer` part `content`. Using the same part name could lead to styling conflicts.

Before: 
```tsx
<ch-virtual-scroller
  part="content"
  // ... other properties
>
```

Now: 
```tsx
<ch-virtual-scroller
  part="messages-container"
  // ... other properties
>
```