### PR TITLE
Fix `ch-popover` not updating its position when scrolling inside a projected slot

### DIFF
--- a/src/common/get-all-root-nodes.ts
+++ b/src/common/get-all-root-nodes.ts
@@ -1,21 +1,61 @@
 /**
- * Given an `HTMLElement`, it returns all his root nodes, including `ShadowRoot`
- * nodes.
+ * Given an `HTMLElement`, it returns all his shadow root nodes, it includes
+ * the shadow root nodes that are even in the assigned slots. For example, in
+ * the following HTML:
+ * ```html
+ * <body>
+ *   <ch-tabular-grid>
+ *     #shadow-root (open)
+ *     | <div>
+ *     |   <slot></slot>
+ *     | </div>
+ *     <ch-tabular-grid-row>
+ *       <ch-tabular-grid-cell>
+ *         <ch-combo-box-render>
+ *           #shadow-root (open)
+ *           | <ch-popover></ch-popover>
+ *         </ch-combo-box-render>
+ *       </ch-tabular-grid-cell>
+ *     </ch-tabular-grid-row>
+ *   </ch-tabular-grid>
+ * </body>
+ * ```
+ *
+ * It returns `[document, #shadow-root of the ch-combo-box-render, #shadow-root of the ch-tabular-grid]`.
  *
  * This utility is helpful for attaching scroll event listeners for the entire
  * document and other events that don't bubble.
  */
-export const getAllRootNodes = (
-  element: HTMLElement
+export const getAllShadowRootAncestors = (
+  node: HTMLElement
 ): [Document, ...ShadowRoot[]] => {
-  const rootNodes: [Document, ...ShadowRoot[]] = [document];
+  const ancestors: [Document, ...ShadowRoot[]] = [document];
+  let current: ParentNode = node;
 
-  let rootNode = element.getRootNode();
+  while (current) {
+    // If a Node is projected as a slot, we need to traverse the slot's
+    // assigned nodes to find the next real ancestor.
+    if (current instanceof Element && current.assignedSlot) {
+      current = current.assignedSlot;
+      continue;
+    }
 
-  while (rootNode instanceof ShadowRoot) {
-    rootNodes.push(rootNode);
-    rootNode = rootNode.host.getRootNode();
+    // Get next parentNode
+    const parent = current.parentNode;
+
+    if (parent) {
+      current = parent;
+    }
+    // If we are on a ShadowRoot the next ancestor is the host
+    else if (current instanceof ShadowRoot) {
+      ancestors.push(current);
+      current = current.host;
+    }
+    // If the current node is the Document or it doesn't exists, return all ancestors
+    else {
+      break;
+    }
   }
 
-  return rootNodes;
+  return ancestors;
 };

--- a/src/common/tests/get-all-root-nodes.e2e.ts
+++ b/src/common/tests/get-all-root-nodes.e2e.ts
@@ -1,0 +1,61 @@
+import { E2EPage, newE2EPage } from "@stencil/core/testing";
+import { getAllShadowRootAncestors } from "../get-all-root-nodes";
+
+const COMPLEX_CASE = `<ch-tabular-grid class="property-grid">
+  <ch-tabular-grid-columnset class="property-grid-column-set">
+    <ch-tabular-grid-column
+      column-name="Property"
+      settingable="false"
+      size="50%"
+      class="property-grid-column"
+    ></ch-tabular-grid-column>
+    <ch-tabular-grid-column
+      column-name="Value"
+      settingable="false"
+      size="minmax(auto, calc(100% - var(--ch-tabular-grid-column-1-width)))"
+      class="property-grid-column"
+    ></ch-tabular-grid-column>
+  </ch-tabular-grid-columnset>
+
+  <ch-tabular-grid-row class="property-grid-row property-grid-value-editing">
+    <ch-tabular-grid-cell class="property-grid-cell"
+      >Combo Box</ch-tabular-grid-cell
+    >
+    <ch-tabular-grid-cell class="property-grid-cell">
+      <ch-combo-box-render
+        accessible-name="Colors"
+        id="combo-box-1"
+        class="combo-box"
+      ></ch-combo-box-render>
+    </ch-tabular-grid-cell>
+  </ch-tabular-grid-row>
+  <ch-tabular-grid-row class="property-grid-row property-grid-value-editing">
+    <ch-tabular-grid-cell class="property-grid-cell"
+      >Form Input</ch-tabular-grid-cell
+    >
+    <ch-tabular-grid-cell class="property-grid-cell">
+      <input type="text" placeholder="Enter your name" class="input" />
+    </ch-tabular-grid-cell>
+  </ch-tabular-grid-row>
+</ch-tabular-grid>`;
+
+describe("[get-all-root-nodes]", () => {
+  let page: E2EPage;
+
+  beforeEach(async () => {
+    page = await newE2EPage({
+      html: "",
+      failOnConsoleError: true
+    });
+  });
+
+  // TODO: Implement this e2e tests with playwright
+  it.skip("should return all root nodes including shadow roots", async () => {
+    await page.setContent(COMPLEX_CASE);
+    await page.waitForChanges();
+
+    expect(
+      getAllShadowRootAncestors(document.querySelector("ch-combo-box-render"))
+    ).toBe([]);
+  });
+});

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -9,7 +9,7 @@ import {
   Watch,
   h
 } from "@stencil/core";
-import { getAllRootNodes } from "../../common/get-all-root-nodes";
+import { getAllShadowRootAncestors } from "../../common/get-all-root-nodes";
 import { KEY_CODES, SCROLLABLE_CLASS } from "../../common/reserved-names";
 import { SyncWithRAF } from "../../common/sync-with-frames";
 import { adoptCommonThemes } from "../../common/theme";
@@ -652,7 +652,7 @@ export class ChPopover {
     // Get all root nodes to attach the scroll listener, since the scroll event
     // does not bubble and therefore, we can't track all scroll events if we}
     // only attach the scroll listener in the document node
-    this.#rootNodes ??= getAllRootNodes(this.el);
+    this.#rootNodes ??= getAllShadowRootAncestors(this.el);
 
     // Listeners
     this.#rootNodes.forEach(rootNode =>


### PR DESCRIPTION
When using the `ch-popover` in the light DOM of a component projecting content with a slot, if one of the slot's parent had a scroll, the `ch-popover` would not update its position when scrolling in that element.

One use case for this issue is the `ch-tabular-grid` (which has a scroll in its shadow root) and a cell using the `ch-combo-box-render` (which is rendered in the Light DOM of the `ch-tabular-grid`). In this case, the `ch-popover` of the `ch-combo-box-render` was not updating its position when scrolling in the `ch-tabular-grid`

This could result in "broken" positions for the `ch-action-menu-render`, `ch-combo-box-render`, and `ch-tooltip` components.