### PR TITLE
`[ch-dialog]` Add support to `preventDefault` the `dialogClosed` event and fix `dialogClosed` not being fired when clicking the close button

### DIFF
--- a/src/components/dialog/readme.md
+++ b/src/components/dialog/readme.md
@@ -27,9 +27,9 @@ interactive component.
 
 ## Events
 
-| Event          | Description                        | Type               |
-| -------------- | ---------------------------------- | ------------------ |
-| `dialogClosed` | Emitted when the dialog is closed. | `CustomEvent<any>` |
+| Event          | Description                                                                                                                   | Type               |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `dialogClosed` | Emitted when the dialog is closed.  This event can be prevented (`preventDefault()`), interrupting the `ch-dialog`'s closing. | `CustomEvent<any>` |
 
 
 ## Slots

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -489,7 +489,7 @@ export class ChPopover {
    * Emitted when the popover is closed by an user interaction.
    *
    * This event can be prevented (`preventDefault()`), interrupting the
-   * ch-popover's closing.
+   * `ch-popover`'s closing.
    */
   @Event() popoverClosed: EventEmitter;
 


### PR DESCRIPTION
**Changes we propose in this PR**:
 - The `dialogClosed` event of the `ch-dialog` now support `preventDefault()`.

 - Fix for clicking on the close button that was not firing the `dialogClosed` event.

 - Fix a memory leak when clicking on the close button, which would not remove a event listener on the document.

 - Fix a memory leak when toggling the `show` property in the `ch-dialog`'s interface/reference, which would not remove a event listener on the document.