### PR TITLE
`[ch-tab-render]` Fix `tabButtonHidden` not working properly

### DIFF
--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -42,6 +42,7 @@ $z-index-gx-navbar-item: 107; // Same as $z-index-gx-navbar-item from w-c-l
   --ch-tab-close-button__background-image-size: 100%;
 
   display: grid;
+  grid-template: "panel-container" 1fr / 1fr;
 }
 
 :host(.ch-tab--block-start) {

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -1369,6 +1369,7 @@ export class ChTabRender implements DraggableView {
     return (
       <Host
         class={
+          // TODO: Add a unit test for the tabButtonHidden property
           !this.tabButtonHidden ? `ch-tab--${this.tabListPosition}` : undefined
         }
       >

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -3,18 +3,28 @@ import {
   Element,
   Event,
   EventEmitter,
+  forceUpdate,
+  h,
   Host,
   Method,
   Prop,
   State,
-  Watch,
-  forceUpdate,
-  h
+  Watch
 } from "@stencil/core";
+import { insertIntoIndex, removeElement } from "../../common/array";
+import { getControlRegisterProperty } from "../../common/registry-properties";
 import {
-  DraggableView,
-  DraggableViewInfo
-} from "../flexible-layout/internal/flexible-layout/types";
+  KEY_CODES,
+  SCROLLABLE_CLASS,
+  TAB_PARTS_DICTIONARY
+} from "../../common/reserved-names";
+import { adoptCommonThemes } from "../../common/theme";
+import type {
+  CssContainProperty,
+  CssOverflowProperty,
+  GxImageMultiState,
+  GxImageMultiStateStart
+} from "../../common/types";
 import {
   inBetween,
   isPseudoElementImg,
@@ -22,6 +32,15 @@ import {
   tokenMap,
   updateDirectionInImageCustomVar
 } from "../../common/utils";
+import {
+  focusComposedPath,
+  MouseEventButton,
+  MouseEventButtons
+} from "../common/helpers";
+import {
+  DraggableView,
+  DraggableViewInfo
+} from "../flexible-layout/internal/flexible-layout/types";
 import {
   TabElementSize,
   TabItemCloseInfo,
@@ -40,25 +59,6 @@ import {
   isStartDirection,
   PANEL_ID
 } from "./utils";
-import { insertIntoIndex, removeElement } from "../../common/array";
-import {
-  focusComposedPath,
-  MouseEventButton,
-  MouseEventButtons
-} from "../common/helpers";
-import type {
-  CssContainProperty,
-  CssOverflowProperty,
-  GxImageMultiState,
-  GxImageMultiStateStart
-} from "../../common/types";
-import { getControlRegisterProperty } from "../../common/registry-properties";
-import {
-  KEY_CODES,
-  SCROLLABLE_CLASS,
-  TAB_PARTS_DICTIONARY
-} from "../../common/reserved-names";
-import { adoptCommonThemes } from "../../common/theme";
 
 const TAB_BUTTON_CLASS = "tab";
 const CLOSE_BUTTON_CLASS = "close-button";
@@ -1190,6 +1190,9 @@ export class ChTabRender implements DraggableView {
 
   #renderTabPages = (blockDirection: boolean, startDirection: boolean) => (
     <div
+      // This key is used key toggling the tabButtonHidden property, so we
+      // avoid destroying this div
+      key="panel-container"
       class={{
         "panel-container": true,
         "panel-container--collapsed": !this.expanded
@@ -1227,6 +1230,7 @@ export class ChTabRender implements DraggableView {
         key={PANEL_ID(item.id)}
         id={PANEL_ID(item.id)}
         role={!this.tabButtonHidden ? "tabpanel" : undefined}
+        // TODO: Should we set the aria-label when tabButtonHidden === true?
         aria-labelledby={!this.tabButtonHidden ? item.id : undefined}
         class={{
           panel: true,

--- a/src/showcase/assets/components/tab/tab.showcase.tsx
+++ b/src/showcase/assets/components/tab/tab.showcase.tsx
@@ -1,20 +1,4 @@
 import { h } from "@stencil/core";
-import {
-  ShowcaseRender,
-  ShowcaseRenderProperties,
-  ShowcaseStory,
-  ShowcaseTemplateFrameWork,
-  ShowcaseTemplatePropertyInfo
-} from "../types";
-import {
-  disabledModel1,
-  disabledModel4,
-  disabledModel2,
-  disabledModel3,
-  simpleModel1,
-  simpleModel2,
-  closeButtonModel
-} from "./models";
 import { ChTabRenderCustomEvent } from "../../../../components";
 import {
   TabItemCloseInfo,
@@ -26,11 +10,27 @@ import {
   preferencesModel
 } from "../tree-view/models";
 import {
+  ShowcaseRender,
+  ShowcaseRenderProperties,
+  ShowcaseStory,
+  ShowcaseTemplateFrameWork,
+  ShowcaseTemplatePropertyInfo
+} from "../types";
+import {
   insertSpacesAtTheBeginningExceptForTheFirstLine,
   renderShowcaseProperties,
   showcaseTemplateClassProperty,
   updateShowcase
 } from "../utils";
+import {
+  closeButtonModel,
+  disabledModel1,
+  disabledModel2,
+  disabledModel3,
+  disabledModel4,
+  simpleModel1,
+  simpleModel2
+} from "./models";
 
 const state: Partial<HTMLChTabRenderElement> = {};
 const renderedItems = new Set(["item1"]);
@@ -73,6 +73,7 @@ const render: ShowcaseRender = designSystem => (
         showTabListEnd={state.showTabListEnd}
         showTabListStart={state.showTabListStart}
         sortable={state.sortable}
+        tabButtonHidden={state.tabButtonHidden}
         onItemClose={handleItemClose}
         onSelectedItemChange={selectedItemChangeHandler}
       >
@@ -126,6 +127,7 @@ const render: ShowcaseRender = designSystem => (
         showTabListEnd={state.showTabListEnd}
         showTabListStart={state.showTabListStart}
         sortable={state.sortable}
+        tabButtonHidden={state.tabButtonHidden}
         onItemClose={handleItemClose}
         onSelectedItemChange={selectedItemChangeHandler}
       >


### PR DESCRIPTION
The layout of the `ch-tab-render` was not rendered correctly when `tabButtonHidden = true`.